### PR TITLE
Implement `pie run` CLI command for one-shot inferlet execution

### DIFF
--- a/pie-cli/src/main.rs
+++ b/pie-cli/src/main.rs
@@ -210,15 +210,16 @@ async fn start_interactive_session(
         auth_secret: engine_config.auth_secret.clone(),
     };
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let (ready_tx, ready_rx) = oneshot::channel();
 
-    // 2. Start the main PIE engine server in a background task
-    println!("🚀 Starting PIE engine in background...");
+    // 2. Start the main PIE engine server
+    println!("🚀 Starting PIE engine...");
     let server_handle = tokio::spawn(async move {
-        if let Err(e) = pie::run_server(engine_config, shutdown_rx).await {
+        if let Err(e) = pie::run_server(engine_config, ready_tx, shutdown_rx).await {
             eprintln!("\n[Engine Error] Engine failed: {}", e);
         }
     });
-    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+    ready_rx.await.unwrap();
     println!("✅ Engine started.");
 
     // 3. Initialize the interactive prompt with highlighting and an external printer

--- a/pie/src/client.rs
+++ b/pie/src/client.rs
@@ -49,6 +49,7 @@ struct ClientInner {
     corr_id_pool: Mutex<IdPool<CorrId>>,
     pending_requests: DashMap<CorrId, oneshot::Sender<(bool, String)>>,
     backend_change_waiters: DashMap<CorrId, oneshot::Sender<(u32, u32)>>,
+    instance_change_waiters: DashMap<CorrId, oneshot::Sender<(u32, u32, u32)>>,
     inst_event_tx: DashMap<InstanceId, mpsc::Sender<InstanceEvent>>,
     // Use a Mutex per entry to avoid deadlocking the DashMap shard
     pending_downloads: DashMap<String, Mutex<DownloadState>>, // Key: blob_hash
@@ -156,6 +157,7 @@ impl Client {
             corr_id_pool: Mutex::new(IdPool::new(CorrId::MAX)),
             pending_requests: DashMap::new(),
             backend_change_waiters: DashMap::new(),
+            instance_change_waiters: DashMap::new(),
             inst_event_tx: DashMap::new(),
             pending_downloads: DashMap::new(),
         });
@@ -336,6 +338,29 @@ impl Client {
         self.inner.corr_id_pool.lock().await.release(corr_id)?;
         Ok((num_attached, num_rejected))
     }
+
+    pub async fn wait_instance_change(
+        &self,
+        cur_num_attached_instances: Option<u32>,
+        cur_num_detached_instances: Option<u32>,
+        cur_num_rejected_instances: Option<u32>,
+    ) -> Result<(u32, u32, u32)> {
+        let corr_id = self.inner.corr_id_pool.lock().await.acquire()?;
+        let msg = ClientMessage::WaitInstanceChange {
+            corr_id,
+            cur_num_attached_instances,
+            cur_num_detached_instances,
+            cur_num_rejected_instances,
+        };
+        let (tx, rx) = oneshot::channel();
+        self.inner.instance_change_waiters.insert(corr_id, tx);
+        self.inner
+            .ws_writer_tx
+            .send(Message::Binary(Bytes::from(encode::to_vec_named(&msg)?)))?;
+        let (num_attached, num_detached, num_rejected) = rx.await?;
+        self.inner.corr_id_pool.lock().await.release(corr_id)?;
+        Ok((num_attached, num_detached, num_rejected))
+    }
 }
 
 /// Main message handler function called by the reader task.
@@ -361,6 +386,16 @@ async fn handle_server_message(
         } => {
             if let Some((_, sender)) = inner.backend_change_waiters.remove(&corr_id) {
                 sender.send((num_attached, num_rejected)).ok();
+            }
+        }
+        ServerMessage::InstanceChange {
+            corr_id,
+            num_attached,
+            num_detached,
+            num_rejected,
+        } => {
+            if let Some((_, sender)) = inner.instance_change_waiters.remove(&corr_id) {
+                sender.send((num_attached, num_detached, num_rejected)).ok();
             }
         }
         ServerMessage::InstanceEvent {


### PR DESCRIPTION
This pull request introduces two main changes to the CLI:
- Renames pie start to pie serve.
- Adds support for pie run to perform one-shot inferlet execution.

### Synchronization Improvements
To support pie run, this pull request also adds several synchronization mechanisms to eliminate race conditions between the CLI client, the engine, and the backends:
- The CLI client now waits until the engine is ready before starting the backends.
- The CLI client waits until all backends are ready before uploading the inferlet binary.
- The CLI client waits until the inferlet completes before shutting down the engine and backends.

### Demonstration of a High-Quality Pull Request
This pull request also serves as an example of what a high-quality pull request should look like.
For comparison, a negative example that implements the same functionality can be found in Pull #87.

A Good Pull Request Should:
- Ensure the system runs on every commit, that is, no half-baked or broken intermediate states.
- Keep each commit focused on a single concern.
- Maintain manageable commit sizes for easy review.

It’s rarely possible to achieve a perfect commit sequence on the first attempt. For instance, my initial version in Pull #87 contained intermediate commits with partially implemented features that caused printer lockups and scattered changes related to `pie run`.

To make this PR reviewable and maintainable, the commits were reordered, split, and squashed where appropriate to form a coherent, readable sequence.

This pull request represents the cleaned-up, review-ready version of that earlier work. Please use this PR as a reference for what to aim for in future contributions.