### PR TITLE
fix: buffer HTTP request body before WASM handler dispatch

### DIFF
--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -47,6 +47,7 @@ futures = "0.3.31"
 rmp-serde = "1.3.0"
 
 hyper = "1.6.0"
+http-body-util = "0.1"
 blake3 = "1.8.2"
 tokio-tungstenite = "0.28.0"
 tungstenite = "0.28.0"

--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -1015,6 +1015,21 @@ impl Runtime {
         py_runtime_dir: Option<PathBuf>,
         req: hyper::Request<hyper::body::Incoming>,
     ) -> anyhow::Result<hyper::Response<HyperOutgoingBody>> {
+        // Collect the full request body before passing to the WASM handler.
+        // hyper's Incoming body uses a zero-capacity channel that requires
+        // sender and receiver to poll in the same task. Since the WASM handler
+        // runs in a spawned task, we must buffer the body here to avoid a
+        // cross-task deadlock for requests larger than ~16KB.
+        let (parts, body) = req.into_parts();
+        let collected = http_body_util::BodyExt::collect(body)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to read request body: {e}"))?;
+        let buffered_body = http_body_util::BodyExt::map_err(
+            http_body_util::Full::new(collected.to_bytes()),
+            |never: std::convert::Infallible| -> hyper::Error { match never {} },
+        );
+        let req = hyper::Request::from_parts(parts, buffered_body);
+
         let inst_id = Uuid::new_v4();
         let (inst_state, _output_delivery_ctrl) =
             InstanceState::new(inst_id, username, arguments, py_runtime_dir.as_deref()).await;


### PR DESCRIPTION
## Summary

- Buffer the full HTTP request body before spawning the WASM handler task
- Fixes deadlock for HTTP server inferlets receiving requests >16KB
- Adds `http-body-util` as a direct dependency (already transitive via wasmtime-wasi-http)

## Problem

hyper's `Incoming` body uses a zero-capacity MPSC channel. The WASM handler runs in a `tokio::task::spawn`, creating a cross-task body delivery that deadlocks when the request body spans multiple TCP segments (~16KB on loopback).

**Symptoms:** HTTP server inferlets crash with `RemoteDisconnected` for POST requests with body >16KB (e.g. OpenAI chat completions with large system prompts).

## Fix

Collect the full body via `http_body_util::BodyExt::collect()` before spawning the handler task, then pass a `Full<Bytes>` body which requires no cross-task coordination.

## Test plan

- Verified with OpenAI-compat inferlet: 28KB request body (27K char system prompt) succeeds
- Previously: requests >18KB crashed immediately
- No regression for small requests (<16KB)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced runtime request body handling to buffer incoming HTTP requests for improved data reception and reliability.

* **Chores**
  * Added http-body-util dependency to runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->