### PR TITLE
Fix the bug that causes ctrl+c to not work with `pie run`.

### DIFF
--- a/pie/src/cli/run.rs
+++ b/pie/src/cli/run.rs
@@ -3,7 +3,7 @@
 //! This module implements the `pie run` subcommand for running inferlets
 //! with a one-shot Pie engine instance.
 
-use super::{output, path, service};
+use super::{path, service};
 use crate::engine::Config as EngineConfig;
 use anyhow::Result;
 use clap::Args;
@@ -29,26 +29,22 @@ pub struct RunArgs {
 /// Handles the `pie run` command.
 ///
 /// This function:
-/// 1. Creates an editor and printer for output handling
-/// 2. Starts the Pie engine and backend services
-/// 3. Runs the specified inferlet with the provided arguments
-/// 4. Waits for the inferlet to finish execution
-/// 5. Terminates the engine and backend services
+/// 1. Starts the Pie engine and backend services
+/// 2. Runs the specified inferlet with the provided arguments
+/// 3. Waits for the inferlet to finish execution
+/// 4. Terminates the engine and backend services
 pub async fn handle_run_command(
     engine_config: EngineConfig,
     backend_configs: Vec<toml::Value>,
     inferlet_path: PathBuf,
     arguments: Vec<String>,
 ) -> Result<()> {
-    let (_rl, printer) = output::create_editor_and_printer_with_history().await?;
-
     // Start the engine and backend services
     let (shutdown_tx, server_handle, backend_processes, client_config) =
-        service::start_engine_and_backend(engine_config, backend_configs, printer.clone()).await?;
+        service::start_engine_and_backend(engine_config, backend_configs, None).await?;
 
     // Run the inferlet
-    service::submit_inferlet_and_wait(&client_config, inferlet_path, arguments, printer.clone())
-        .await?;
+    service::submit_inferlet_and_wait(&client_config, inferlet_path, arguments, None).await?;
 
     // Terminate the engine and backend services
     service::terminate_engine_and_backend(backend_processes, shutdown_tx, server_handle).await?;

--- a/pie/src/cli/serve.rs
+++ b/pie/src/cli/serve.rs
@@ -12,6 +12,7 @@ use rustyline::Editor;
 use rustyline::error::ReadlineError;
 use rustyline::history::FileHistory;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 /// Arguments for the `pie serve` command.
 #[derive(Args, Debug, Default)]
@@ -70,7 +71,12 @@ pub async fn handle_serve_command(
 
     // Start the engine and backend services
     let (shutdown_tx, server_handle, backend_processes, client_config) =
-        service::start_engine_and_backend(engine_config, backend_configs, printer.clone()).await?;
+        service::start_engine_and_backend(
+            engine_config,
+            backend_configs,
+            Some(Arc::clone(&printer)),
+        )
+        .await?;
 
     // Run interactive shell or wait for ctrl-c
     if interactive {


### PR DESCRIPTION
The `rustyline` library captures the Ctrl+C signal. It works with `pie serve` because it runs in an interactive shell, and it prints a message when Ctrl+C is pressed so that the user will know to press Ctrl-D to exit.

However, `pie run` does not run in an interactive shell. Previously, the code reused the `rustyline` printer for inferlet output, but that prevented the Ctrl+C signal from killing the engine process.

This commit fixes the bug by changing the printer to be optional. When running `pie run`, the printer is `None`, and the code prints the output through the standard `println!` macro. Since the `rustyline` printer is no longer created for `pie run`, the Ctrl+C signal is not captured, and the engine process can be killed by Ctrl+C.

Addressing Issue #133 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of output handling with fallback to standard streams when printer is unavailable.

* **Refactor**
  * Streamlined run command execution flow for simplified operation.
  * Optimized shutdown signal handling in the engine for more direct termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->