### PR TITLE
perf: add TLB for KV page virtual-to-physical translation

### DIFF
--- a/runtime/src/api/core/forward.rs
+++ b/runtime/src/api/core/forward.rs
@@ -104,18 +104,13 @@ impl inferlet::core::forward::Host for InstanceState {
     async fn kv_cache(
         &mut self,
         pass: Resource<ForwardPass>,
-        mut kv_page_ptrs: Vec<ResourceId>,
+        kv_page_ptrs: Vec<ResourceId>,
         kv_page_last_len: u32,
     ) -> Result<()> {
         let svc_id = self.ctx().table.get(&pass)?.queue.service_id;
-
-        kv_page_ptrs.iter_mut().try_for_each(|kv_page_ptr| {
-            *kv_page_ptr = self.translate_resource_ptr(svc_id, KV_PAGE_TYPE_ID, *kv_page_ptr)?;
-            Ok::<_, anyhow::Error>(())
-        })?;
-
+        let translated = self.translate_kv_pages_cached(svc_id, &kv_page_ptrs)?;
         let pass = self.ctx().table.get_mut(&pass)?;
-        pass.kv_page_ptrs = kv_page_ptrs;
+        pass.kv_page_ptrs = translated;
         pass.kv_page_last_len = kv_page_last_len;
         Ok(())
     }

--- a/runtime/src/instance.rs
+++ b/runtime/src/instance.rs
@@ -63,6 +63,9 @@ struct ResourceIdMapper {
     virtual_id_pool: utils::IdPool<u32>,
     /// The map from a virtual ID to its corresponding physical ID.
     virtual_to_physical: HashMap<ResourceId, ResourceId>,
+    /// Monotonically increasing counter, bumped on every map/unmap operation.
+    /// Used to invalidate translation caches when mappings change.
+    generation: u64,
 }
 
 impl Default for ResourceIdMapper {
@@ -70,6 +73,7 @@ impl Default for ResourceIdMapper {
         ResourceIdMapper {
             virtual_id_pool: utils::IdPool::new(u32::MAX),
             virtual_to_physical: HashMap::new(),
+            generation: 0,
         }
     }
 }
@@ -91,6 +95,7 @@ impl ResourceIdMapper {
             self.virtual_to_physical.insert(virtual_id, physical_id);
         }
 
+        self.generation += 1;
         virtual_ids
     }
 
@@ -100,6 +105,7 @@ impl ResourceIdMapper {
             self.virtual_to_physical.remove(&virtual_id);
         }
         self.virtual_id_pool.release_many(virtual_ids).unwrap();
+        self.generation += 1;
     }
 
     /// Translates a single virtual ID to its corresponding physical ID.
@@ -123,8 +129,9 @@ pub struct InstanceState {
     resources: HashMap<(usize, ResourceTypeId), ResourceIdMapper>,
 
     // Cache of translated KV page IDs to avoid redundant HashMap lookups per decode step.
-    // Keyed by service_id. Value is (virtual_ids, physical_ids) from last kv_cache() call.
-    kv_translation_cache: HashMap<usize, (Vec<ResourceId>, Vec<ResourceId>)>,
+    // Keyed by service_id. Value is (mapper_generation, virtual_ids, physical_ids).
+    // Cache is invalidated when mapper generation changes (any map/unmap operation).
+    kv_translation_cache: HashMap<usize, (u64, Vec<ResourceId>, Vec<ResourceId>)>,
 
     // Dynamic linking state: maps host rep -> guest's ResourceAny
     dynamic_resource_map: HashMap<u32, ResourceAny>,
@@ -346,19 +353,26 @@ impl InstanceState {
                 "Failed to find resource mapper for service_id: {:?}, resource_type: {:?}",
                 service_id, KV_PAGE_TYPE_ID
             ))?;
+        let current_gen = mapper.generation;
 
-        let (cached_virt, cached_phys) = self.kv_translation_cache
+        let (cached_gen, cached_virt, cached_phys) = self.kv_translation_cache
             .entry(service_id)
-            .or_insert_with(|| (Vec::new(), Vec::new()));
+            .or_insert_with(|| (0, Vec::new(), Vec::new()));
 
-        // Find how many leading pages match the cache
-        let prefix_len = cached_virt.len().min(kv_page_ptrs.len());
+        // If any mappings changed (map/unmap), invalidate the entire cache.
+        // This handles page replacement, masking, and virtual ID recycling.
+        let gen_valid = *cached_gen == current_gen;
+
+        // Find how many leading pages match the cache (0 if generation changed)
         let mut match_len = 0;
