### PR TITLE
Introduce "gpu_mem_headroom" to allow adaptive KV cache size.

### DIFF
--- a/backend/backend-python/handler.py
+++ b/backend/backend-python/handler.py
@@ -7,7 +7,6 @@ It instantiates the common Handler class with FlashInfer operations.
 
 from common import Handler
 from backend_ops import FlashInferOps
-import torch
 
 
 class PythonHandler(Handler):
@@ -16,15 +15,6 @@ class PythonHandler(Handler):
     def __init__(
         self,
         config: dict,
-        kv_page_size: int,
-        max_dist_size: int,
-        max_num_kv_pages: int,
-        max_num_embeds: int,
-        max_batch_tokens: int,
-        max_num_adapters: int,
-        max_adapter_rank: int,
-        dtype: torch.dtype,
-        device: str,
     ):
         """Initialize Python handler with FlashInfer operations."""
 
@@ -35,15 +25,6 @@ class PythonHandler(Handler):
         super().__init__(
             config=config,
             ops=flashinfer_ops,
-            kv_page_size=kv_page_size,
-            max_dist_size=max_dist_size,
-            max_num_kv_pages=max_num_kv_pages,
-            max_num_embeds=max_num_embeds,
-            max_batch_tokens=max_batch_tokens,
-            max_num_adapters=max_num_adapters,
-            max_adapter_rank=max_adapter_rank,
-            dtype=dtype,
-            device=device,
         )
 
         print("✅ PythonHandler initialized with FlashInfer backend")

--- a/backend/backend-python/server.py
+++ b/backend/backend-python/server.py
@@ -2,8 +2,8 @@
 # type: ignore
 # Ignoring checks for pylint and pyright since we are actively working on this file
 
+from typing import Optional
 import fire
-
 from common import (
     build_config,
     print_config,
@@ -22,11 +22,12 @@ def main(
     cache_dir: str = None,
     kv_page_size: int = 16,
     max_dist_size: int = 64,
-    max_num_kv_pages: int = 1024,
     max_num_embeds: int = 128,
     max_batch_tokens: int = 10240,
     max_num_adapters: int = 48,
     max_adapter_rank: int = 8,
+    max_num_kv_pages: Optional[int] = None,
+    gpu_mem_headroom: Optional[float] = None,
     device: str = "cuda:0",
     dtype: str = "bfloat16",
 ):
@@ -62,11 +63,12 @@ def main(
         cache_dir=cache_dir,
         kv_page_size=kv_page_size,
         max_dist_size=max_dist_size,
-        max_num_kv_pages=max_num_kv_pages,
         max_num_embeds=max_num_embeds,
         max_batch_tokens=max_batch_tokens,
         max_num_adapters=max_num_adapters,
         max_adapter_rank=max_adapter_rank,
+        max_num_kv_pages=max_num_kv_pages,
+        gpu_mem_headroom=gpu_mem_headroom,
         device=device,
         dtype=dtype,
     )

--- a/pie-cli/example_config.toml
+++ b/pie-cli/example_config.toml
@@ -20,3 +20,4 @@ max_num_kv_pages = 10240
 max_num_embeds = 128
 max_num_adapters = 32
 max_adapter_rank = 8
+gpu_mem_headroom = 10.0


### PR DESCRIPTION
When the user specifies "gpu_mem_headroom", we will calculate the number of KV pages based on the available GPU memory after accounting for the reserved percentage of GPU memory specified through "gpu_mem_headroom".

If the user also specifies "max_num_kv_pages", we will use the smaller of the two values.

Addressing Issue #80 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added gpu_mem_headroom option to enable adaptive GPU memory-based KV cache sizing.
  - max_num_kv_pages is now optional; auto-calculated when adaptive mode is used.
  - Server entrypoint accepts gpu_mem_headroom and Optional max_num_kv_pages.

- Documentation
  - Updated example configuration to include backend.gpu_mem_headroom.

- Chores
  - Stricter config validation: require either max_num_kv_pages or gpu_mem_headroom.
  - Runtime checks ensure CUDA availability when gpu_mem_headroom is set.
  - Clearer termination messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->