### PR TITLE
fix(worker): remove <|im_start|> from Qwen3 stop tokens

### DIFF
--- a/pie/src/pie_worker/model/chat_templates.py
+++ b/pie/src/pie_worker/model/chat_templates.py
@@ -295,7 +295,7 @@ _QWEN_3_TEMPLATE_CONTENT = """
 Qwen3Template = ChatTemplate(
     template_type="minijinja",
     template=_QWEN_3_TEMPLATE_CONTENT,
-    stop_tokens=["<|im_end|>", "<|im_start|>", "<|endoftext|>"],
+    stop_tokens=["<|im_end|>", "<|endoftext|>"],
 )
 
 # Gemma 2 chat template


### PR DESCRIPTION
## Summary

- Remove `<|im_start|>` from `Qwen3Template.stop_tokens` in `chat_templates.py`
- `<|im_start|>` is a message boundary marker, not a generation stop signal
- This caused beam search to return empty responses when a beam produced `<|im_start|>` as its first token, immediately triggering the stop condition

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Qwen3 model text generation stopping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->