### PR TITLE
perf: add batch coalesce window to prevent decode fragmentation

### DIFF
--- a/runtime/src/model.rs
+++ b/runtime/src/model.rs
@@ -487,10 +487,49 @@ impl Model {
                 prof_requests_received[group_id] += 1;
             }
 
-            // Try to accumulate more requests (non-blocking)
-            loop {
-                match req_rx.try_recv() {
-                    Ok((req, tx, group_id)) => {
+            // Drain channel into batches, with optional coalesce window.
+            //
+            // Coalesce: when a group's pipeline is empty and batch is incomplete,
+            // wait up to 2ms for more requests before firing. This prevents batch
+            // fragmentation when WASM inferlets resume with slight stagger after
+            // a batch completes.
+            //
+            // Without coalesce, the scheduler fires the first arrival immediately,
+            // producing single-request batches instead of full batches.
+            {
+                const COALESCE_WINDOW: Duration = Duration::from_millis(2);
+
+                // Compute coalesce deadline if any group needs it.
+                // Groups at capacity or with in-flight batches don't participate.
+                let deadline = (0..num_groups)
+                    .filter(|&gid| {
+                        batches[gid].len() > 0
+                            && in_flight_counts[gid] == 0
+                            && batches[gid].len() < max_batch_size
+                            && group_tokens[gid] < max_batch_tokens
+                    })
+                    .next()
+                    .map(|_| Instant::now() + COALESCE_WINDOW);
+
+                loop {
+                    let maybe_req = if let Some(dl) = deadline {
+                        let remaining = dl.saturating_duration_since(Instant::now());
+                        if remaining.is_zero() {
+                            break;
+                        }
+                        match tokio::time::timeout(remaining, req_rx.recv()).await {
+                            Ok(Some(req)) => Some(req),
+                            _ => break, // timeout or channel closed
+                        }
+                    } else {
+                        // No coalesce needed — just drain what's immediately available
+                        match req_rx.try_recv() {
+                            Ok(req) => Some(req),
+                            Err(_) => break,
+                        }
+                    };
+
+                    if let Some((req, tx, group_id)) = maybe_req {
                         let group_id = std::cmp::min(group_id, num_groups - 1);
                         {
                             let mut sched = scheduler.lock().unwrap();
@@ -501,12 +540,13 @@ impl Model {
                         batches[group_id].push((req, tx));
                         prof_requests_received[group_id] += 1;
 
-                        // Stop accumulating if THIS group hit capacity to avoid latency spikes
-                        if batches[group_id].len() >= max_batch_size || group_tokens[group_id] >= max_batch_tokens {
+                        // If this group hit capacity, stop draining
+                        if batches[group_id].len() >= max_batch_size
+                            || group_tokens[group_id] >= max_batch_tokens
+                        {
                             break;
                         }
                     }
-                    Err(_) => break,
                 }
             }
 


### PR DESCRIPTION
## Summary

When multiple WASM inferlets resume after a batch completes, they resubmit `decode_step` requests with slight stagger (~1-2ms spread). Without coalescing, the scheduler's `fire_pipeline_empty` rule fires the first arrival immediately, fragmenting what should be a single batch of N sequences into multiple small batches.

**Fix:** Add a 2ms coalesce window that waits for staggered inferlet resumes to converge into full batches.

## Changes

- Unified the accumulate loop and coalesce loop into a single drain loop
- Non-coalesce path: non-blocking `try_recv` (same behavior as before)
- Coalesce path: async `tokio::time::timeout` instead of busy `thread::yield_now()` spin
- Enforces `max_batch_tokens` during coalesce (was only checking `max_batch_size`)
- Coalesce only activates when: batch has requests, pipeline is empty, batch is below both size and token capacity

## Benchmark (A40, Qwen3-8B)

| Concurrency | Before (avg batch) | After (avg batch) | Before tok/s | After tok/s |
|---|---|---|---|---|
| 1 | 1.0/1.0 | 1.0/1.0 | 30.6 | 30.6 (no regression) |
| 4 | 2.0/4.0 (50%) | 4.0/4.0 (100%) | 84.9 | 117.2 (+38%) |
| 8 | 3.25/8.0 (41%) | 8.0/8.0 (100%) | 120.4 | 169.2 (+41%) |

## Test plan

- [x] Verify conc=1 has no regression (coalesce skipped when at capacity)
- [x] Verify conc=4,8 produce full batches
- [x] Verify `max_batch_tokens` is enforced during coalesce
- [x] Verify no CPU spin (replaced `yield_now` with async timeout)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved request coalescing: the runtime now briefly waits (small coalesce window) to group near-simultaneous requests into batches, falling back to immediate processing when not applicable. This reduces unnecessary work, increases batching efficiency, and lowers end-to-end latency while maintaining firing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->