### PR TITLE
feat: Remove namespace from inferlet name

### DIFF
--- a/benches/tput.py
+++ b/benches/tput.py
@@ -26,7 +26,7 @@ async def run_benchmark(args):
     if not wasm_path.exists():
         print(f"Error: WASM binary not found at {wasm_path}")
         print(
-            "Please run `cargo build --target wasm32-wasip2 --release` in `std/text-completion` first."
+            "Please run `cargo build --target wasm32-wasip2 --release` in `text-completion` first."
         )
         sys.exit(1)
 

--- a/client/javascript/src/index.js
+++ b/client/javascript/src/index.js
@@ -310,11 +310,10 @@ export class PieClient {
      * Check if a program exists on the server.
      *
      * The inferlet parameter can be:
-     * - Full name with version: "std/text-completion@0.1.0"
-     * - Without namespace (defaults to "std"): "text-completion@0.1.0"
-     * - Without version (defaults to "latest"): "std/text-completion" or "text-completion"
+     * - Full name with version: "text-completion@0.1.0"
+     * - Without version (defaults to "latest"): "text-completion"
      *
-     * @param {string} inferlet The inferlet name (e.g., "std/text-completion@0.1.0").
+     * @param {string} inferlet The inferlet name (e.g., "text-completion@0.1.0").
      * @param {string|null} [wasmPath=null] Optional path to the WASM binary file for hash verification (Node.js only).
      * @param {string|null} [manifestPath=null] Optional path to the manifest TOML file for hash verification (Node.js only).
      *   If paths are provided, both must be specified together.
@@ -404,11 +403,10 @@ export class PieClient {
      * 2. If not found, it falls back to searching the registry.
      *
      * The inferlet parameter can be:
-     * - Full name with version: "std/text-completion@0.1.0"
-     * - Without namespace (defaults to "std"): "text-completion@0.1.0"
-     * - Without version (defaults to "latest"): "std/text-completion" or "text-completion"
+     * - Full name with version: "text-completion@0.1.0"
+     * - Without version (defaults to "latest"): "text-completion"
      *
-     * @param {string} inferlet The inferlet name (e.g., "std/text-completion@0.1.0").
+     * @param {string} inferlet The inferlet name (e.g., "text-completion@0.1.0").
      * @param {string[]} [args=[]] Optional command-line arguments.
      * @param {boolean} [detached=false] If true, the instance runs in detached mode.
      * @returns {Promise<Instance>}
@@ -438,11 +436,10 @@ export class PieClient {
      * an inferlet from the registry.
      * 
      * The inferlet parameter can be:
-     * - Full name with version: "std/text-completion@0.1.0"
-     * - Without namespace (defaults to "std"): "text-completion@0.1.0"
-     * - Without version (defaults to "latest"): "std/text-completion" or "text-completion"
+     * - Full name with version: "text-completion@0.1.0"
+     * - Without version (defaults to "latest"): "text-completion"
      * 
-     * @param {string} inferlet The inferlet name (e.g., "std/text-completion@0.1.0").
+     * @param {string} inferlet The inferlet name (e.g., "text-completion@0.1.0").
      * @param {string[]} [args=[]] Optional command-line arguments.
      * @param {boolean} [detached=false] If true, the instance runs in detached mode.
      * @returns {Promise<Instance>}
@@ -504,15 +501,15 @@ async function main() {
         // 2. Upload a simple program with manifest
         const programCode = new TextEncoder().encode('print("Hello from JavaScript instance!")');
         const manifest = `[package]
-name = "example/hello-world"
+name = "hello-world"
 version = "0.1.0"
 `;
         await client.uploadProgram(programCode, manifest);
-        console.log(`[Example] Uploaded program: example/hello-world@0.1.0`);
+        console.log(`[Example] Uploaded program: hello-world@0.1.0`);
 
         // 3. Launch the instance using inferlet name
         console.log("[Example] Launching instance...");
-        const instance = await client.launchInstance("example/hello-world@0.1.0");
+        const instance = await client.launchInstance("hello-world@0.1.0");
         console.log(`[Example] Launched instance with ID: ${instance.instanceId}`);
 
         // 4. Wait for the instance to finish

--- a/client/python/src/pie_client/client.py
+++ b/client/python/src/pie_client/client.py
@@ -395,12 +395,11 @@ class PieClient:
         """Check if a program exists on the server.
 
         The inferlet parameter can be:
-        - Full name with version: "std/text-completion@0.1.0"
-        - Without namespace (defaults to "std"): "text-completion@0.1.0"
-        - Without version (defaults to "latest"): "std/text-completion" or "text-completion"
+        - Full name with version: "text-completion@0.1.0"
+        - Without version (defaults to "latest"): "text-completion"
 
         Args:
-            inferlet: The inferlet name (e.g., "std/text-completion@0.1.0").
+            inferlet: The inferlet name (e.g., "text-completion@0.1.0").
             wasm_path: Optional path to the WASM binary file for hash verification.
             manifest_path: Optional path to the manifest TOML file for hash verification.
                 If paths are provided, both must be specified together.
@@ -501,11 +500,10 @@ class PieClient:
         2. If not found, it falls back to searching the registry.
 
         The inferlet parameter can be:
-        - Full name with version: "std/text-completion@0.1.0"
-        - Without namespace (defaults to "std"): "text-completion@0.1.0"
-        - Without version (defaults to "latest"): "std/text-completion" or "text-completion"
+        - Full name with version: "text-completion@0.1.0"
+        - Without version (defaults to "latest"): "text-completion"
 
-        :param inferlet: The inferlet name (e.g., "std/text-completion@0.1.0").
+        :param inferlet: The inferlet name (e.g., "text-completion@0.1.0").
         :param arguments: Command-line arguments to pass to the inferlet.
         :param detached: If True, the instance runs in detached mode.
         :return: An Instance object for the launched inferlet.
@@ -541,11 +539,10 @@ class PieClient:
         an inferlet from the registry.
 
         The inferlet parameter can be:
-        - Full name with version: "std/text-completion@0.1.0"
-        - Without namespace (defaults to "std"): "text-completion@0.1.0"
-        - Without version (defaults to "latest"): "std/text-completion" or "text-completion"
+        - Full name with version: "text-completion@0.1.0"
+        - Without version (defaults to "latest"): "text-completion"
 
-        :param inferlet: The inferlet name (e.g., "std/text-completion@0.1.0").
+        :param inferlet: The inferlet name (e.g., "text-completion@0.1.0").
         :param arguments: Command-line arguments to pass to the inferlet.
         :param detached: If True, the instance runs in detached mode.
         :return: An Instance object for the launched inferlet.

--- a/client/python/src/pie_client_cli/engine.py
+++ b/client/python/src/pie_client_cli/engine.py
@@ -344,13 +344,12 @@ def program_exists(
     """Check if a program exists (sync wrapper).
 
     The inferlet parameter can be:
-    - Full name with version: "std/text-completion@0.1.0"
-    - Without namespace (defaults to "std"): "text-completion@0.1.0"
-    - Without version (defaults to "latest"): "std/text-completion" or "text-completion"
+    - Full name with version: "text-completion@0.1.0"
+    - Without version (defaults to "latest"): "text-completion"
 
     Args:
         client: The Pie client.
-        inferlet: The inferlet name (e.g., "std/text-completion@0.1.0").
+        inferlet: The inferlet name (e.g., "text-completion@0.1.0").
         wasm_path: Optional path to the WASM binary file for hash verification.
         manifest_path: Optional path to the manifest TOML file for hash verification.
             If paths are provided, both must be specified together.
@@ -373,9 +372,8 @@ def launch_instance(
     2. If not found, it falls back to searching the registry.
 
     The inferlet parameter can be:
-    - Full name with version: "std/text-completion@0.1.0"
-    - Without namespace (defaults to "std"): "text-completion@0.1.0"
-    - Without version (defaults to "latest"): "std/text-completion" or "text-completion"
+    - Full name with version: "text-completion@0.1.0"
+    - Without version (defaults to "latest"): "text-completion"
     """
     return asyncio.get_event_loop().run_until_complete(
         client.launch_instance(inferlet, arguments, detached)
@@ -395,9 +393,8 @@ def launch_instance_from_registry(
     an inferlet from the registry.
 
     The inferlet parameter can be:
-    - Full name with version: "std/text-completion@0.1.0"
-    - Without namespace (defaults to "std"): "text-completion@0.1.0"
-    - Without version (defaults to "latest"): "std/text-completion" or "text-completion"
+    - Full name with version: "text-completion@0.1.0"
+    - Without version (defaults to "latest"): "text-completion"
     """
     return asyncio.get_event_loop().run_until_complete(
         client.launch_instance_from_registry(inferlet, arguments, detached)

--- a/client/python/src/pie_client_cli/main.py
+++ b/client/python/src/pie_client_cli/main.py
@@ -81,7 +81,7 @@ def submit(
     inferlet: Annotated[
         Optional[str],
         typer.Argument(
-            help="Inferlet name from registry (e.g., 'std/text-completion@0.1.0')"
+            help="Inferlet name from registry (e.g., 'text-completion@0.1.0')"
         ),
     ] = None,
     path: Annotated[
@@ -117,7 +117,7 @@ def submit(
 
     You can specify an inferlet either by registry name or by path (mutually exclusive):
 
-    - By registry: pie-client submit std/text-completion@0.1.0
+    - By registry: pie-client submit text-completion@0.1.0
     - By path: pie-client submit --path ./my_inferlet.wasm --manifest ./Pie.toml
     """
     try:

--- a/client/python/src/pie_client_cli/submit.py
+++ b/client/python/src/pie_client_cli/submit.py
@@ -16,17 +16,17 @@ import typer
 from . import engine
 
 
-def parse_manifest(manifest_content: str) -> tuple[str, str, str]:
-    """Parse the manifest to extract namespace, name, and version.
+def parse_manifest(manifest_content: str) -> tuple[str, str]:
+    """Parse the manifest to extract name and version.
 
     Args:
         manifest_content: The TOML manifest content as a string.
 
     Returns:
-        A tuple of (namespace, name, version).
+        A tuple of (name, version).
 
     Raises:
-        ValueError: If the manifest is missing required fields or has invalid format.
+        ValueError: If the manifest is missing required fields.
     """
     manifest = tomllib.loads(manifest_content)
 
@@ -34,22 +34,15 @@ def parse_manifest(manifest_content: str) -> tuple[str, str, str]:
     if package is None:
         raise ValueError("Manifest missing [package] section")
 
-    full_name = package.get("name")
-    if full_name is None:
+    name = package.get("name")
+    if name is None:
         raise ValueError("Manifest missing package.name field")
 
     version = package.get("version")
     if version is None:
         raise ValueError("Manifest missing package.version field")
 
-    # Parse "namespace/name" format
-    parts = full_name.split("/", 1)
-    if len(parts) != 2:
-        raise ValueError(
-            f"Invalid package.name format '{full_name}': expected 'namespace/name'"
-        )
-
-    return parts[0], parts[1], version
+    return name, version
 
 
 def compose_components(
@@ -152,7 +145,7 @@ def handle_submit_command(
 
     You can specify an inferlet either by registry name or by path (mutually exclusive):
 
-    - By registry: pie-client submit std/text-completion@0.1.0
+    - By registry: pie-client submit text-completion@0.1.0
     - By path: pie-client submit --path ./my_inferlet.wasm --manifest ./Pie.toml
 
     Steps:
@@ -204,9 +197,9 @@ def handle_submit_command(
 
             manifest_content = manifest.read_text()
 
-            # Parse the manifest to extract namespace, name, and version
-            namespace, name, version = parse_manifest(manifest_content)
-            inferlet_name = f"{namespace}/{name}@{version}"
+            # Parse the manifest to extract name and version
+            name, version = parse_manifest(manifest_content)
+            inferlet_name = f"{name}@{version}"
 
             typer.echo(f"Inferlet: {inferlet_name}")
 

--- a/client/rust/src/client.rs
+++ b/client/rust/src/client.rs
@@ -346,9 +346,8 @@ impl Client {
     /// Optionally verifies that the stored hashes match the provided file contents.
     ///
     /// The `inferlet` parameter can be:
-    /// - Full name with version: `std/text-completion@0.1.0`
-    /// - Without namespace (defaults to `std`): `text-completion@0.1.0`
-    /// - Without version (defaults to `latest`): `std/text-completion` or `text-completion`
+    /// - Full name with version: `text-completion@0.1.0`
+    /// - Without version (defaults to `latest`): `text-completion`
     ///
     /// If paths are provided, both `wasm_path` and `manifest_path` must be specified together.
     /// The function will read the files and compute blake3 hashes for verification.
@@ -431,9 +430,8 @@ impl Client {
     /// 2. If not found, it falls back to searching the registry.
     ///
     /// The `inferlet` parameter can be:
-    /// - Full name with version: `std/text-completion@0.1.0`
-    /// - Without namespace (defaults to `std`): `text-completion@0.1.0`
-    /// - Without version (defaults to `latest`): `std/text-completion` or `text-completion`
+    /// - Full name with version: `text-completion@0.1.0`
+    /// - Without version (defaults to `latest`): `text-completion`
     pub async fn launch_instance(
         &self,
         inferlet: String,
@@ -472,9 +470,8 @@ impl Client {
     /// explicitly want to launch an inferlet from the registry.
     ///
     /// The `inferlet` parameter can be:
-    /// - Full name with version: `std/text-completion@0.1.0`
-    /// - Without namespace (defaults to `std`): `text-completion@0.1.0`
-    /// - Without version (defaults to `latest`): `std/text-completion` or `text-completion`
+    /// - Full name with version: `text-completion@0.1.0`
+    /// - Without version (defaults to `latest`): `text-completion`
     pub async fn launch_instance_from_registry(
         &self,
         inferlet: String,

--- a/pie/src/pie/manager.py
+++ b/pie/src/pie/manager.py
@@ -1308,7 +1308,7 @@ def submit_inferlet_from_registry_and_wait(
 
     Args:
         client_config: Client configuration with host, port, internal_auth_token
-        inferlet_name: Inferlet name (e.g., "std/text-completion@0.1.0")
+        inferlet_name: Inferlet name (e.g., "text-completion@0.1.0")
         arguments: Arguments to pass to the inferlet
         server_handle: Optional server handle for process monitoring
         backend_processes: Optional list of backend processes to monitor

--- a/pie/src/pie_cli/http.py
+++ b/pie/src/pie_cli/http.py
@@ -19,7 +19,7 @@ console = Console()
 
 def http(
     inferlet: Optional[str] = typer.Argument(
-        None, help="Inferlet name from registry (e.g., 'std/http-server@0.1.0')"
+        None, help="Inferlet name from registry (e.g., 'http-server@0.1.0')"
     ),
     path: Optional[Path] = typer.Option(
         None, "--path", "-p", help="Path to a local .wasm server inferlet file"
@@ -48,7 +48,7 @@ def http(
 
     \b
     - By path: pie http --path ./server.wasm --port 8080
-    - By registry: pie http std/http-server@0.1.0 --port 8080
+    - By registry: pie http http-server@0.1.0 --port 8080
 
     The server will run until interrupted with Ctrl+C.
     """

--- a/pie/src/pie_cli/run.py
+++ b/pie/src/pie_cli/run.py
@@ -19,7 +19,7 @@ console = Console()
 
 def run(
     inferlet: Optional[str] = typer.Argument(
-        None, help="Inferlet name from registry (e.g., 'std/text-completion@0.1.0')"
+        None, help="Inferlet name from registry (e.g., 'text-completion@0.1.0')"
     ),
     path: Optional[Path] = typer.Option(
         None, "--path", "-p", help="Path to a local .wasm inferlet file"
@@ -46,7 +46,7 @@ def run(
 
     You can specify an inferlet either by registry name or by path (mutually exclusive):
 
-    - By registry: pie run std/text-completion@0.1.0
+    - By registry: pie run text-completion@0.1.0
     - By path: pie run --path ./my_inferlet.wasm
     """
     # Validate at least one of inferlet or path is provided


### PR DESCRIPTION
Remove the inferlet namespace from the server side and the client library for the changes proposed in https://github.com/pie-project/pie/discussions/98#discussioncomment-15668385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified inferlet naming convention; inferlets now referenced as "name@version" instead of "namespace/name@version" across all client libraries and CLI tools.

* **Documentation**
  * Updated help text, examples, and usage documentation throughout to reflect the simplified inferlet naming format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->