### PR TITLE
fix: align Python auth TOML format with Rust runtime

### DIFF
--- a/pie/src/pie/auth.py
+++ b/pie/src/pie/auth.py
@@ -6,13 +6,27 @@ import toml
 
 
 def load_authorized_users(auth_path: Path) -> dict:
-    """Load authorized users from file, or return empty dict if not exists."""
+    """Load authorized users from file, or return empty dict if not exists.
+
+    Expected format (compatible with Rust runtime):
+        [users.username.keys]
+        key_name = "ssh-ed25519..."
+    """
     if not auth_path.exists():
         return {}
-    return toml.loads(auth_path.read_text())
+    data = toml.loads(auth_path.read_text())
+    if "users" not in data:
+        return {}
+    return {u: k.get("keys", {}) for u, k in data["users"].items()}
 
 
 def save_authorized_users(auth_path: Path, users: dict) -> None:
-    """Save authorized users to file."""
+    """Save authorized users to file in the format expected by the Rust runtime.
+
+    Output format:
+        [users.username.keys]
+        key_name = "ssh-ed25519..."
+    """
     auth_path.parent.mkdir(parents=True, exist_ok=True)
-    auth_path.write_text(toml.dumps(users))
+    formatted = {"users": {u: {"keys": k} for u, k in users.items()}}
+    auth_path.write_text(toml.dumps(formatted))


### PR DESCRIPTION
## Summary

Fixes a format mismatch between the Python CLI (`pie auth add`) and the Rust runtime's `AuthorizedUsers` deserialization.

**Problem:** The Python CLI was producing flat TOML format:
```toml
[testuser]
mykey = "ssh-ed25519..."
```

But the Rust `AuthorizedUsers` struct expects nested format:
```toml
[users.testuser.keys]
mykey = "ssh-ed25519..."
```

This caused `authorized_users.get(&username)` to always return `None`, silently breaking authentication for all users added via `pie auth add`.

**Root cause:** The Python migration (Dec 2025) introduced simple `toml.dumps(dict)` serialization without matching the Rust struct's expected nesting structure.

## Changes

- `save_authorized_users`: produces nested format `[users.X.keys]` compatible with Rust
- `load_authorized_users`: parses nested format correctly
- Updated tests to verify Rust-compatible format

## Test plan

- [x] All 12 auth tests pass
- [x] `test_save_produces_rust_compatible_format` verifies output matches Rust struct
- [x] `test_roundtrip_preserves_data` verifies load/save cycle works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of user authorization data loading with enhanced error handling for missing or incomplete configuration files.

* **Tests**
  * Expanded test coverage for user authentication workflows and data integrity validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->