### PR TITLE
fix: batch response misalignment when flush and decode are batched

### DIFF
--- a/runtime/src/api/core/forward.rs
+++ b/runtime/src/api/core/forward.rs
@@ -386,28 +386,29 @@ impl inferlet::core::forward::HostForwardPass for InstanceState {
             (request, svc_id, queue_id, priority)
         };
 
-        if returns_output {
-            let (tx, rx) = oneshot::channel();
+        // Always create a response channel so every request participates in
+        // the batch response protocol.  Without this, flush (no output) and
+        // decode (with output) in the same batch cause response misalignment:
+        // Python returns N responses for N requests, but the old code only
+        // advanced the response iterator for requests with a sender, shifting
+        // all subsequent responses by one.
+        //
+        // For flush requests (returns_output=false), the SDK still gets a
+        // pollable ForwardPassResult.  The inferlet awaits it, which ensures
+        // the batch's GPU forward pass completes before fork() proceeds —
+        // preventing KV write races with forked contexts.
+        let (tx, rx) = oneshot::channel();
+        let req = Request::ForwardPass(request, Some(tx));
+        submit_request(svc_id, queue_id, priority, req)?;
 
-            let req = Request::ForwardPass(request, Some(tx));
+        let res = ForwardPassResult {
+            receiver: rx,
+            distributions: vec![],
+            tokens: vec![],
+            done: false,
+        };
 
-            submit_request(svc_id, queue_id, priority, req)?;
-
-            let res = ForwardPassResult {
-                receiver: rx,
-                distributions: vec![],
-                tokens: vec![],
-                done: false,
-            };
-
-            Ok(Some(self.ctx().table.push(res)?))
-        } else {
-            let req = Request::ForwardPass(request, None);
-
-            submit_request(svc_id, queue_id, priority, req)?;
-
-            Ok(None)
-        }
+        Ok(Some(self.ctx().table.push(res)?))
     }
     async fn drop(&mut self, this: Resource<ForwardPass>) -> Result<()> {
         self.ctx().table.delete(this)?;

--- a/runtime/src/model.rs
+++ b/runtime/src/model.rs
@@ -680,9 +680,16 @@ impl Model {
             Ok(batch_resp) => {
                 let mut resp_iter = batch_resp.results.into_iter();
                 for (_, resp_tx) in requests {
+                    // Always advance the iterator to stay aligned with the
+                    // Python-side response array, which contains one entry per
+                    // request regardless of whether the request expects output.
+                    // Flush requests (resp_tx = None) still produce a response
+                    // in the batch; skipping them here would shift all
+                    // subsequent responses by one.
+                    let resp = resp_iter.next();
                     if let Some(tx) = resp_tx {
-                        if let Some(resp) = resp_iter.next() {
-                            tx.send(resp).ok();
+                        if let Some(r) = resp {
+                            tx.send(r).ok();
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- Fixes inferlet panic (`context.rs:558`) on 2nd run of fork-based examples (e.g. `parallel-generation`)
- Root cause: when `flush()` and `decode_step()` land in the same batch, response iterator misalignment causes decode to receive flush's empty response

## Root Cause

`execute_forward_pass_batch` only advanced the response iterator for requests with `resp_tx = Some`, skipping flush requests (`resp_tx = None`). Python returns N responses for N requests regardless, so skipping the flush response shifted all subsequent responses by one.

**Why 2nd run only**: 1st run compiles WASM (slow) → flush fires alone. 2nd run uses cached WASM → flush and first decode_step batch together.

**Why native engine only**: vLLM uses `PieVllmRuntime.fire_batch` with its own response packaging — never hits this code path.

## Changes

1. **`runtime/src/model.rs`**: Always advance response iterator regardless of `resp_tx`, keeping Rust aligned with Python's response array
2. **`runtime/src/api/core/forward.rs`**: Always create a response channel for every forward pass (including flush), making flush synchronous — ensures batch completes before `fork()` proceeds, preventing both the misalignment and a latent KV write race

## Reproduction

```bash
# Start native PIE engine, then:
pie-client submit parallel-generation  # run 1: passes
pie-client submit parallel-generation  # run 2: panics at context.rs:558
```

## Test plan

- [x] Reproduced panic on native engine (Qwen3-1.7B, ECL cuda:1)
- [x] Confirmed no-flush version (without `common.flush().await`) passes 5/5 on same engine
- [x] Confirmed vLLM backend passes 15/15 (not affected)
- [x] `cargo check` passes
- [x] Run `parallel-generation` example 10x on native engine with fix applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected batch response handling to ensure all requests are processed with consistent synchronization, preventing potential misalignment in response dispatch ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->