### PR TITLE
update pie-client dependency in Cargo.toml for cargo.io packaging and…

### DIFF
--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name = "picli"
+name = "pie-cli"
 version = "0.2.0"
 edition = "2024"
 authors = ["Pie Team"]
-description = "Programmable Inference Command Line Interface"
+description = "Pie Command Line Interface"
 license = "Apache-2.0"
 repository = "https://github.com/pie-project/pie"
 
 [[bin]]
-name = "picli"
+name = "pie-cli"
 path = "src/main.rs"
 
 [dependencies]
-pie-client = { path = "../rust" }
+pie-client = { version = "0.2.0", path = "../rust" }
 tokio = { version = "1.38", features = ["full"] }
 anyhow = "1.0"
 clap = { version = "4.5", features = ["derive"] }

--- a/client/rust/Cargo.toml
+++ b/client/rust/Cargo.toml
@@ -3,7 +3,7 @@ name = "pie-client"
 version = "0.2.0"
 edition = "2024"
 authors = ["Pie Team"]
-description = "Programmable Inference Engine (Pie) Client"
+description = "Pie Client"
 license = "Apache-2.0"
 repository = "https://github.com/pie-project/pie"
 


### PR DESCRIPTION
… rename `picli` -> `pie-cli` to match existing crates.io entry (#145)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed CLI package from `picli` to `pie-cli`.
  * Updated CLI and client package descriptions.
  * Bumped pie-client dependency to version 0.2.0 and added new supporting dependencies for enhanced functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->