### PR TITLE
profiler argument parser

### DIFF
--- a/tool/profile_visualizer/README.md
+++ b/tool/profile_visualizer/README.md
@@ -12,23 +12,30 @@ A web-based tool for visualizing profiling data from the PIE backend.
 - **Percent of Total**: All percentages shown relative to total execution time
 
 ## Usage
+
 Inside the `tool` directory:
 
-### Start with a specific profiling file:
+### Start with a specific profiling file
 
 ```bash
 python -m profile_visualizer path/to/profiling_result.json
 ```
 
-### Start without a file (browse from workspace root):
+### Start without a file (browse from workspace root)
 
 ```bash
 python -m profile_visualizer
 ```
 
+### Start at a specified port
+
+```bash
+python -m profile_visualizer --port 8080
+```
+
 ## Structure
 
-```
+```bash
 profile_visualizer/
 ├── __init__.py          # Package initialization
 ├── __main__.py          # Entry point (python -m profile_visualizer)

--- a/tool/profile_visualizer/__main__.py
+++ b/tool/profile_visualizer/__main__.py
@@ -4,14 +4,15 @@ Simple web-based profiling visualization tool.
 
 Usage:
     # Start with an initial file
-    python -m profile_visualizer <path_to_profiling_json>
+    python -m profile_visualizer <path_to_profiling_json> [--port PORT]
 
     # Start without a file (uses parent directory for file search)
-    python -m profile_visualizer
+    python -m profile_visualizer [--port PORT]
 
     Example:
     python -m profile_visualizer pie-metal/20251003_205526_profiling_result.json
-    python -m profile_visualizer
+    python -m profile_visualizer --port 8080
+    python -m profile_visualizer --port 8080 pie-metal/20251003_205526_profiling_result.json
 
 Features:
     - Load files from server directory dropdown
@@ -19,6 +20,7 @@ Features:
     - Click to browse local files
 """
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -26,14 +28,55 @@ from pathlib import Path
 from .server import start_server
 
 
+def parse_args():
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Web-based profiling visualization tool.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Start server on default port (8000) without initial file
+  python -m profile_visualizer
+
+  # Load a specific profiling file
+  python -m profile_visualizer path/to/profiling.json
+
+  # Start server on custom port
+  python -m profile_visualizer --port 8080
+
+  # Load file and use custom port
+  python -m profile_visualizer path/to/profiling.json --port 8080""",
+)
+
+    parser.add_argument(
+        "file",
+        nargs="?",
+        type=str,
+        default=None,
+        help="Path to profiling JSON file to load initially (optional)",
+    )
+
+    parser.add_argument(
+        "-p",
+        "--port",
+        type=int,
+        default=8000,
+        help="Port number to run the web server on (default: 8000)",
+    )
+
+    return parser.parse_args()
+
+
 def main():
     """Main entry point."""
+    args = parse_args()
+    
     initial_data = None
     search_dir = None
 
     # Optional: Load initial file if provided
-    if len(sys.argv) >= 2:
-        json_path = Path(sys.argv[1])
+    if args.file:
+        json_path = Path(args.file)
         if not json_path.exists():
             print(f"Error: File not found: {json_path}")
             sys.exit(1)
@@ -57,8 +100,9 @@ def main():
     static_dir = str(Path(__file__).parent / "static")
 
     # Start the server
+    print(f"Starting server on port {args.port}...")
     start_server(
-        port=8000,
+        port=args.port,
         search_dir=search_dir,
         initial_data=initial_data,
         static_dir=static_dir,


### PR DESCRIPTION
Added an argument parser to the profiler tool, which enables specifying the server port.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added command-line options to choose the server port and optionally preload a profiling JSON file. Improved startup messaging; defaults remain unchanged.

* Documentation
  * Expanded README with a usage example for starting on a specific port.
  * Documented project structure and roles of key components.
  * Added an API Endpoints section describing available routes.
  * Updated development notes (default localhost port and static asset serving).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->