### PR TITLE
Move inferlet composition to client side.

### DIFF
--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -23,3 +23,5 @@ rand = { version = "0.8" }
 shellexpand = "3.1"
 base64 = "0.22"
 whoami = "1.5"
+wac-graph = "0.8"
+wac-types = "0.8"

--- a/client/cli/src/submit.rs
+++ b/client/cli/src/submit.rs
@@ -11,6 +11,8 @@ use clap::Args;
 use pie_client::client;
 use std::fs;
 use std::path::PathBuf;
+use wac_graph::{CompositionGraph, EncodeOptions};
+use wac_types::Package;
 
 /// Arguments for the `pie submit` command.
 #[derive(Args, Debug)]
@@ -44,14 +46,66 @@ pub struct SubmitArgs {
     pub arguments: Vec<String>,
 }
 
+/// Compose a component with a library. The library (plug) is linked into the
+/// main program (socket).
+fn compose_one_component(socket_bytes: Vec<u8>, plug_bytes: Vec<u8>) -> Result<Vec<u8>> {
+    // Create a new composition graph
+    let mut graph = CompositionGraph::new();
+
+    // Prepare the socket package
+    let socket_package = Package::from_bytes("socket", None, socket_bytes, graph.types_mut())
+        .context("Failed to load socket component")?;
+    let socket_id = graph
+        .register_package(socket_package)
+        .context("Failed to register socket package")?;
+
+    // Prepare the plug package
+    let plug_package = Package::from_bytes("plug", None, plug_bytes, graph.types_mut())
+        .context("Failed to load plug component")?;
+    let plug_id = graph
+        .register_package(plug_package)
+        .context("Failed to register plug package")?;
+
+    // Perform the composition: connect the plug's exports to the socket's imports
+    wac_graph::plug(&mut graph, vec![plug_id], socket_id)
+        .context("Failed to compose components")?;
+
+    // Encode the composed component to bytes
+    let composed_bytes = graph
+        .encode(EncodeOptions::default())
+        .context("Failed to encode composed component")?;
+
+    Ok(composed_bytes)
+}
+
+/// Compose a component with multiple libraries. The libraries are linked into the main program
+/// sequentially in the order of the library paths.
+///
+/// Notably, the composition is done iteratively. At each iteration, a library is linked into
+/// the main program. This allows an interface instrumented by a library to be instrumented
+/// again by another following library.
+fn compose_components(program_bytes: Vec<u8>, library_paths: &[PathBuf]) -> Result<Vec<u8>> {
+    let mut socket_bytes = program_bytes;
+
+    for library_path in library_paths {
+        let plug_bytes = fs::read(library_path)
+            .context(format!("Failed to read library file at {:?}", library_path))?;
+        let composed_bytes = compose_one_component(socket_bytes, plug_bytes)?;
+        socket_bytes = composed_bytes;
+    }
+
+    Ok(socket_bytes)
+}
+
 /// Handles the `pie submit` command.
 ///
 /// This function:
 /// 1. Reads configuration from the specified config file or default config
 /// 2. Creates a client configuration from config and command-line arguments
 /// 3. Connects to the existing Pie engine server
