### PR TITLE
fix: Parse dependencies from manifest correctly

### DIFF
--- a/runtime/src/server.rs
+++ b/runtime/src/server.rs
@@ -1734,17 +1734,21 @@ fn manifest_program_name(table: &toml::Table) -> Result<ProgramName> {
 
 /// Extracts the dependencies from a parsed manifest.
 ///
-/// The optional "dependencies" field in the [package] section is an array of strings
-/// in the format "name@version". Returns an empty vector if no dependencies are specified.
+/// The optional [dependencies] section is a table of key-value pairs where each key is
+/// the dependency name and the value is its version string. Returns an empty vector if
+/// no dependencies are specified.
 fn get_manifest_dependencies(table: &toml::Table) -> Vec<ProgramName> {
     table
-        .get("package")
-        .and_then(|p| p.as_table())
-        .and_then(|p| p.get("dependencies"))
-        .and_then(|d| d.as_array())
-        .map(|arr| {
-            arr.iter()
-                .filter_map(|v| v.as_str().map(ProgramName::parse))
+        .get("dependencies")
+        .and_then(|d| d.as_table())
+        .map(|deps| {
+            deps.iter()
+                .filter_map(|(name, version)| {
+                    version.as_str().map(|v| ProgramName {
+                        name: name.clone(),
+                        version: v.to_string(),
+                    })
+                })
                 .collect()
         })
         .unwrap_or_default()


### PR DESCRIPTION
Following the update to the manifest format in
https://github.com/pie-project/pie/discussions/98#discussioncomment-15668385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated manifest dependency parsing format. Dependencies are now defined in a `[dependencies]` table with name-version pairs, replacing the previous string array format under `[package]`. No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->