### PR TITLE
feat: support untied embeddings for Qwen3 models (8B+)

### DIFF
--- a/pie/src/pie_worker/loader.py
+++ b/pie/src/pie_worker/loader.py
@@ -620,7 +620,7 @@ class ModelLoader:
                 from .model import qwen3
 
                 model_config = qwen3.ModelConfig.from_dict(hf_config)
-                schema = qwen3.QWEN3_SCHEMA
+                schema = qwen3.create_schema(model_config)
                 num_layers = model_config.num_layers
 
             case "gptoss":


### PR DESCRIPTION
## Summary

  Qwen3 models larger than 1.7B use `tie_word_embeddings=false`, meaning `embed_tokens` and `lm_head` are separate weight tensors. The existing Qwen3 handler unconditionally used `embed_token` for the output projection, producing garbage output on 8B+ models.

  This PR adds untied embedding support to Qwen3, following the exact same pattern already used by **Qwen2** (`qwen2.py:104-115, 140, 161, 481-503`), as well as Llama3, Gemma2, and Gemma3:

  1. **`create_schema(config)`** — replaces the static `QWEN3_SCHEMA` with a function that conditionally adds a `lm_head` weight mapping when `tie_word_embeddings=false`
  2. **`tie_word_embeddings: bool` in `ModelConfig`** — parsed from HuggingFace config (defaults to `true` for backward compatibility)
  3. **Conditional weight selection in `lm_head()`** — uses `embed_token` when tied, `lm_head` when untied (both single-GPU and multi-GPU paths)
  4. **`loader.py` dispatch** — calls `qwen3.create_schema(model_config)` instead of referencing the bare `qwen3.QWEN3_SCHEMA`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Qwen3 models with configurable embedding schemes
  * Implemented dynamic schema generation for flexible model configuration handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->