-/// 4. Submits the specified inferlet with the provided arguments
-/// 5. In non-detached mode, streams the inferlet output with signal handling:
+/// 4. If libraries are specified, composes them with the inferlet on the client side
+/// 5. Submits the composed inferlet with the provided arguments
+/// 6. In non-detached mode, streams the inferlet output with signal handling:
 ///    - Ctrl-C (SIGINT): Terminates the inferlet on the server
 ///    - Ctrl-D (EOF): Detaches from the inferlet (continues running on server)
 pub async fn handle_submit_command(args: SubmitArgs) -> Result<()> {
@@ -65,29 +119,28 @@ pub async fn handle_submit_command(args: SubmitArgs) -> Result<()> {
 
     let client = engine::connect_and_authenticate(&client_config).await?;
 
+    // Read the main inferlet
     let inferlet_blob = fs::read(&args.inferlet)
         .context(format!("Failed to read Wasm file at {:?}", args.inferlet))?;
-    let hash = client::hash_blob(&inferlet_blob);
-    println!("Inferlet hash: {}", hash);
 
+    // If libraries are specified, compose them with the main inferlet
+    let final_blob = if args.link.is_empty() {
+        inferlet_blob
+    } else {
+        compose_components(inferlet_blob, &args.link)
+            .context("Failed to compose inferlet with libraries")?
+    };
+
+    // Calculate the hash of the final composed blob
+    let hash = client::hash_blob(&final_blob);
+    println!("Final inferlet hash: {}", hash);
+
+    // Upload the composed inferlet to the server
     if !client.program_exists(&hash).await? {
-        client.upload_program(&inferlet_blob).await?;
+        client.upload_program(&final_blob).await?;
         println!("✅ Inferlet upload successful.");
-    }
-
-    let mut library_hashes = Vec::new();
-    for library_path in &args.link {
-        let library_blob = fs::read(library_path)
-            .context(format!("Failed to read library file at {:?}", library_path))?;
-        let library_hash = client::hash_blob(&library_blob);
-        println!("Library hash: {}", library_hash);
-
-        if !client.program_exists(&library_hash).await? {
-            client.upload_program(&library_blob).await?;
-            println!("✅ Library upload successful.");
-        }
-
-        library_hashes.push(library_hash);
+    } else {
+        println!("Inferlet already exists on server.");
     }
 
     let cmd_name = args
@@ -96,14 +149,9 @@ pub async fn handle_submit_command(args: SubmitArgs) -> Result<()> {
         .context("Inferlet path must have a valid file name")?
         .to_string_lossy()
         .to_string();
+
     let instance = client
-        .launch_instance(
-            hash,
-            cmd_name,
-            args.arguments,
-            library_hashes,
-            args.detached,
-        )
+        .launch_instance(hash, cmd_name, args.arguments, args.detached)
         .await?;
 
     println!("✅ Inferlet launched with ID: {}", instance.id());

--- a/client/rust/src/client.rs
+++ b/client/rust/src/client.rs
@@ -388,7 +388,6 @@ impl Client {
         program_hash: String,
         cmd_name: String,
         arguments: Vec<String>,
-        library_hashes: Vec<String>,
         detached: bool,
     ) -> Result<Instance> {
         let corr_id_guard = self.inner.corr_id_pool.acquire().await?;
@@ -397,7 +396,6 @@ impl Client {
             program_hash,
             cmd_name,
             arguments,
-            library_hashes,
             detached,
         };
 

--- a/client/rust/src/message.rs
+++ b/client/rust/src/message.rs
@@ -83,7 +83,6 @@ pub enum ClientMessage {
         program_hash: String,
         cmd_name: String,
         arguments: Vec<String>,
-        library_hashes: Vec<String>,
         detached: bool,
     },
 
@@ -95,7 +94,6 @@ pub enum ClientMessage {
         corr_id: u32,
         port: u32,
         program_hash: String,
-        library_hashes: Vec<String>,
         cmd_name: String,
         arguments: Vec<String>,
     },

--- a/pie/Cargo.toml
+++ b/pie/Cargo.toml
@@ -37,8 +37,6 @@ serde_json = "1.0"
 wasmtime = { version = "37.0.1", features = ["pooling-allocator"] } #{ path = "../../wasmtime/crates/wasmtime" }
 wasmtime-wasi = "37.0.1"# { path = "../../wasmtime/crates/wasi" }
 wasmtime-wasi-http = "37.0.1" #{ path = "../../wasmtime/crates/wasi-http" }
-wac-graph = "0.8"
-wac-types = "0.8"
 bytes = "1.10.1"
 uuid = { version = "1.16.0", features = ["serde", "v4"] }
 dashmap = "6.1.0"

--- a/pie/src/cli/manager.rs
+++ b/pie/src/cli/manager.rs
@@ -439,7 +439,7 @@ async fn submit_inferlet(
         .to_string_lossy()
         .to_string();
     let instance = client
-        .launch_instance(hash, cmd_name, arguments, vec![], detached)
+        .launch_instance(hash, cmd_name, arguments, detached)
         .await?;
     println!("✅ Inferlet launched with ID: {}", instance.id());
     Ok(instance)

--- a/pie/src/server.rs
+++ b/pie/src/server.rs
@@ -555,7 +555,6 @@ impl Session {
                     program_hash,
                     cmd_name,
                     arguments,
-                    library_hashes,
                     detached,
                 } => {
                     self.handle_launch_instance(
@@ -563,7 +562,6 @@ impl Session {
                         program_hash,
                         cmd_name,
                         arguments,
-                        library_hashes,
                         detached,
                     )
                     .await
@@ -578,7 +576,6 @@ impl Session {
                     corr_id,
                     port,
                     program_hash,
-                    library_hashes: _,
                     cmd_name,
                     arguments,
                 } => {
@@ -877,7 +874,6 @@ impl Session {
         program_hash: String,
         cmd_name: String,
         arguments: Vec<String>,
-        library_hashes: Vec<String>,
         detached: bool,
     ) {
         let (evt_tx, evt_rx) = oneshot::channel();
@@ -886,7 +882,6 @@ impl Session {
             program_hash,
             cmd_name,
             arguments,
-            library_hashes,
             detached,
             event: evt_tx,
         }


### PR DESCRIPTION
The engine should remain simple and only handle the execution of inferlets. The client side should handle the composition of inferlets and the submission of the composed inferlet to the engine.