### PR TITLE
Gracefully handle the error when the specified model is not downloaded

### DIFF
--- a/backend/backend-python/model_loader.py
+++ b/backend/backend-python/model_loader.py
@@ -17,6 +17,16 @@ from config.common import ModelInfo
 CreateModelFn = Callable[[ModelInfo], Tuple[torch.nn.Module, dict]]
 
 
+class MetadataNotFoundError(FileNotFoundError):
+    """Exception raised when a metadata file is not found."""
+
+    model_name: str
+
+    def __init__(self, model_name: str, error: str):
+        self.model_name = model_name
+        super().__init__(error)
+
+
 def load_model_info(config: dict) -> ModelInfo:
     """Load the model information from the metadata file."""
 
@@ -27,7 +37,9 @@ def load_model_info(config: dict) -> ModelInfo:
     metadata_path = model_path / f"{model_name}.toml"
 
     if not metadata_path.exists():
-        raise FileNotFoundError(f"Metadata file not found at: {metadata_path}")
+        raise MetadataNotFoundError(
+            model_name, f"Metadata file not found at: {metadata_path}"
+        )
 
     # Load the model information from the metadata file.
     model_device = config["device"]

--- a/backend/backend-python/server.py
+++ b/backend/backend-python/server.py
@@ -42,6 +42,8 @@ from message import (
     UploadAdapterRequest,
 )
 
+from model_loader import MetadataNotFoundError
+
 
 class HandlerId(enum.Enum):
     """Enumeration of handler message types."""
@@ -508,10 +510,15 @@ def main(
 
     print_config(config)
 
-    start_service(
-        config=config,
-        handler_cls=Handler,
-    )
+    try:
+        start_service(
+            config=config,
+            handler_cls=Handler,
+        )
+    except MetadataNotFoundError as e:
+        print(f"Error: {e}")
+        print(f"Try `pie model add {e.model_name}` to download the model.")
+        os._exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Changes:
- Let the backend print a graceful message and exit if the specified model is not downloaded.
- Let the CLI listen for premature backend termination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clear, user-friendly error when required model metadata is missing, including a suggested command to download the model and an immediate exit.

* **Bug Fixes**
  * CLI now immediately reports and fails if a backend process terminates prematurely, avoiding silent waits.
  * More robust readiness handling using concurrent monitoring, reducing race conditions and hangs.
  * Improved error messages for backend termination and registration issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->