### PR TITLE
fix: prevent unconditional cuda.set_device call on MPS

### DIFF
--- a/pie/src/pie/manager.py
+++ b/pie/src/pie/manager.py
@@ -617,8 +617,9 @@ def _ipc_worker_process(
              _init_distributed(rank, world_size, master_port, devices[rank])
         else:
              # Skip distributed for single device to avoid NCCL/socket issues
-             torch.cuda.set_device(devices[rank])
-             pass
+            device_str = devices[rank]
+            if device_str.startswith("cuda"):
+                torch.cuda.set_device(device_str)
 
         # Setup process groups (collective ops - all ranks must participate)
         # Capture the mappings to pass to Runtime


### PR DESCRIPTION
### Description
This PR fixes the `Failed to initialize backend: Worker process 54756 died unexpectedly with exit code 1` crash occurring on Apple Silicon when starting the engine. 

As discussed in issue #253, the worker process was unconditionally calling `torch.cuda.set_device()`, which is incompatible with MPS devices.

### Changes
- Added a check in `manager.py` to ensure `torch.cuda.set_device()` is only called for CUDA-prefixed device strings.
- Follows existing device-checking patterns found elsewhere in `manager.py`.

### Testing
- [x] Verified on macOS 26 (M4 Pro) - Engine now starts successfully.
- [ ] Needs verification on CUDA (logic is intended to be a no-op for CUDA).

Fixes #253 