### PR TITLE
Miscellaneous improvement for the CLI.

### DIFF
--- a/pie-cli/src/main.rs
+++ b/pie-cli/src/main.rs
@@ -574,11 +574,12 @@ fn build_configs(
     verbose: bool,
     log: Option<PathBuf>,
 ) -> Result<(EngineConfig, Vec<toml::Value>)> {
-    let config_path = config_path
-        .map(Ok)
-        .unwrap_or_else(get_default_config_path)?;
-    let config_str = fs::read_to_string(&config_path)
-        .with_context(|| format!("Failed to read config file at {:?}", config_path))?;
+    let config_str = match config_path {
+        Some(path) => fs::read_to_string(&path)
+            .with_context(|| format!("Failed to read config file at {:?}", path))?,
+        None => fs::read_to_string(&get_default_config_path()?)
+            .context("Failed to read default config file. Try running `pie config init` first.")?,
+    };
     let cfg_file: ConfigFile = toml::from_str(&config_str)?;
 
     let enable_auth = if no_auth {

--- a/pie-cli/src/main.rs
+++ b/pie-cli/src/main.rs
@@ -89,12 +89,11 @@ pub struct ServeArgs {
 /// Arguments to submit an inferlet (Wasm program) to the engine in the shell.
 pub struct RunArgs {
     /// Path to the .wasm inferlet file.
-    #[arg(long, short, value_parser = expand_tilde)]
+    #[arg(value_parser = expand_tilde)]
     pub inferlet: PathBuf,
     /// Path to a custom TOML configuration file.
     #[arg(long, short)]
     pub config: Option<PathBuf>,
-    /// Accept arguments after `--` and pass them to the Wasm program.
     /// A log file to write to.
     #[arg(long)]
     pub log: Option<PathBuf>,

--- a/pie-cli/src/main.rs
+++ b/pie-cli/src/main.rs
@@ -42,7 +42,7 @@ use tracing_subscriber::{EnvFilter, FmtSubscriber, Layer};
 //================================================================================//
 
 #[derive(Parser, Debug)]
-#[command(author, version, about = "PIE Command Line Interface")]
+#[command(author, version, about = "Pie Command Line Interface")]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -63,7 +63,7 @@ enum Commands {
 }
 
 #[derive(Args, Debug)]
-/// Arguments for starting the PIE engine.
+/// Arguments for starting the Pie engine.
 pub struct ServeArgs {
     /// Path to a custom TOML configuration file.
     #[arg(long)]
@@ -424,7 +424,7 @@ async fn handle_shell_command(
                 "  run [--detach] <path> [ARGS]... - Run a .wasm inferlet with optional arguments"
             );
             println!("  query                  - (Placeholder) Query the engine state");
-            println!("  exit                   - Exit the PIE session");
+            println!("  exit                   - Exit the Pie session");
             println!("  help                   - Show this help message");
         }
         "exit" => {
@@ -684,7 +684,7 @@ fn create_default_config_content(exec_path: &str, backend_type: &str) -> Result<
 }
 
 fn init_default_config_file(exec_path: &str, backend_type: &str) -> Result<()> {
-    println!("⚙️ Initializing PIE configuration...");
+    println!("⚙️ Initializing Pie configuration...");
 
     let config_path = get_default_config_path()?;
 
@@ -755,7 +755,7 @@ fn update_default_config_file(args: ConfigUpdateArgs) -> Result<()> {
         return Ok(());
     }
 
-    println!("⚙️ Updating PIE configuration...");
+    println!("⚙️ Updating Pie configuration...");
 
     let config_path = get_default_config_path()?;
 
@@ -1027,8 +1027,8 @@ async fn start_engine_and_backend(
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let (ready_tx, ready_rx) = oneshot::channel();
 
-    // Start the main PIE engine server
-    println!("🚀 Starting PIE engine...");
+    // Start the main Pie engine server
+    println!("🚀 Starting Pie engine...");
     let server_handle = tokio::spawn(async move {
         if let Err(e) = pie::run_server(engine_config, ready_tx, shutdown_rx).await {
             eprintln!("\n[Engine Error] Engine failed: {}", e);


### PR DESCRIPTION
See commit messages for details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - CLI update: the inferlet parameter is now a positional argument (no -i/--inferlet); path tilde expansion remains supported. Help output updated accordingly.
- Documentation
  - Refreshed CLI help/about text and command descriptions for clarity.
- Style
  - Standardized product naming from “PIE” to “Pie” across help text and runtime messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->