### PR TITLE
docs(readme): add beam search example to quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Run a test prompt (you will be prompted for configuration and model download if 
 
 ```bash
 pie run text-completion -- --prompt "Hello world!"
+pie run beam-search -- --prompt "What is the capital of France?" --beam-size 2
 ```
 
 > **Note:** The first run may take longer due to JIT compilation.


### PR DESCRIPTION
Minor fix based on Lin's request: add a one-line beam search example alongside the existing text-completion example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a beam-search example to the Quick Start section demonstrating how to invoke beam-search with custom prompts and beam size parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->