### PR TITLE
perf: add TLB for KV page virtual-to-physical translation

### DIFF
--- a/runtime/src/api/core/forward.rs
+++ b/runtime/src/api/core/forward.rs
@@ -104,18 +104,13 @@ impl inferlet::core::forward::Host for InstanceState {
     async fn kv_cache(
         &mut self,
         pass: Resource<ForwardPass>,
-        mut kv_page_ptrs: Vec<ResourceId>,
+        kv_page_ptrs: Vec<ResourceId>,
         kv_page_last_len: u32,
     ) -> Result<()> {
         let svc_id = self.ctx().table.get(&pass)?.queue.service_id;
-
-        kv_page_ptrs.iter_mut().try_for_each(|kv_page_ptr| {
-            *kv_page_ptr = self.translate_resource_ptr(svc_id, KV_PAGE_TYPE_ID, *kv_page_ptr)?;
-            Ok::<_, anyhow::Error>(())
-        })?;
-
+        let translated = self.translate_kv_pages_cached(svc_id, &kv_page_ptrs)?;
         let pass = self.ctx().table.get_mut(&pass)?;
-        pass.kv_page_ptrs = kv_page_ptrs;
+        pass.kv_page_ptrs = translated;
         pass.kv_page_last_len = kv_page_last_len;
         Ok(())
     }

--- a/runtime/src/instance.rs
+++ b/runtime/src/instance.rs
@@ -5,7 +5,7 @@ use crate::server::InstanceEvent;
 use anyhow::{Result, format_err};
 use bytes::Bytes;
 use ringbuffer::{AllocRingBuffer, RingBuffer};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io;
 use std::path::Path;
 use std::pin::Pin;
@@ -63,9 +63,11 @@ struct ResourceIdMapper {
     virtual_id_pool: utils::IdPool<u32>,
     /// The map from a virtual ID to its corresponding physical ID.
     virtual_to_physical: HashMap<ResourceId, ResourceId>,
-    /// Monotonically increasing counter, bumped on every map/unmap operation.
-    /// Used to invalidate translation caches when mappings change.
-    generation: u64,
+    /// Virtual IDs that were unmapped and may be recycled with different
+    /// physical mappings. Only `unmap_resources` populates this set;
+    /// `map_resources` does not (new allocations cannot collide with
+    /// existing cached translations). Consumed by the TLB on next lookup.
+    invalidated_ids: HashSet<ResourceId>,
 }
 
 impl Default for ResourceIdMapper {
@@ -73,7 +75,7 @@ impl Default for ResourceIdMapper {
         ResourceIdMapper {
             virtual_id_pool: utils::IdPool::new(u32::MAX),
             virtual_to_physical: HashMap::new(),
-            generation: 0,
+            invalidated_ids: HashSet::new(),
         }
     }
 }
@@ -95,7 +97,6 @@ impl ResourceIdMapper {
             self.virtual_to_physical.insert(virtual_id, physical_id);
         }
 
-        self.generation += 1;
         virtual_ids
     }
 
@@ -105,7 +106,7 @@ impl ResourceIdMapper {
             self.virtual_to_physical.remove(&virtual_id);
         }
         self.virtual_id_pool.release_many(virtual_ids).unwrap();
-        self.generation += 1;
+        self.invalidated_ids.extend(virtual_ids);
     }
 
     /// Translates a single virtual ID to its corresponding physical ID.