-        for i in 0..prefix_len {
-            if kv_page_ptrs[i] == cached_virt[i] {
-                match_len = i + 1;
-            } else {
-                break;
+        if gen_valid {
+            let prefix_len = cached_virt.len().min(kv_page_ptrs.len());
+            for i in 0..prefix_len {
+                if kv_page_ptrs[i] == cached_virt[i] {
+                    match_len = i + 1;
+                } else {
+                    break;
+                }
             }
         }
 
@@ -375,10 +389,12 @@ impl InstanceState {
         if crate::model::ffi_ipc::ipc_timing_enabled() {
             let total = kv_page_ptrs.len();
             let fresh = total - match_len;
-            eprintln!("[KV-CACHE] total={} cached={} fresh={}", total, match_len, fresh);
+            eprintln!("[KV-CACHE] total={} cached={} fresh={} gen_hit={}",
+                total, match_len, fresh, gen_valid);
         }
 
         // Update cache
+        *cached_gen = current_gen;
         cached_virt.clear();
         cached_virt.extend_from_slice(kv_page_ptrs);
         *cached_phys = translated.clone();

--- a/runtime/src/instance.rs
+++ b/runtime/src/instance.rs
@@ -1,6 +1,6 @@
 use super::api::core::Queue;
 use super::utils;
-use crate::model::resource::{ResourceId, ResourceTypeId};
+use crate::model::resource::{KV_PAGE_TYPE_ID, ResourceId, ResourceTypeId};
 use crate::server::InstanceEvent;
 use anyhow::{Result, format_err};
 use bytes::Bytes;
@@ -122,6 +122,10 @@ pub struct InstanceState {
     // virtual resources
     resources: HashMap<(usize, ResourceTypeId), ResourceIdMapper>,
 
+    // Cache of translated KV page IDs to avoid redundant HashMap lookups per decode step.
+    // Keyed by service_id. Value is (virtual_ids, physical_ids) from last kv_cache() call.
+    kv_translation_cache: HashMap<usize, (Vec<ResourceId>, Vec<ResourceId>)>,
+
     // Dynamic linking state: maps host rep -> guest's ResourceAny
     dynamic_resource_map: HashMap<u32, ResourceAny>,
     // Reverse map: guest ResourceAny -> host rep (for identity preservation)
@@ -218,6 +222,7 @@ impl InstanceState {
             resource_table: ResourceTable::new(),
             http_ctx: WasiHttpCtx::new(),
             resources: HashMap::new(),
+            kv_translation_cache: HashMap::new(),
             dynamic_resource_map: HashMap::new(),
             guest_resource_map: Vec::new(),
             next_dynamic_rep: 1,
@@ -326,6 +331,59 @@ impl InstanceState {
             m.virtual_to_physical
         ))?;
         Ok(phys_id)
+    }
+
+    /// Translate KV page virtual IDs to physical IDs, caching translations across calls.
+    /// Only translates pages beyond the matching prefix from the previous call.
+    pub fn translate_kv_pages_cached(
+        &mut self,
+        service_id: usize,
+        kv_page_ptrs: &[ResourceId],
+    ) -> Result<Vec<ResourceId>> {
+        let mapper = self.resources
+            .get(&(service_id, KV_PAGE_TYPE_ID))
+            .ok_or_else(|| format_err!(
+                "Failed to find resource mapper for service_id: {:?}, resource_type: {:?}",
+                service_id, KV_PAGE_TYPE_ID
+            ))?;
+
+        let (cached_virt, cached_phys) = self.kv_translation_cache
+            .entry(service_id)
+            .or_insert_with(|| (Vec::new(), Vec::new()));
+
+        // Find how many leading pages match the cache
+        let prefix_len = cached_virt.len().min(kv_page_ptrs.len());
+        let mut match_len = 0;
+        for i in 0..prefix_len {
+            if kv_page_ptrs[i] == cached_virt[i] {
+                match_len = i + 1;
+            } else {
+                break;
+            }
+        }
+
+        // Build translated list: cached prefix + fresh translations for new tail
+        let mut translated = Vec::with_capacity(kv_page_ptrs.len());
+        translated.extend_from_slice(&cached_phys[..match_len]);
+        for &virt_id in &kv_page_ptrs[match_len..] {
+            translated.push(mapper.translate(virt_id).ok_or_else(|| {
+                format_err!("Failed to translate KV page ptr: {}", virt_id)
+            })?);
+        }
+
+        #[cfg(feature = "ipc-profiling")]
+        if crate::model::ffi_ipc::ipc_timing_enabled() {
+            let total = kv_page_ptrs.len();
+            let fresh = total - match_len;
+            eprintln!("[KV-CACHE] total={} cached={} fresh={}", total, match_len, fresh);
+        }
+
+        // Update cache
+        cached_virt.clear();
+        cached_virt.extend_from_slice(kv_page_ptrs);
+        *cached_phys = translated.clone();
+
+        Ok(translated)
     }
 }
 


### PR DESCRIPTION
## Summary

Every decode step, `kv_cache()` translates all KV page virtual IDs to physical IDs via per-page `HashMap::get()` lookups. With long cached prefixes (400–900 pages), this takes **8.2ms per step** — the dominant source of Pie's decode overhead vs standalone vLLM.

This PR adds a **translation lookaside buffer (TLB)** that caches the virtual→physical page translations across decode steps. Since KV pages are append-only during generation (new pages added at the tail, never replaced in-place), the cached translations remain valid and only new tail entries need fresh lookups.

### Safety: generation counter

To handle page replacement/masking (which IS possible in Pie), `ResourceIdMapper` now tracks a monotonic generation counter that increments on every `map_resources()` or `unmap_resources()` call. The TLB checks this generation before reusing cached translations — if any mapping changed, the entire cache is invalidated for that step and repopulated.

## Changes

- **`runtime/src/instance.rs`**: Add `generation` field to `ResourceIdMapper`, bump on map/unmap. Add `kv_translation_cache` field to `InstanceState`. Add `translate_kv_pages_cached()` method with prefix-matching + generation check.
- **`runtime/src/api/core/forward.rs`**: Replace per-page `translate_resource_ptr()` loop in `kv_cache()` with single `translate_kv_pages_cached()` call.

## Results

**40-request OpenClaw benchmark (same pod, same fixtures):**
36.9 ms -> 28.4ms

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized KV page translation handling with improved efficiency and intelligent caching mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->