### PR TITLE
Fix: dtype mismatch and protobuf type errors in backend-python

### DIFF
--- a/backend/backend-python/driver.py
+++ b/backend/backend-python/driver.py
@@ -365,8 +365,9 @@ class Driver:
         # print('qo_indptr', qo_indptr)
         # print('custom_mask', custom_masks)
 
-        with torch.cuda.device(self.device):
-
+        # Fix for AMP/autocast thread locality issue
+        # Ensure consistent dtype (bfloat16) in worker thread
+        with torch.cuda.device(self.device), torch.amp.autocast('cuda', dtype=self.dtype):
             output_embeds = self.lm.model.forward(
                 input_embeds=input_embeds,
                 position_ids=pt_new_position_ids,
@@ -528,8 +529,9 @@ class Driver:
 
         responses = []
 
-        with torch.cuda.device(self.device):
-
+        # Fix for AMP/autocast thread locality issue
+        # Ensure consistent dtype (bfloat16) in worker thread
+        with torch.cuda.device(self.device), torch.amp.autocast('cuda', dtype=self.dtype):
             output_embeds = self.lm.model.forward(
                 input_embeds=input_embeds,
                 position_ids=pt_new_position_ids,

--- a/backend/backend-python/qwen3.py
+++ b/backend/backend-python/qwen3.py
@@ -181,6 +181,10 @@ class Qwen3Attention(nn.Module):
             pos_ids=position_ids,
             rope_theta=self.config.rope_theta
         )
+        
+        # Ensure query_states matches the configured dtype for FlashInfer plan
+        if query_states.dtype != self.config.dtype:
+            query_states = query_states.to(self.config.dtype)
 
         ops.append_paged_kv_cache(
             append_key=key_states,
@@ -341,7 +345,7 @@ class Qwen3Model(nn.Module):
                 head_dim=self.config.head_size,
                 page_size=page_size,
                 pos_encoding_mode="NONE",
-                q_data_type=torch.bfloat16,
+                q_data_type=self.config.dtype,
             )
             wrapper = self.wrapper_decode
         else:
@@ -355,7 +359,7 @@ class Qwen3Model(nn.Module):
                 head_dim_qk=self.config.head_size,
                 page_size=page_size,
                 custom_mask=custom_mask,
-                q_data_type=torch.bfloat16,
+                q_data_type=self.config.dtype,
             )
             wrapper = self.wrapper_append
 

--- a/backend/backend-python/server.py
+++ b/backend/backend-python/server.py
@@ -215,7 +215,8 @@ def load_model(config: dict):
         else:
             print("\nSuccessfully loaded all expected model weights.")
 
-        # Move the entire model to the specified device
+        # Move the entire model to the specified device and dtype
+        model.to(device=metadata.architecture.device, dtype=metadata.architecture.dtype)
         model.eval()  # Set the model to evaluation mode
 
         return model, metadata
@@ -408,8 +409,14 @@ def run_zmq_server(router, engine, config, model_metadata):
                             num_available_embeddings=config.get("max_num_embeds"),
                             num_available_distributions=0,
                             tokenizer=l4m_pb2.Tokenizer(
-                                merge_table=model_metadata.tokenizer.merge_table,
-                                special_tokens=model_metadata.tokenizer.special_tokens,
+                                merge_table=[
+                                    l4m_pb2.Tokenizer.MergeTableEntry(key=k, value=v)
+                                    for k, v in model_metadata.tokenizer.merge_table.items()
+                                ],
+                                special_tokens=[
+                                    l4m_pb2.Tokenizer.SpecialTokensEntry(key=k, value=v)
+                                    for k, v in model_metadata.tokenizer.special_tokens.items()
+                                ],
                                 split_regex=model_metadata.tokenizer.split_regex,
                                 escape_non_printable=model_metadata.tokenizer.escape_non_printable,
                             )


### PR DESCRIPTION
## Problem
- dtype mismatch: service crashed due to inconsistent dtype handling across FlashInfer plan, config, and worker-thread autocast.  
- Protobuf mismatch: `merge_table` / `special_tokens` as dicts caused serialization errors in `get_info`.  

## Fix
- Unified dtype configuration
- Added explicit autocast context in worker threads
- Converted `merge_table` and `special_tokens` into the correct protobuf message types before serialization

## Files Changed
- `backend-python/server.py`  
- `backend-python/driver.py`  
- `backend-python/l4ma.py`  
- `backend-python/qwen3.py`  

## Validation
- Verified inference works with both `bfloat16` and `float16`
