### PR TITLE
fix: improve SDK example robustness and error logging

### DIFF
--- a/sdk/examples/constrained-decoding/src/lib.rs
+++ b/sdk/examples/constrained-decoding/src/lib.rs
@@ -83,12 +83,13 @@ async fn main(mut args: Args) -> Result<()> {
     // This is because we need to add some special prompts for these models to output the JSON
     // directly. See the `ctx.fill` calls below for more details.
     let model_name = model.get_name();
-    if !(model_name.starts_with("llama-3")
-        || model_name.starts_with("qwen-3")
-        || model_name.starts_with("deepseek-r1-distill-qwen-2"))
+    let name_lower = model_name.to_lowercase();
+    if !(name_lower.starts_with("llama-3")
+        || name_lower.starts_with("qwen")
+        || name_lower.starts_with("deepseek-r1-distill-qwen"))
     {
         return Err(anyhow!(
-            "Constrained decoding example is only implemented for Llama 3 and Qwen 3. Got: {}",
+            "Constrained decoding example is only implemented for Llama 3, Qwen, and DeepSeek. Got: {}",
             model_name
         ));
     }
@@ -97,7 +98,7 @@ async fn main(mut args: Args) -> Result<()> {
     // For example, Qwen 3 and DeepSeek R1 Distill Qwen 2 models will output "Ġ" for space, while
     // Llama 3 models will output " " for space.
     let escape_non_printable =
-        model_name.starts_with("qwen-3") || model_name.starts_with("deepseek-r1-distill-qwen-2");
+        name_lower.starts_with("qwen") || name_lower.starts_with("deepseek-r1-distill-qwen");
 
     // Find the EOS token ID for the model. This is used as a fallback when the grammar constraint
     // is not met. We need to find a single EOS token ID because the sampler outputs a single token
@@ -134,15 +135,15 @@ async fn main(mut args: Args) -> Result<()> {
 
     // Llama 3 models strongly prefer to output two newlines first. We put the newlines here
     // so that the model can output the JSON directly.
-    if model_name.starts_with("llama-3") {
+    if name_lower.starts_with("llama-3") {
         ctx.fill("\n\n");
     // Qwen 3 models are thinking models. We put the <think> and </think> tags here so that
     // the model can output the JSON directly.
-    } else if model_name.starts_with("qwen-3") {
+    } else if name_lower.starts_with("qwen") {
         ctx.fill("\n\n<think></think>\n\n");
     // DeepSeek R1 Distill Qwen 2 models are thinking models. We put the </think> tag here so that
     // the model can output the JSON directly.
-    } else if model_name.starts_with("deepseek-r1-distill-qwen-2") {
+    } else if name_lower.starts_with("deepseek-r1-distill-qwen") {
         ctx.fill("\n</think>\n\n");
     }
 

--- a/sdk/examples/output-validation/src/lib.rs
+++ b/sdk/examples/output-validation/src/lib.rs
@@ -3,7 +3,7 @@
 //! This example shows how to evaluate the likelihood of different candidate outputs
 //! given a context.
 
-use inferlet::{Args, Context, Result, anyhow};
+use inferlet::{Args, Context, Result};
 use std::time::Instant;
 
 const HELP: &str = "\
@@ -101,26 +101,13 @@ async fn main(mut args: Args) -> Result<()> {
     let model = inferlet::get_auto_model();
     let mut ctx = model.create_context();
 
-    if !model.get_name().starts_with("llama-3") {
-        return Err(anyhow!(
-            "Output validation example is only implemented for Llama 3 models. Got: {}",
-            model.get_name()
-        ));
-    }
-
-    // 1. Set up the initial context (the "prompt")
+    // 1. Set up the initial context using model-agnostic chat formatting
     let prompt = "The name of the person in the report is ";
-    ctx.fill("<|begin_of_text|>");
-    ctx.fill(
-        "<|start_header_id|>system<|end_header_id|>\n\n\
-        You are an expert at information extraction.<|eot_id|>",
+    ctx.fill_system("You are an expert at information extraction.");
+    ctx.fill_user(
+        "From the sentence \"The financial report was prepared by David Chen.\", \
+        extract the person's name.",
     );
-    ctx.fill(&format!(
-        "<|start_header_id|>user<|end_header_id|>\n\n\
-        From the sentence \"The financial report was prepared by David Chen.\", \
-        extract the person's name.<|eot_id|>"
-    ));
-    ctx.fill("<|start_header_id|>assistant<|end_header_id|>\n\n");
     ctx.fill(prompt);
     ctx.flush().await;
 

--- a/sdk/examples/recursion-of-thought/src/lib.rs
+++ b/sdk/examples/recursion-of-thought/src/lib.rs
@@ -61,11 +61,17 @@ fn parse_response(response: &str) -> Result<(Option<String>, Option<(String, Str
         }
     }
 
-    let branches: Vec<String> = response
-        .match_indices("<branch>")
-        .zip(response.match_indices("</branch>"))
-        .map(|((start, _), (end, _))| response[start + 8..end].trim().to_string())
-        .collect();
+    let mut branches: Vec<String> = Vec::new();
+    let mut search_from = 0;
+    while let Some(start) = response[search_from..].find("<branch>") {
+        let abs_start = search_from + start + 8; // past "<branch>"
+        if let Some(end) = response[abs_start..].find("</branch>") {
+            branches.push(response[abs_start..abs_start + end].trim().to_string());
+            search_from = abs_start + end + 9; // past "</branch>"
+        } else {
+            break; // unclosed tag — truncated output
+        }
+    }
 
     if branches.len() == 2 {
         Ok((None, Some((branches[0].clone(), branches[1].clone()))))

--- a/sdk/examples/skeleton-of-thought/src/lib.rs
+++ b/sdk/examples/skeleton-of-thought/src/lib.rs
@@ -47,13 +47,46 @@ async fn plan_and_generate_parallel(
         .await;
 
     // 2. Robustly parse points from the output.
-    let points: Vec<String> = output
+    let mut points: Vec<String> = output
         .split("<point>")
         .skip(1)
         .filter_map(|s| s.split("</point>").next())
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
         .collect();
+
+    // Fallback: try numbered lists (1. ..., 2. ...) or bullet points (- ..., * ...)
+    if points.is_empty() {
+        points = output
+            .lines()
+            .filter_map(|line| {
+                let trimmed = line.trim();
+                // Match "- text" or "* text"
+                if let Some(rest) =
+                    trimmed.strip_prefix("- ").or_else(|| trimmed.strip_prefix("* "))
+                {
+                    Some(rest.trim().to_string())
+                } else if trimmed.len() > 2 && trimmed.as_bytes()[0].is_ascii_digit() {
+                    // Match "1. text" or "1) text"
+                    let after_digit =
+                        trimmed.trim_start_matches(|c: char| c.is_ascii_digit());
+                    if let Some(rest) =
+                        after_digit.strip_prefix(". ").or_else(|| after_digit.strip_prefix(") "))
+                    {
+                        Some(rest.trim().to_string())
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            })
+            .filter(|s| !s.is_empty())
+            .collect();
+    }
+
+    // Limit to requested number of points
+    points.truncate(max_points);
 
     if points.is_empty() {
         return Vec::new();

--- a/sdk/python/src/inferlet/chat.py
+++ b/sdk/python/src/inferlet/chat.py
@@ -5,6 +5,7 @@ Mirrors the Rust ChatFormatter from inferlet/src/chat.rs
 
 from __future__ import annotations
 
+import sys
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -62,7 +63,8 @@ class ChatFormatter:
             env.globals["raise_exception"] = self._raise_exception
             try:
                 self._template = env.from_string(self._template_str)
-            except Exception:
+            except Exception as e:
+                print(f"[ChatFormatter] Jinja2 template parse failed: {e}", file=sys.stderr)
                 self._template = None
 
     @staticmethod
@@ -170,7 +172,8 @@ class ChatFormatter:
                 env = Environment(loader=BaseLoader())
                 env.globals["raise_exception"] = self._raise_exception
                 active_template = env.from_string(template)
-            except Exception:
+            except Exception as e:
+                print(f"[ChatFormatter] Jinja2 override template parse failed: {e}", file=sys.stderr)
                 active_template = None
 
         # Convert messages to dict format for template
@@ -185,8 +188,8 @@ class ChatFormatter:
                     bos_token="",
                     eos_token="",
                 )
-            except Exception:
-                pass
+            except Exception as e:
+                print(f"[ChatFormatter] Jinja2 render failed, using fallback: {e}", file=sys.stderr)
 
         # Fallback formatting
         return self._format_fallback(messages_dict, add_generation_prompt)
@@ -340,8 +343,8 @@ class ChatFormatter:
                     bos_token="",
                     eos_token="",
                 )
-            except Exception:
-                pass
+            except Exception as e:
+                print(f"[ChatFormatter] Jinja2 render failed, using fallback: {e}", file=sys.stderr)
 
         # Fallback formatting
         return self._format_fallback(messages, add_generation_prompt)


### PR DESCRIPTION
- constrained-decoding: case-insensitive model matching, broaden model prefix support (qwen, deepseek-r1-distill-qwen)
- output-validation: remove Llama-3-only gate, use model-agnostic fill_system/fill_user instead of hardcoded chat tokens
- recursion-of-thought: fix XML branch parser to handle unclosed tags from truncated output
- skeleton-of-thought: add fallback parsing for numbered/bullet lists, add points.truncate safety limit
- Python SDK chat.py: log Jinja2 template errors to stderr instead of silently swallowing them