### PR TITLE
fix(sdk/python): pass actual_pages to forward.kv_cache

### DIFF
--- a/sdk/python/src/inferlet/forward.py
+++ b/sdk/python/src/inferlet/forward.py
@@ -54,15 +54,25 @@ class ForwardPass:
         """
         _forward.input_embeddings(self._inner, emb_ptrs, positions)
 
-    def kv_cache(self, kv_page_ptrs: list[int], last_kv_page_len: int) -> None:
+    def kv_cache(
+        self,
+        kv_page_ptrs: list[int],
+        last_kv_page_len: int,
+        actual_pages: int | None = None,
+    ) -> None:
         """
         Set the KV cache pages for the forward pass.
 
         Args:
             kv_page_ptrs: Pointers to KV cache pages
             last_kv_page_len: Length of the last KV page
+            actual_pages: Number of pages that currently contain data. Defaults
+                to len(kv_page_ptrs). Supply a smaller value when pre-allocating
+                trailing pages (see Rust SDK Context::flush).
         """
-        _forward.kv_cache(self._inner, kv_page_ptrs, last_kv_page_len)
+        if actual_pages is None:
+            actual_pages = len(kv_page_ptrs)
+        _forward.kv_cache(self._inner, kv_page_ptrs, last_kv_page_len, actual_pages)
 
     def attention_mask(self, mask: list[list[int]]) -> None:
         """


### PR DESCRIPTION
WIT interface requires actual_pages as the 4th arg, but Python binding still had the old 2-arg signature, causing TypeError at runtime for any inferlet using generate/decode paths (beam search, generate, decode_step_dist).

Default actual_pages to len(kv_page_ptrs) so the 3 existing call sites in context.py (decode, decode_dist, decode_step_dist) keep working — Python's decode path never pre-allocates trailing pages, unlike the Rust SDK.