@@ -128,10 +129,9 @@ pub struct InstanceState {
     // virtual resources
     resources: HashMap<(usize, ResourceTypeId), ResourceIdMapper>,
 
-    // Cache of translated KV page IDs to avoid redundant HashMap lookups per decode step.
-    // Keyed by service_id. Value is (mapper_generation, virtual_ids, physical_ids).
-    // Cache is invalidated when mapper generation changes (any map/unmap operation).
-    kv_translation_cache: HashMap<usize, (u64, Vec<ResourceId>, Vec<ResourceId>)>,
+    // TLB: caches virtual→physical KV page translations across decode steps.
+    // Keyed by service_id. Per-page invalidation via ResourceIdMapper.invalidated_ids.
+    kv_translation_cache: HashMap<usize, (Vec<ResourceId>, Vec<ResourceId>)>,
 
     // Dynamic linking state: maps host rep -> guest's ResourceAny
     dynamic_resource_map: HashMap<u32, ResourceAny>,
@@ -340,32 +340,46 @@ impl InstanceState {
         Ok(phys_id)
     }
 
-    /// Translate KV page virtual IDs to physical IDs, caching translations across calls.
-    /// Only translates pages beyond the matching prefix from the previous call.
+    /// TLB for KV page virtual→physical translation.
+    ///
+    /// Caches translations across decode steps. Per-page invalidation:
+    /// only pages unmapped via `unmap_resources` (which may be recycled
+    /// with different physical mappings) trigger re-translation. New
+    /// allocations via `map_resources` are safe and don't invalidate.
     pub fn translate_kv_pages_cached(
         &mut self,
         service_id: usize,
         kv_page_ptrs: &[ResourceId],
     ) -> Result<Vec<ResourceId>> {
-        let mapper = self.resources
-            .get(&(service_id, KV_PAGE_TYPE_ID))
-            .ok_or_else(|| format_err!(
-                "Failed to find resource mapper for service_id: {:?}, resource_type: {:?}",
-                service_id, KV_PAGE_TYPE_ID
-            ))?;
-        let current_gen = mapper.generation;
+        // Check for per-page invalidations (from unmap_resources).
+        // Drain the set unconditionally to prevent unbounded growth.
+        let needs_full_retranslate = {
+            let mapper = self.resources
+                .get_mut(&(service_id, KV_PAGE_TYPE_ID))
+                .ok_or_else(|| format_err!(
+                    "Failed to find resource mapper for service_id: {:?}, resource_type: {:?}",
+                    service_id, KV_PAGE_TYPE_ID
+                ))?;
+            if mapper.invalidated_ids.is_empty() {
+                false
+            } else {
+                let (cached_virt, _) = self.kv_translation_cache
+                    .get(&service_id)
+                    .map(|(v, p)| (v.as_slice(), p.as_slice()))
+                    .unwrap_or((&[], &[]));
+                let hit = mapper.invalidated_ids.iter().any(|id| cached_virt.contains(id));
+                mapper.invalidated_ids.clear();
+                hit
+            }
+        };
 
-        let (cached_gen, cached_virt, cached_phys) = self.kv_translation_cache
+        let (cached_virt, cached_phys) = self.kv_translation_cache
             .entry(service_id)
-            .or_insert_with(|| (0, Vec::new(), Vec::new()));
+            .or_insert_with(|| (Vec::new(), Vec::new()));
 
-        // If any mappings changed (map/unmap), invalidate the entire cache.
-        // This handles page replacement, masking, and virtual ID recycling.
-        let gen_valid = *cached_gen == current_gen;
-
-        // Find how many leading pages match the cache (0 if generation changed)
+        // Prefix match: reuse cached translations for unchanged leading pages.
         let mut match_len = 0;
-        if gen_valid {
+        if !needs_full_retranslate {
             let prefix_len = cached_virt.len().min(kv_page_ptrs.len());
             for i in 0..prefix_len {
                 if kv_page_ptrs[i] == cached_virt[i] {
@@ -376,7 +390,12 @@ impl InstanceState {
             }
         }
 
-        // Build translated list: cached prefix + fresh translations for new tail
+        // Re-fetch mapper (immutable — split borrow released above)
+        let mapper = self.resources
+            .get(&(service_id, KV_PAGE_TYPE_ID))
+            .unwrap();
+
+        // Build translated list: cached prefix + fresh lookups for tail
         let mut translated = Vec::with_capacity(kv_page_ptrs.len());
         translated.extend_from_slice(&cached_phys[..match_len]);
         for &virt_id in &kv_page_ptrs[match_len..] {
@@ -389,12 +408,14 @@ impl InstanceState {
         if crate::model::ffi_ipc::ipc_timing_enabled() {
             let total = kv_page_ptrs.len();
             let fresh = total - match_len;
-            eprintln!("[KV-CACHE] total={} cached={} fresh={} gen_hit={}",
-                total, match_len, fresh, gen_valid);
+            eprintln!("[KV-CACHE] total={} cached={} fresh={} invalidated={}",
+                total, match_len, fresh, needs_full_retranslate);
         }
 
         // Update cache
-        *cached_gen = current_gen;
+        let (cached_virt, cached_phys) = self.kv_translation_cache
+            .get_mut(&service_id)
+            .unwrap();
         cached_virt.clear();
         cached_virt.extend_from_slice(kv_page_ptrs);
         *cached_phys = translated.clone();

--- a/runtime/src/instance.rs
+++ b/runtime/src/instance.rs
@@ -63,6 +63,9 @@ struct ResourceIdMapper {
     virtual_id_pool: utils::IdPool<u32>,
     /// The map from a virtual ID to its corresponding physical ID.
     virtual_to_physical: HashMap<ResourceId, ResourceId>,
+    /// Monotonically increasing counter, bumped on every map/unmap operation.
+    /// Used to invalidate translation caches when mappings change.
+    generation: u64,
 }
 
 impl Default for ResourceIdMapper {
@@ -70,6 +73,7 @@ impl Default for ResourceIdMapper {
         ResourceIdMapper {
             virtual_id_pool: utils::IdPool::new(u32::MAX),
             virtual_to_physical: HashMap::new(),
+            generation: 0,
         }
     }
 }
@@ -91,6 +95,7 @@ impl ResourceIdMapper {
             self.virtual_to_physical.insert(virtual_id, physical_id);
         }
 
+        self.generation += 1;
         virtual_ids
     }
 
@@ -100,6 +105,7 @@ impl ResourceIdMapper {
             self.virtual_to_physical.remove(&virtual_id);
         }
         self.virtual_id_pool.release_many(virtual_ids).unwrap();
+        self.generation += 1;
     }
 
     /// Translates a single virtual ID to its corresponding physical ID.
@@ -123,8 +129,9 @@ pub struct InstanceState {
     resources: HashMap<(usize, ResourceTypeId), ResourceIdMapper>,
 
     // Cache of translated KV page IDs to avoid redundant HashMap lookups per decode step.
-    // Keyed by service_id. Value is (virtual_ids, physical_ids) from last kv_cache() call.
-    kv_translation_cache: HashMap<usize, (Vec<ResourceId>, Vec<ResourceId>)>,
+    // Keyed by service_id. Value is (mapper_generation, virtual_ids, physical_ids).
+    // Cache is invalidated when mapper generation changes (any map/unmap operation).
+    kv_translation_cache: HashMap<usize, (u64, Vec<ResourceId>, Vec<ResourceId>)>,
 
     // Dynamic linking state: maps host rep -> guest's ResourceAny
     dynamic_resource_map: HashMap<u32, ResourceAny>,
@@ -346,19 +353,26 @@ impl InstanceState {
                 "Failed to find resource mapper for service_id: {:?}, resource_type: {:?}",
                 service_id, KV_PAGE_TYPE_ID
             ))?;
+        let current_gen = mapper.generation;
 
-        let (cached_virt, cached_phys) = self.kv_translation_cache
+        let (cached_gen, cached_virt, cached_phys) = self.kv_translation_cache
             .entry(service_id)
-            .or_insert_with(|| (Vec::new(), Vec::new()));
+            .or_insert_with(|| (0, Vec::new(), Vec::new()));
 
-        // Find how many leading pages match the cache
-        let prefix_len = cached_virt.len().min(kv_page_ptrs.len());
+        // If any mappings changed (map/unmap), invalidate the entire cache.
+        // This handles page replacement, masking, and virtual ID recycling.
+        let gen_valid = *cached_gen == current_gen;
+
+        // Find how many leading pages match the cache (0 if generation changed)
         let mut match_len = 0;
-        for i in 0..prefix_len {
-            if kv_page_ptrs[i] == cached_virt[i] {
-                match_len = i + 1;
-            } else {
-                break;
+        if gen_valid {
+            let prefix_len = cached_virt.len().min(kv_page_ptrs.len());
+            for i in 0..prefix_len {
+                if kv_page_ptrs[i] == cached_virt[i] {
+                    match_len = i + 1;
+                } else {
+                    break;
+                }
             }
         }
 
@@ -375,10 +389,12 @@ impl InstanceState {
         if crate::model::ffi_ipc::ipc_timing_enabled() {
             let total = kv_page_ptrs.len();
             let fresh = total - match_len;
-            eprintln!("[KV-CACHE] total={} cached={} fresh={}", total, match_len, fresh);
+            eprintln!("[KV-CACHE] total={} cached={} fresh={} gen_hit={}",
+                total, match_len, fresh, gen_valid);
         }
 
         // Update cache
+        *cached_gen = current_gen;
         cached_virt.clear();
         cached_virt.extend_from_slice(kv_page_ptrs);
         *cached_phys = translated.clone();

--- a/runtime/src/instance.rs
+++ b/runtime/src/instance.rs
@@ -1,6 +1,6 @@
 use super::api::core::Queue;
 use super::utils;
-use crate::model::resource::{ResourceId, ResourceTypeId};
+use crate::model::resource::{KV_PAGE_TYPE_ID, ResourceId, ResourceTypeId};
 use crate::server::InstanceEvent;
 use anyhow::{Result, format_err};
 use bytes::Bytes;
@@ -122,6 +122,10 @@ pub struct InstanceState {
     // virtual resources
     resources: HashMap<(usize, ResourceTypeId), ResourceIdMapper>,
 
+    // Cache of translated KV page IDs to avoid redundant HashMap lookups per decode step.
+    // Keyed by service_id. Value is (virtual_ids, physical_ids) from last kv_cache() call.
+    kv_translation_cache: HashMap<usize, (Vec<ResourceId>, Vec<ResourceId>)>,
+
     // Dynamic linking state: maps host rep -> guest's ResourceAny
     dynamic_resource_map: HashMap<u32, ResourceAny>,
     // Reverse map: guest ResourceAny -> host rep (for identity preservation)
@@ -218,6 +222,7 @@ impl InstanceState {
             resource_table: ResourceTable::new(),
             http_ctx: WasiHttpCtx::new(),
             resources: HashMap::new(),
+            kv_translation_cache: HashMap::new(),
             dynamic_resource_map: HashMap::new(),
             guest_resource_map: Vec::new(),
             next_dynamic_rep: 1,
@@ -326,6 +331,59 @@ impl InstanceState {
             m.virtual_to_physical
         ))?;
         Ok(phys_id)
+    }
+
+    /// Translate KV page virtual IDs to physical IDs, caching translations across calls.
+    /// Only translates pages beyond the matching prefix from the previous call.
+    pub fn translate_kv_pages_cached(
+        &mut self,
+        service_id: usize,
+        kv_page_ptrs: &[ResourceId],
+    ) -> Result<Vec<ResourceId>> {
+        let mapper = self.resources
+            .get(&(service_id, KV_PAGE_TYPE_ID))
+            .ok_or_else(|| format_err!(
+                "Failed to find resource mapper for service_id: {:?}, resource_type: {:?}",
+                service_id, KV_PAGE_TYPE_ID
+            ))?;
+
+        let (cached_virt, cached_phys) = self.kv_translation_cache
+            .entry(service_id)
+            .or_insert_with(|| (Vec::new(), Vec::new()));
+
+        // Find how many leading pages match the cache
+        let prefix_len = cached_virt.len().min(kv_page_ptrs.len());
+        let mut match_len = 0;
+        for i in 0..prefix_len {
+            if kv_page_ptrs[i] == cached_virt[i] {
+                match_len = i + 1;
+            } else {
+                break;
+            }
+        }
+
+        // Build translated list: cached prefix + fresh translations for new tail
+        let mut translated = Vec::with_capacity(kv_page_ptrs.len());
+        translated.extend_from_slice(&cached_phys[..match_len]);
+        for &virt_id in &kv_page_ptrs[match_len..] {
+            translated.push(mapper.translate(virt_id).ok_or_else(|| {
+                format_err!("Failed to translate KV page ptr: {}", virt_id)
+            })?);
+        }
+
+        #[cfg(feature = "ipc-profiling")]
+        if crate::model::ffi_ipc::ipc_timing_enabled() {
+            let total = kv_page_ptrs.len();
+            let fresh = total - match_len;
+            eprintln!("[KV-CACHE] total={} cached={} fresh={}", total, match_len, fresh);
+        }
+
+        // Update cache
+        cached_virt.clear();
+        cached_virt.extend_from_slice(kv_page_ptrs);
+        *cached_phys = translated.clone();
+
+        Ok(translated)
     }
 }
 


### PR DESCRIPTION
## Summary

Every decode step, `kv_cache()` translates ALL KV page virtual IDs to physical IDs via per-page `HashMap::get()` lookups. This is O(N) per step where N is the number of KV pages — wasteful since the page list rarely changes between steps.

This PR adds a **translation lookaside buffer (TLB)** that caches virtual→physical page translations across decode steps.

## Design

### TLB cache

`InstanceState` holds a `kv_translation_cache: HashMap<usize, (Vec<ResourceId>, Vec<ResourceId>)>` keyed by service_id. On each `kv_cache()` call, the incoming virtual IDs are compared against the cached list via prefix matching. Only new tail entries (from `grow_kv_pages`) need fresh HashMap lookups.

### Per-page invalidation via `invalidated_ids` (=a list of modified translations)

`ResourceIdMapper` gains an `invalidated_ids: HashSet<ResourceId>` field.

**Lifecycle:**

1. **Populated** — only by `unmap_resources()`. When pages are deallocated, their virtual IDs are added to the set. These IDs return to the pool and may be recycled with different physical mappings.

2. **Consumed** — by `translate_kv_pages_cached()` on the next TLB lookup. If the set is non-empty, it checks whether any invalidated ID appears in the cached translation list. If so, the cache is fully re-translated for that one step.

3. **Drained** — unconditionally cleared at the end of the consumption step, regardless of whether any IDs matched. This prevents unbounded growth from repeated unmap cycles.

**Why `map_resources` does NOT populate it:** New virtual IDs acquired from the pool are fresh — they cannot collide with any existing cached translation. Only freed IDs (from unmap) can be recycled with different physical mappings.

### Complexity per decode step

| Scenario | Operations | Complexity |
|----------|-----------|------------|
| Normal decode (no unmap) | `is_empty()` check + prefix match | O(1) amortized — typically 0 fresh lookups |
| `grow_kv_pages` (+1 page) | prefix match + 1 HashMap lookup | O(1) |
| `shrink_kv_pages` (-K pages) | iterate K invalidated IDs against N cached | O(K) if no match, O(N) if match found |
| Page replacement (unmap+map) | same as shrink | O(K) or O(N) |

In steady-state generation (the hot path), the cost is one `is_empty()` boolean check per step.

## Changes

- **`runtime/src/instance.rs`**:
  - Add `invalidated_ids: HashSet<ResourceId>` to `ResourceIdMapper`
  - Add `kv_translation_cache` to `InstanceState`
  - Add `translate_kv_pages_cached()` — prefix-matching with per-page invalidation
- **`runtime/src/api/core/forward.rs`**: Replace per-page `translate_resource_ptr()` loop in `kv_cache()` with `translate_kv_pages_cached()` call