### PR TITLE
fix: use full shared modules when snapshotting Python components with dependencies

### DIFF
--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -705,7 +705,7 @@ impl Runtime {
 
         let mut visited = HashSet::new();
         let mut dependency_components = Vec::new();
-        let mut dep_python_runtime: Option<String> = None;
+        let mut dep_python_runtime = None;
         let mut any_dep_snapshotted = false;
         let mut any_dep_not_snapshotted = false;
 
@@ -721,30 +721,17 @@ impl Runtime {
             )?;
         }
 
-        if any_dep_snapshotted && any_dep_not_snapshotted {
-            return Err(RuntimeError::Other(
-                "Inconsistent snapshot status among dependencies: some Python components \
-                 are snapshotted while others are not."
-                    .to_string(),
-            ));
-        }
-
-        if any_dep_not_snapshotted {
-            return Err(RuntimeError::Other(
-                "Cannot snapshot: Python dependencies are not snapshotted. \
-                 All Python components in a dependency tree must share the same \
-                 snapshot status."
-                    .to_string(),
-            ));
-        }
-
-        let shared_modules = if any_dep_snapshotted {
-            &self.stripped_shared_modules
-        } else {
-            &self.shared_modules
-        };
-
-        let mut linker = create_linker(&engine, shared_modules);
+        // Always use full (non-stripped) shared modules for snapshotting.
+        // The snapshot process must initialize CPython from scratch to load
+        // the component's Python code; stripped modules lack the data segments
+        // and start functions required for this.  Each component gets its own
+        // instances of the shared modules, so snapshotted dependencies are
+        // unaffected — their snapshot state may be partially overwritten in
+        // their own instance, but the snapshot process only needs their WIT
+        // exports for import resolution, not their full Python runtime state.
+        // Stripped modules are only needed at *runtime* (in launch_instance)
+        // to prevent shared-module data segments from clobbering the snapshot.
+        let mut linker = create_linker(&engine, &self.shared_modules);
 
         let (inst_state, _output_delivery_ctrl) = InstanceState::new(
             Uuid::new_v4(),


### PR DESCRIPTION
The snapshot process for Python components was using stripped shared modules (no data segments, no start functions) whenever any dependency was an already-snapshotted Python component. This prevented CPython from initializing during the snapshot of the dependent component, causing a panic in `componentize_py_runtime::ensure_init` when `__prepare_snapshot` was called.

Stripped shared modules are only needed at runtime to avoid clobbering a snapshotted component's memory image. During snapshot creation, the full shared modules are always required so that CPython can initialize from scratch and load the new component's Python code. Each component receives its own instances of the shared modules, so using full modules during snapshotting does not affect snapshotted dependencies.

Remove the snapshot-status checks that blocked snapshotting when dependencies had mixed or non-snapshotted Python components, as they were only relevant to the now-removed stripped-module selection logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python component snapshotting behavior by removing overly restrictive validation checks and error conditions that could block snapshotting in certain scenarios.
  * Made shared module handling more consistent during Python component snapshots, regardless of dependency snapshot status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->