### PR TITLE
feat: Add `pie-client install` command

### DIFF
--- a/client/python/src/pie_client_cli/install.py
+++ b/client/python/src/pie_client_cli/install.py
@@ -1,0 +1,64 @@
+"""Install command implementation for the Pie CLI.
+
+This module implements the `pie-cli install` subcommand for installing inferlets
+to an existing running Pie engine instance without launching them.
+"""
+
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from . import engine
+from .submit import parse_manifest
+
+
+def handle_install_command(
+    path: Path,
+    manifest: Path,
+    config: Optional[Path] = None,
+    host: Optional[str] = None,
+    port: Optional[int] = None,
+    username: Optional[str] = None,
+    private_key_path: Optional[Path] = None,
+    force: bool = False,
+) -> None:
+    """Handle the `pie-cli install` command.
+
+    Installs an inferlet to the Pie engine without launching it.
+
+    Steps:
+    1. Creates a client configuration from config file and command-line arguments
+    2. Connects to the Pie engine server
+    3. Uploads the inferlet if not already on server (or --force is used)
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"Inferlet file not found: {path}")
+
+    if not manifest.exists():
+        raise FileNotFoundError(f"Manifest file not found: {manifest}")
+
+    manifest_content = manifest.read_text()
+    name, version = parse_manifest(manifest_content)
+    inferlet_name = f"{name}@{version}"
+
+    typer.echo(f"Inferlet: {inferlet_name}")
+
+    client_config = engine.ClientConfig.create(
+        config_path=config,
+        host=host,
+        port=port,
+        username=username,
+        private_key_path=private_key_path,
+    )
+
+    client = engine.connect_and_authenticate(client_config)
+
+    try:
+        if force or not engine.program_exists(client, inferlet_name, path, manifest):
+            engine.install_program(client, path, manifest)
+            typer.echo("✅ Inferlet installed successfully.")
+        else:
+            typer.echo("Inferlet already exists on server.")
+    finally:
+        engine.close_client(client)

--- a/client/python/src/pie_client_cli/main.py
+++ b/client/python/src/pie_client_cli/main.py
@@ -11,6 +11,7 @@ import typer
 from . import abort as abort_cmd
 from . import attach as attach_cmd
 from . import config as config_cmd
+from . import install as install_cmd
 from . import list as list_cmd
 from . import ping as ping_cmd
 from . import submit as submit_cmd
@@ -133,6 +134,57 @@ def submit(
             detached=detached,
             link=[expand_path(p) for p in link] if link else None,
             arguments=arguments,
+        )
+    except Exception as e:
+        typer.echo(f"Error: {e}", err=True)
+        raise typer.Exit(1)
+
+
+# ============================================================================
+# Install command
+# ============================================================================
+
+
+@app.command()
+def install(
+    path: Annotated[
+        Path,
+        typer.Option("--path", "-p", help="Path to a local .wasm inferlet file"),
+    ],
+    manifest: Annotated[
+        Path,
+        typer.Option(
+            "--manifest",
+            "-m",
+            help="Path to the manifest TOML file",
+        ),
+    ],
+    config: ConfigOption = None,
+    host: HostOption = None,
+    port: PortOption = None,
+    username: UsernameOption = None,
+    private_key_path: PrivateKeyPathOption = None,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "-f", "--force", help="Force reinstall even if already installed."
+        ),
+    ] = False,
+) -> None:
+    """Install an inferlet to a running Pie engine without launching it.
+
+    Example: pie-client install --path ./my_inferlet.wasm --manifest ./Pie.toml
+    """
+    try:
+        install_cmd.handle_install_command(
+            path=expand_path(path),
+            manifest=expand_path(manifest),
+            config=expand_path(config),
+            host=host,
+            port=port,
+            username=username,
+            private_key_path=expand_path(private_key_path),
+            force=force,
         )
     except Exception as e:
         typer.echo(f"Error: {e}", err=True)


### PR DESCRIPTION
This command allows you to install an inferlet to a running Pie engine without launching it, which is useful for uploading library inferlets to the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `install` command to Pie CLI for installing inferlets from manifest files with authentication support (host, port, username, private key)
  * Includes manifest validation and server existence checks
  * Added `--force` flag to override existing inferlets on server

<!-- end of auto-generated comment: release notes by coderabbit.ai -->