### PR TITLE
Stop backend heartbeat before terminating backend processes.

### DIFF
--- a/pie/src/client.rs
+++ b/pie/src/client.rs
@@ -208,6 +208,7 @@ impl Client {
             ClientMessage::Authenticate { corr_id, .. }
             | ClientMessage::Query { corr_id, .. }
             | ClientMessage::LaunchInstance { corr_id, .. }
+            | ClientMessage::StopBackendHeartbeat { corr_id }
             | ClientMessage::QueryBackendStats { corr_id } => corr_id,
             _ => anyhow::bail!("Invalid message type for this helper"),
         };
@@ -258,6 +259,16 @@ impl Client {
             Ok(result)
         } else {
             anyhow::bail!("Query backend stats failed: {}", result)
+        }
+    }
+
+    pub async fn stop_backend_heartbeat(&self) -> Result<()> {
+        let msg = ClientMessage::StopBackendHeartbeat { corr_id: 0 };
+        let (successful, result) = self.send_msg_and_wait(msg).await?;
+        if successful {
+            Ok(())
+        } else {
+            anyhow::bail!("Stop backend heartbeat failed: {}", result)
         }
     }
 


### PR DESCRIPTION
This is to avoid broken pipe errors due to sending heartbeat requests to the backend after it has exited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added ability to stop backend heartbeat on demand via CLI and API.
  * Server now supports a stop-backend-heartbeat request with confirmation.
  * Models honor stop requests and cease sending heartbeat signals.

* Bug Fixes
  * Improved shutdown behavior to prevent lingering heartbeat activity.
  * Reduced race conditions during serve/run termination for more reliable exits.
  * Lowered resource use and log noise during shutdown sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->