### PR TITLE
Use internal authentication for Pie shell and backend connections.

### DIFF
--- a/backend/backend-python/server.py
+++ b/backend/backend-python/server.py
@@ -253,9 +253,9 @@ def register_thread(config: Dict[str, Any], endpoint: str) -> None:
         with connect(controller_addr) as websocket:
             auth_msg = msgpack.packb(
                 {
-                    "type": "authenticate",
+                    "type": "internal_authenticate",
                     "corr_id": 0,
-                    "token": config["auth_token"],
+                    "token": config["internal_auth_token"],
                 },
                 use_bin_type=True,
             )
@@ -487,7 +487,7 @@ def main(
     port: int = 10123,
     controller_host: str = "localhost",
     controller_port: int = 9123,
-    auth_token: str | None = None,
+    internal_auth_token: str | None = None,
     cache_dir: str | None = None,
     kv_page_size: int = 16,
     max_dist_size: int = 64,
@@ -510,7 +510,7 @@ def main(
         port: Port for the ZMQ service to bind to.
         controller_host: Hostname of the controller to register with.
         controller_port: Port of the controller to register with.
-        auth_token: Authentication token for connecting to the controller.
+        internal_auth_token: Internal authentication token for connecting to the controller.
         cache_dir: Directory for model cache. Defaults to PIE_HOME env var,
                    then the platform-specific user cache dir.
         kv_page_size: The size of each page in the key-value cache.
@@ -545,7 +545,7 @@ def main(
         port=port,
         controller_host=controller_host,
         controller_port=controller_port,
-        auth_token=auth_token,
+        internal_auth_token=internal_auth_token,
         cache_dir=cache_dir,
         kv_page_size=kv_page_size,
         max_dist_size=max_dist_size,

--- a/client/rust/src/client.rs
+++ b/client/rust/src/client.rs
@@ -201,6 +201,7 @@ impl Client {
         let corr_id_new = self.inner.corr_id_pool.lock().await.acquire()?;
         let corr_id_ref = match &mut msg {
             ClientMessage::Authenticate { corr_id, .. }
+            | ClientMessage::InternalAuthenticate { corr_id, .. }
             | ClientMessage::Query { corr_id, .. }
             | ClientMessage::LaunchInstance { corr_id, .. } => corr_id,
             _ => anyhow::bail!("Invalid message type for this helper"),
@@ -228,6 +229,19 @@ impl Client {
             Ok(())
         } else {
             anyhow::bail!("Authentication failed: {}", result)
+        }
+    }
+
+    pub async fn internal_authenticate(&self, token: &str) -> Result<()> {
+        let msg = ClientMessage::InternalAuthenticate {
+            corr_id: 0,
+            token: token.to_string(),
+        };
+        let (successful, result) = self.send_msg_and_wait(msg).await?;
+        if successful {
+            Ok(())
+        } else {
+            anyhow::bail!("Internal authentication failed: {}", result)
         }
     }
 

--- a/client/rust/src/message.rs
+++ b/client/rust/src/message.rs
@@ -95,6 +95,9 @@ pub enum ClientMessage {
         service_type: String,
         service_name: String,
     },
+
+    #[serde(rename = "internal_authenticate")]
+    InternalAuthenticate { corr_id: u32, token: String },
 }
 
 /// Messages from server -> client

--- a/pie/Cargo.toml
+++ b/pie/Cargo.toml
@@ -23,7 +23,7 @@ toml = "0.9"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 indicatif = "0.18"
 dirs = "6.0"
-rand = { version = "0.9.2", features = ["std_rng"] }
+rand = { version = "0.9.2", features = ["std_rng", "os_rng"] }
 rustyline = "17.0.0"
 shellexpand = "3.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }


### PR DESCRIPTION
Previously, the user CLI client, the Pie shell, and the backend subprocess all used the same authentication token for authentication. However, since the Pie shell and backend subprocesses are part of the Pie system, they should use a simplified authentication mechanism.

For user CLI client, the authentication token will later be changed to public key authentication.

This commit adds a new internal authentication mechanism for the Pie shell and backend subprocesses. The internal authentication token is a random 64-character string, which is shared with the Pie shell and the backend subprocesses internally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an internal authentication pathway allowing components to authenticate using engine-issued tokens.
  * Client and CLI APIs extended to initiate internal authentication with the engine-provided token.

* **Improvements**
  * Engine now generates and securely distributes a runtime internal token to backends at startup.
  * Backend startup and connection flows use the engine-issued token instead of per-backend JWTs, simplifying authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->