### PR TITLE
Let chat template render the BOS token only once.

### DIFF
--- a/inferlet/src/chat.rs
+++ b/inferlet/src/chat.rs
@@ -102,7 +102,17 @@ impl ChatFormatter {
     }
 
     /// Renders the entire conversation into a single formatted string prompt.
-    pub fn render(&self, template: &str, add_generation_prompt: bool) -> String {
-        minijinja::render!(template, messages => self.messages, add_generation_prompt => add_generation_prompt)
+    pub fn render(
+        &self,
+        template: &str,
+        add_generation_prompt: bool,
+        begin_of_sequence: bool,
+    ) -> String {
+        minijinja::render!(
+            template,
+            messages => self.messages,
+            add_generation_prompt => add_generation_prompt,
+            begin_of_sequence => begin_of_sequence,
+        )
     }
 }


### PR DESCRIPTION
The DeepSeek distilled Qwen 2 models need a BOS token at the beginning (according to the official chat template). However, our previous chat template rendering will duplicate the BOS token.

More specifically, the `text-completion` example app contains two fill statements:
```
ctx.fill_system(...);
ctx.fill_user(...);
```

Each fill statement goes through the chat template rendering separately, so the BOS token will be included twice, one at the beginning of the system prompt, and one for the user prompt.

In contract, the correct behavior should include one BOS token only before the system prompt. The fix is to add a boolean variable in the `Context` structure that tracks if it is the first chat template rendering. The BOS token is added only when the condition is true. The [chat template of the model](https://github.com/pie-project/model-index/blob/acd334059954db69ef0206ad86768e577aeb8eff/deepseek-r1-distill-qwen-2-32b.toml#L40-L47) is also modified to cooperate with the chat template rendering engine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generation and prompt rendering now recognize when output starts at the beginning of a sequence, improving first-token handling and overall output quality.
* **Bug Fixes**
  * Start-of-sequence state is preserved across continuations and forks, ensuring consistent behavior when resuming or branching generations.
  * Rendering correctly resets start-of-sequence after initial output, reducing artifacts at the start of new generations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->