### PR TITLE
feat(server): let clients choose the bind host for launch_server_instance

### DIFF
--- a/client/python/src/pie_client/client.py
+++ b/client/python/src/pie_client/client.py
@@ -646,6 +646,7 @@ class PieClient:
         program_hash: str,
         port: int,
         arguments: list[str] | None = None,
+        host: str | None = None,
     ) -> None:
         """
         Launch a server inferlet that listens on a specific port.
@@ -657,14 +658,18 @@ class PieClient:
         :param program_hash: The hash of the uploaded program.
         :param port: The TCP port to listen on.
         :param arguments: Command-line arguments to pass to the inferlet.
+        :param host: IP to bind on (e.g. ``"0.0.0.0"``). ``None`` keeps the
+            engine's historical default of ``127.0.0.1``.
         :raises Exception: If launch fails.
         """
-        msg = {
+        msg: dict = {
             "type": "launch_server_instance",
             "port": port,
             "inferlet": program_hash,
             "arguments": arguments or [],
         }
+        if host is not None:
+            msg["host"] = host
         successful, result = await self._send_msg_and_wait(msg)
         if not successful:
             raise Exception(f"Failed to launch server instance: {result}")

--- a/client/rust/src/message.rs
+++ b/client/rust/src/message.rs
@@ -108,6 +108,10 @@ pub enum ClientMessage {
         port: u32,
         inferlet: String,
         arguments: Vec<String>,
+        /// IP to bind the server inferlet on.  Omitted by older clients → defaults to
+        /// `127.0.0.1` runtime-side (see `server::handle_launch_server_instance`).
+        #[serde(default)]
+        host: Option<String>,
     },
 
     #[serde(rename = "signal_instance")]

--- a/pie/src/pie_cli/http.py
+++ b/pie/src/pie_cli/http.py
@@ -27,6 +27,13 @@ def http(
     port: int = typer.Option(
         ..., "--port", help="TCP port for the server to listen on"
     ),
+    host: str = typer.Option(
+        "127.0.0.1",
+        "--host",
+        help="IP to bind the server inferlet on. Use 0.0.0.0 to accept "
+             "connections from outside the current network namespace (e.g. "
+             "when running under Docker bridge networking with -p).",
+    ),
     config: Optional[Path] = typer.Option(
         None, "--config", "-c", help="Path to TOML configuration file"
     ),
@@ -83,8 +90,8 @@ def http(
     lines = Text()
     lines.append(f"{'Inferlet':<15}", style="white")
     lines.append(f"{inferlet_display}\n", style="dim")
-    lines.append(f"{'Port':<15}", style="white")
-    lines.append(f"{port}\n", style="cyan bold")
+    lines.append(f"{'Bind':<15}", style="white")
+    lines.append(f"{host}:{port}\n", style="cyan bold")
     lines.append(f"{'Model':<15}", style="white")
     lines.append(f"{model_configs[0].get('hf_repo', 'unknown')}\n", style="dim")
     lines.append(f"{'Device':<15}", style="white")
@@ -119,14 +126,14 @@ def http(
 
         if path is not None:
             _launch_server_inferlet(
-                client_config, path, port, arguments or []
+                client_config, path, port, arguments or [], host=host
             )
         else:
             # TODO: Support launching from registry
             console.print("[red]✗[/red] Registry mode not yet supported for server inferlets")
             raise typer.Exit(1)
 
-        console.print(f"[green]✓[/green] Server inferlet listening on [cyan]http://127.0.0.1:{port}/[/cyan]")
+        console.print(f"[green]✓[/green] Server inferlet listening on [cyan]http://{host}:{port}/[/cyan]")
         console.print("[dim]Press Ctrl+C to stop[/dim]")
         console.print()
 
@@ -159,6 +166,7 @@ def _launch_server_inferlet(
     path: Path,
     port: int,
     arguments: list[str],
+    host: str = "127.0.0.1",
 ) -> None:
     """Upload and launch a server inferlet from a local path."""
     import asyncio
@@ -198,8 +206,15 @@ def _launch_server_inferlet(
                 console.print(f"[dim]Installing {path.name} as {inferlet_id}...[/dim]")
                 await client.install_program(str(path), str(manifest_path))
 
-            # Launch as server instance using program name (not hash)
-            console.print(f"[dim]Starting {inferlet_id} on port {port}...[/dim]")
-            await client.launch_server_instance(inferlet_id, port, arguments)
+            # Launch as server instance using program name (not hash).
+            # Omit the host kwarg when the caller wants the historical
+            # default so we stay wire-compatible with older runtimes.
+            console.print(f"[dim]Starting {inferlet_id} on {host}:{port}...[/dim]")
+            if host == "127.0.0.1":
+                await client.launch_server_instance(inferlet_id, port, arguments)
+            else:
+                await client.launch_server_instance(
+                    inferlet_id, port, arguments, host=host
+                )
 
     asyncio.run(_launch())

--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -113,6 +113,9 @@ pub enum Command {
         username: String,
         program_hash: ProgramHash,
         port: u32,
+        /// IP to bind the server on. `None` → `127.0.0.1` (preserves
+        /// historical behaviour for callers that don't opt in).
+        host: Option<String>,
         arguments: Vec<String>,
         event: oneshot::Sender<Result<(), RuntimeError>>,
     },
@@ -342,11 +345,12 @@ impl Service for Runtime {
                 username,
                 program_hash,
                 port,
+                host,
                 arguments,
                 event,
             } => {
                 let res = self
-                    .launch_server_instance(username, program_hash, port, arguments)
+                    .launch_server_instance(username, program_hash, port, host, arguments)
                     .await;
                 event.send(res.map(|_| ())).unwrap();
             }
@@ -963,6 +967,7 @@ impl Runtime {
         username: String,
         program_hash: ProgramHash,
         port: u32,
+        host: Option<String>,
         arguments: Vec<String>,
     ) -> Result<InstanceId, RuntimeError> {
         let instance_id = Uuid::new_v4();
@@ -985,7 +990,17 @@ impl Runtime {
 
         // Instantiate and run in a task
         let engine = self.engine.clone();
-        let addr = SocketAddr::from(([127, 0, 0, 1], port as u16));
+        // Default to 127.0.0.1 so clients that don't opt in keep the old
+        // loopback-only semantics. Setting host = Some("0.0.0.0") makes the
+        // server reachable from other netns / outside the container, which
+        // is what the pieclaw inferlet-runner image needs.
+        let bind_host = host.as_deref().unwrap_or("127.0.0.1");
+        let bind_ip: std::net::IpAddr = bind_host.parse().map_err(|e| {
+            RuntimeError::Other(format!(
+                "launch_server_instance: invalid host {bind_host:?}: {e}"
+            ))
+        })?;
+        let addr = SocketAddr::from((bind_ip, port as u16));
 
         // Create a oneshot channel to signal when the task can start
         let (start_tx, start_rx) = oneshot::channel();

--- a/runtime/src/server.rs
+++ b/runtime/src/server.rs
@@ -676,8 +676,9 @@ impl Session {
                     port,
                     inferlet,
                     arguments,
+                    host,
                 } => {
-                    self.handle_launch_server_instance(corr_id, port, inferlet, arguments)
+                    self.handle_launch_server_instance(corr_id, port, inferlet, arguments, host)
                         .await
                 }
                 ClientMessage::SignalInstance {
@@ -1344,6 +1345,7 @@ impl Session {
         port: u32,
         inferlet: String,
         arguments: Vec<String>,
+        host: Option<String>,
     ) {
         let program_name = ProgramName::parse(&inferlet);
 
@@ -1385,6 +1387,7 @@ impl Session {
                     program_metadata.manifest_hash,
                 ),
                 port,
+                host,
                 arguments,
                 event: evt_tx,
             }


### PR DESCRIPTION
## Motivation

The server inferlet binding is hardcoded to \`127.0.0.1\` in
\`runtime::launch_server_instance\`. That's the right default — a loopback
HTTP server owned by a trusted parent process — but it blocks a real
use case: running \`pie http\` inside a Docker container on bridge
networking and exposing the server via \`-p 8095:8095\`. Under bridge
networking Docker can only port-forward to the container's \`0.0.0.0\`,
so a \`127.0.0.1\` bind is unreachable from the host.

The immediate driver is the \`pieclaw/docker/inferlet-runner\` image
(just merged) — it's currently forced onto \`--network host\` purely
because of this constraint, which leaks host-port collisions between
multiple runner containers (every new one has to pick its own engine
WS port to avoid stepping on 8080).

## What changes

Optional \`host\` field threaded end-to-end through the
\`launch_server_instance\` RPC:

- **\`client/rust/src/message.rs\`** — new \`host: Option<String>\` on
  \`LaunchServerInstance\`, \`#[serde(default)]\` so older clients still
  deserialize.
- **\`runtime/src/server.rs\`** — destructure + forward through
  \`handle_launch_server_instance\` into the runtime \`Command\`.
- **\`runtime/src/runtime.rs\`** — \`Command::LaunchServerInstance\` grows
  a \`host: Option<String>\` variant field. \`launch_server_instance\`
  parses the host string into an \`IpAddr\` (errors with a clear message
  on garbage input) and uses it in the \`SocketAddr\`. \`None\` falls
  through to \`127.0.0.1\`.
- **\`client/python/src/pie_client/client.py\`** — \`host: str | None = None\`
  kwarg; only included in the outgoing msgpack when set, preserving
  wire-compat with older runtimes.
- **\`pie/src/pie_cli/http.py\`** — new \`--host\` typer option defaulting
  to \`127.0.0.1\`. The \"Listening on...\" panel + message now echo the
  chosen host.

## Wire compatibility

- **Old client → new runtime**: no \`host\` in payload → \`serde(default)\`
  gives \`None\` → default \`127.0.0.1\`. ✅
- **New client, default host → old runtime**: Python helper omits the
  key when host == 127.0.0.1, so the msgpack wire bytes are identical
  to the old path. ✅
- **New client, \`--host 0.0.0.0\` → old runtime**: the old runtime fails
  msgpack deserialization with an unknown field. Expected & acceptable —
  only surfaces when the operator opts in.

## Test plan

- [x] \`cargo check\` passes for \`runtime/\` + \`client/rust/\` on the
      pieclaw-native-dev image.
- [x] \`python3 -m py_compile\` passes for the changed Python files.
- [ ] Smoke test on ECL: \`pie http --path ... --port 18099 --host 0.0.0.0\`
      binds \`0.0.0.0:18099\` (and reaches from host); default binds
      \`127.0.0.1:18099\` as before.

## Follow-up

Once merged + bumped in \`pie-vllm\`, the \`pieclaw/docker/inferlet-runner\`
image drops the \`ENGINE_PORT=PORT+10000\` workaround and switches from
\`--network host\` to \`--network bridge -p EXT:INT\`, which gives each
runner container its own netns. Tracking in shsym/pieclaw#12.