### PR TITLE
Add `stat` command to the shell and remove periodic stats printing.

### DIFF
--- a/pie-cli/src/main.rs
+++ b/pie-cli/src/main.rs
@@ -417,6 +417,9 @@ async fn handle_shell_command(
         "query" => {
             println!("(Query functionality not yet implemented)");
         }
+        "stat" => {
+            print_backend_stats(client_config, printer).await?;
+        }
         "help" => {
             println!("Available commands:");
             println!(
@@ -1322,6 +1325,20 @@ async fn run_inferlet(
         });
     }
 
+    Ok(())
+}
+
+async fn print_backend_stats(
+    client_config: &ClientConfig,
+    printer: &Arc<Mutex<dyn rustyline::ExternalPrinter + Send>>,
+) -> Result<()> {
+    let client = connect_and_authenticate(client_config).await?;
+    let stats = client.query_backend_stats().await?;
+    {
+        let mut p = printer.lock().await;
+        p.print("Backend runtime stats:\n".to_string()).unwrap();
+        p.print(format!("{}\n", stats)).unwrap();
+    }
     Ok(())
 }
 

--- a/pie/src/client.rs
+++ b/pie/src/client.rs
@@ -207,7 +207,8 @@ impl Client {
         let corr_id_ref = match &mut msg {
             ClientMessage::Authenticate { corr_id, .. }
             | ClientMessage::Query { corr_id, .. }
-            | ClientMessage::LaunchInstance { corr_id, .. } => corr_id,
+            | ClientMessage::LaunchInstance { corr_id, .. }
+            | ClientMessage::QueryBackendStats { corr_id } => corr_id,
             _ => anyhow::bail!("Invalid message type for this helper"),
         };
         *corr_id_ref = corr_id_new;
@@ -247,6 +248,16 @@ impl Client {
             Ok(result)
         } else {
             anyhow::bail!("Query failed: {}", result)
+        }
+    }
+
+    pub async fn query_backend_stats(&self) -> Result<String> {
+        let msg = ClientMessage::QueryBackendStats { corr_id: 0 };
+        let (successful, result) = self.send_msg_and_wait(msg).await?;
+        if successful {
+            Ok(result)
+        } else {
+            anyhow::bail!("Query backend stats failed: {}", result)
         }
     }
 


### PR DESCRIPTION
The change will also help to implement telemetry support (Issue #85).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CLI command to display backend runtime statistics on demand.
  * Clients can request runtime stats; responses are authenticated, sorted, and formatted for readability.

* **Chores**
  * Removed periodic automatic runtime stats logging to reduce noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->