### PR TITLE
Fix: let wasm runtime use refactored wit names

### DIFF
--- a/pie/src/runtime.rs
+++ b/pie/src/runtime.rs
@@ -585,9 +585,9 @@ impl Runtime {
                 .await
                 .map_err(|e| RuntimeError::Other(format!("Instantiation error: {e}")))?;
 
-            // Attempt to call “run”
+            // Attempt to call "run"
             let (_, run_export) = instance
-                .get_export(&mut store, None, "pie:inferlet/run")
+                .get_export(&mut store, None, "inferlet:core/run")
                 .ok_or_else(|| RuntimeError::Other("No 'run' function found".into()))?;
 
             let (_, run_func_export) = instance


### PR DESCRIPTION
WASM exported function name `pie:inferlet/run` should be changed to `inferlet:core/run`, consistent with the recent WIT refactoring.