### PR TITLE
website: add /whypieagent demo page (dark-themed)

### DIFF
--- a/website/src/components/whypieagent/BenchmarkResults.module.css
+++ b/website/src/components/whypieagent/BenchmarkResults.module.css
@@ -1,0 +1,134 @@
+/* Benchmark Results — dark theme */
+
+.wrapper {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 0 1rem 2rem;
+}
+
+.title {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: clamp(1.3rem, 2.2vw, 1.6rem);
+  font-weight: 700;
+  text-align: center;
+  margin: 0 0 1.5rem;
+  color: #f0f0f8;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+  table-layout: fixed;
+}
+
+.table th,
+.table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid #2a2a3a;
+  vertical-align: top !important;
+  word-wrap: break-word;
+}
+
+.table th:nth-child(1),
+.table td:nth-child(1) {
+  width: 38%;
+}
+
+.table th:nth-child(2),
+.table td:nth-child(2) {
+  width: 25%;
+}
+
+.table th:nth-child(3),
+.table td:nth-child(3) {
+  width: 22%;
+}
+
+.table th:nth-child(4),
+.table td:nth-child(4) {
+  width: 15%;
+  min-width: 110px;
+  white-space: nowrap;
+}
+
+.table th {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6b6b88;
+  background: #12121a;
+}
+
+.table td {
+  color: #c0c0d0;
+}
+
+.table tbody tr:hover {
+  background: rgba(59, 130, 246, 0.04);
+}
+
+.monoCell {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-weight: 400;
+}
+
+.metricPrimary {
+  display: block;
+  color: #e0e0f0;
+}
+
+.metricSecondary {
+  display: block;
+  color: #7a7a95;
+  font-size: 0.85em;
+  margin-top: 0.2rem;
+}
+
+.scenarioDesc {
+  display: block;
+  font-size: 0.85em;
+  font-weight: 400;
+  color: #8a8aa0;
+  margin-top: 0.2rem;
+}
+
+.badge {
+  display: inline-block;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  vertical-align: middle;
+}
+
+.badgeEstimated {
+  background: rgba(245, 158, 11, 0.15);
+  color: #f59e0b;
+}
+
+.badgeMeasured {
+  background: rgba(34, 197, 94, 0.15);
+  color: #22c55e;
+}
+
+.tableNote {
+  text-align: center;
+  margin-top: 1rem;
+  font-size: 0.85rem;
+  color: #6b6b88;
+  line-height: 1.5;
+}
+
+@media (max-width: 640px) {
+  .table th,
+  .table td {
+    padding: 0.5rem 0.6rem;
+    font-size: 0.82rem;
+  }
+}

--- a/website/src/components/whypieagent/BenchmarkResults.tsx
+++ b/website/src/components/whypieagent/BenchmarkResults.tsx
@@ -76,8 +76,7 @@ export default function BenchmarkResults({ case1, case2, benchmarks }: Props) {
       </table>
 
       <p className={styles.tableNote}>
-        Percentages reflect token reduction (prefill for rows 1-3; input per turn for row 4).
-        End-to-end latency improvement varies with response length since decode throughput is similar between systems.
+        Percentages reflect token reduction (prefill for scenarios 1-3; input per turn for scenario 4).
         {benchmarks?.platform && <>{' '}Measured on {benchmarks.platform}.</>}
       </p>
     </div>

--- a/website/src/components/whypieagent/BenchmarkResults.tsx
+++ b/website/src/components/whypieagent/BenchmarkResults.tsx
@@ -1,0 +1,90 @@
+import styles from './BenchmarkResults.module.css';
+
+interface BenchmarkData {
+  platform?: string;
+  date?: string;
+  rows: {
+    scenario: string;
+    standard: string;
+    pie: string;
+    improvement: string;
+  }[];
+}
+
+interface Props {
+  case1: { vllm_prefill_tokens: number; pie_prefill_tokens: number };
+  case2: { vllm_reprefill_tokens: number; pie_reprefill_tokens: number; reduction_pct: number };
+  benchmarks: BenchmarkData | null;
+}
+
+export default function BenchmarkResults({ case1, case2, benchmarks }: Props) {
+  const rows = benchmarks?.rows ?? [
+    {
+      scenario: 'Cold start prefill',
+      standard: `${case1.vllm_prefill_tokens.toLocaleString()} tokens`,
+      pie: `${case1.pie_prefill_tokens.toLocaleString()} tokens`,
+      improvement: `${Math.round((1 - case1.pie_prefill_tokens / case1.vllm_prefill_tokens) * 100)}%`,
+    },
+    {
+      scenario: 'Channel switch re-prefill',
+      standard: `${case2.vllm_reprefill_tokens.toLocaleString()} tokens`,
+      pie: `${case2.pie_reprefill_tokens.toLocaleString()} tokens`,
+      improvement: `${case2.reduction_pct}%`,
+    },
+  ];
+
+  return (
+    <div className={styles.wrapper}>
+      <h3 className={styles.title}>Results</h3>
+
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            <th>Scenario</th>
+            <th>Standard Serving</th>
+            <th>Pie</th>
+            <th>Tokens saved</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const colonIdx = row.scenario.indexOf(':');
+            const title = colonIdx >= 0 ? row.scenario.slice(0, colonIdx) : row.scenario;
+            const rest = colonIdx >= 0 ? row.scenario.slice(colonIdx + 1).trim() : '';
+            const renderMetric = (s: string) => {
+              const lines = s.split('\n');
+              return (
+                <>
+                  <span className={styles.metricPrimary}>{lines[0]}</span>
+                  {lines[1] && <span className={styles.metricSecondary}>{lines[1]}</span>}
+                </>
+              );
+            };
+            return (
+              <tr key={row.scenario}>
+                <td>
+                  <strong>{title}</strong>
+                  {rest && <span className={styles.scenarioDesc}>{rest}</span>}
+                </td>
+                <td className={styles.monoCell}>{renderMetric(row.standard)}</td>
+                <td className={styles.monoCell}>{renderMetric(row.pie)}</td>
+                <td className={styles.monoCell}>{row.improvement}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+
+      <p className={styles.tableNote}>
+        Percentages reflect token reduction (prefill for rows 1-3; input per turn for row 4).
+        End-to-end latency improvement varies with response length since decode throughput is similar between systems.
+        {benchmarks?.platform && (
+          <>
+            {' '}Measured on {benchmarks.platform}
+            {benchmarks.date && ` \u00b7 ${benchmarks.date}`}.
+          </>
+        )}
+      </p>
+    </div>
+  );
+}

--- a/website/src/components/whypieagent/BenchmarkResults.tsx
+++ b/website/src/components/whypieagent/BenchmarkResults.tsx
@@ -78,12 +78,7 @@ export default function BenchmarkResults({ case1, case2, benchmarks }: Props) {
       <p className={styles.tableNote}>
         Percentages reflect token reduction (prefill for rows 1-3; input per turn for row 4).
         End-to-end latency improvement varies with response length since decode throughput is similar between systems.
-        {benchmarks?.platform && (
-          <>
-            {' '}Measured on {benchmarks.platform}
-            {benchmarks.date && ` \u00b7 ${benchmarks.date}`}.
-          </>
-        )}
+        {benchmarks?.platform && <>{' '}Measured on {benchmarks.platform}.</>}
       </p>
     </div>
   );

--- a/website/src/components/whypieagent/BenchmarkResults.tsx
+++ b/website/src/components/whypieagent/BenchmarkResults.tsx
@@ -77,7 +77,7 @@ export default function BenchmarkResults({ case1, case2, benchmarks }: Props) {
 
       <p className={styles.tableNote}>
         Percentages reflect token reduction (prefill for scenarios 1-3; input per turn for scenario 4).
-        {benchmarks?.platform && <>{' '}Measured on {benchmarks.platform}.</>}
+        {benchmarks?.platform && <><br />Measured on {benchmarks.platform}.</>}
       </p>
     </div>
   );

--- a/website/src/components/whypieagent/ChannelSwitchDiagram.module.css
+++ b/website/src/components/whypieagent/ChannelSwitchDiagram.module.css
@@ -1,0 +1,214 @@
+/* Case 2: Channel Switch — side-by-side, pastel dark theme */
+
+.wrapper {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+
+/* Side by side layout */
+.sideBySide {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+
+@media (max-width: 760px) {
+  .sideBySide {
+    grid-template-columns: 1fr;
+  }
+}
+
+.column {
+  display: flex;
+  flex-direction: column;
+}
+
+.columnTitle {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #9898b0;
+  margin: 0 0 0.75rem;
+  text-align: center;
+  letter-spacing: 0.02em;
+}
+
+.blockStack {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid #22222e;
+}
+
+
+.blockLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  position: relative;
+  z-index: 1;
+}
+
+.blockTokens {
+  font-size: 0.6rem;
+  opacity: 0.5;
+  margin-left: 0.5rem;
+  flex-shrink: 0;
+  position: relative;
+  z-index: 1;
+}
+
+/* Block base — always the default gray, overlay wipes color in */
+.block {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 0.6rem;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.68rem;
+  overflow: hidden;
+  white-space: nowrap;
+  min-height: 18px;
+  background-color: #282840;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+/* Color overlay — wipes in from left */
+.blockOverlay {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  clip-path: inset(0 100% 0 0);
+}
+
+.blockOverlay.blockWiped {
+  clip-path: inset(0 0 0 0);
+  transition: clip-path 0.3s ease;
+}
+
+.overlayCached {
+  background-color: #1a3a2e;
+}
+
+.overlayInvalidated {
+  background-color: #3a2e1a;
+}
+
+.overlayChanged {
+  background-color: #3a1a22;
+}
+
+/* Stats below each column */
+.stats {
+  display: flex;
+  justify-content: center;
+  gap: 1.25rem;
+  margin-top: 0.75rem;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.75rem;
+}
+
+.statCached {
+  color: #7ec9a0;
+}
+
+.statReprefill {
+  color: #d4a06a;
+}
+
+/* Summary bar */
+.summaryBar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  padding: 0.75rem 1.5rem;
+  background: rgba(107, 138, 219, 0.08);
+  border: 1px solid rgba(107, 138, 219, 0.2);
+  border-radius: 8px;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  flex-wrap: wrap;
+}
+
+.summaryLabel {
+  font-size: 0.78rem;
+  color: #7080a0;
+}
+
+.summaryValue {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #a0c0e8;
+}
+
+.summaryDetail {
+  font-size: 0.72rem;
+  color: #606880;
+}
+
+/* Legend */
+.legend {
+  display: flex;
+  justify-content: center;
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  color: #787890;
+}
+
+.legendDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.dotCached { background: #1a3a2e; border: 1px solid #2a5040; }
+.dotChanged { background: #3a1a22; border: 1px solid #5a2a35; }
+.dotInvalidated { background: #3a2e1a; border: 1px solid #5a4a2a; }
+
+.legend {
+  margin-top: 1.5rem;
+}
+
+.replayRow {
+  margin-top: 0.75rem;
+  text-align: center;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  pointer-events: none;
+}
+
+.replayRow.replayVisible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.replayBtn {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.92rem;
+  font-weight: 600;
+  padding: 0;
+  border: none;
+  background: none;
+  color: #505068;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.replayBtn:hover {
+  color: #8090b0;
+}
+

--- a/website/src/components/whypieagent/ChannelSwitchDiagram.tsx
+++ b/website/src/components/whypieagent/ChannelSwitchDiagram.tsx
@@ -1,0 +1,282 @@
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import styles from './ChannelSwitchDiagram.module.css';
+
+interface Section {
+  name: string;
+  token_start: number;
+  token_end: number;
+  tokens: number;
+  stability: 'static' | 'dynamic';
+}
+
+interface Props {
+  sections: Section[];
+  totalTokens: number;
+  divergenceOriginal: number;
+  divergenceReordered: number;
+  standardReprefill: number;
+  pieReprefill: number;
+  reductionPct: number;
+}
+
+type BlockState = 'default' | 'cached' | 'invalidated' | 'changed';
+
+function shortName(name: string): string {
+  let s = name.replace(/^#{1,3}\s+/, '');
+  if (s.includes(' + ')) s = s.split(' + ')[0];
+  s = s.replace(/\/home\/node\/.openclaw\/workspace\//, '');
+  s = s.replace(/[\u{1F300}-\u{1FAFF}]/gu, '').trim();
+  if (s.length > 24) s = s.slice(0, 22) + '\u2026';
+  return s;
+}
+
+export default function ChannelSwitchDiagram({
+  sections,
+  totalTokens,
+  divergenceOriginal,
+  standardReprefill,
+  pieReprefill,
+  reductionPct,
+}: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [switched, setSwitched] = useState(false);
+  const [stdRevealed, setStdRevealed] = useState(0);
+  const [pieRevealed, setPieRevealed] = useState(0);
+  const [finished, setFinished] = useState(false);
+  const hasAutoPlayed = useRef(false);
+  const stdTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pieTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const originalBlocks = useMemo(
+    () => sections.map((s) => ({ ...s, shortName: shortName(s.name) })),
+    [sections],
+  );
+
+  const reorderedBlocks = useMemo(() => {
+    const statics = sections.filter((s) => s.stability === 'static');
+    const dynamics = sections.filter((s) => s.stability === 'dynamic');
+    return [...statics, ...dynamics].map((s) => ({ ...s, shortName: shortName(s.name) }));
+  }, [sections]);
+
+  // Compute target states (what each block SHOULD be when revealed)
+  const originalTargets: BlockState[] = useMemo(() => {
+    if (!switched) return originalBlocks.map(() => 'default');
+    return originalBlocks.map((b) => {
+      const mid = b.token_start + b.tokens / 2;
+      if (b.stability === 'dynamic') return 'changed';
+      if (mid < divergenceOriginal) return 'cached';
+      return 'invalidated';
+    });
+  }, [originalBlocks, switched, divergenceOriginal]);
+
+  const reorderedTargets: BlockState[] = useMemo(() => {
+    if (!switched) return reorderedBlocks.map(() => 'default');
+    return reorderedBlocks.map((b) => (b.stability === 'dynamic' ? 'changed' : 'cached'));
+  }, [reorderedBlocks, switched]);
+
+  // Two independent reveal chains — each side advances at its own pace
+  // Green (cached) = 100ms, orange/red (invalidated/changed) = 350ms
+  const FAST = 100;
+  const SLOW = 350;
+
+  const delayFor = (state: BlockState) => state === 'cached' ? FAST : SLOW;
+
+  // Standard side reveal
+  useEffect(() => {
+    if (!switched) {
+      setStdRevealed(0);
+      if (stdTimerRef.current) clearTimeout(stdTimerRef.current);
+      return;
+    }
+    let step = 0;
+    const advance = () => {
+      step++;
+      setStdRevealed(step);
+      if (step < originalBlocks.length) {
+        stdTimerRef.current = setTimeout(advance, delayFor(originalTargets[step]));
+      }
+    };
+    stdTimerRef.current = setTimeout(advance, delayFor(originalTargets[0]));
+    return () => { if (stdTimerRef.current) clearTimeout(stdTimerRef.current); };
+  }, [switched, originalBlocks.length, originalTargets]);
+
+  // Pie side reveal
+  useEffect(() => {
+    if (!switched) {
+      setPieRevealed(0);
+      if (pieTimerRef.current) clearTimeout(pieTimerRef.current);
+      return;
+    }
+    let step = 0;
+    const advance = () => {
+      step++;
+      setPieRevealed(step);
+      if (step < reorderedBlocks.length) {
+        pieTimerRef.current = setTimeout(advance, delayFor(reorderedTargets[step]));
+      }
+    };
+    pieTimerRef.current = setTimeout(advance, delayFor(reorderedTargets[0]));
+    return () => { if (pieTimerRef.current) clearTimeout(pieTimerRef.current); };
+  }, [switched, reorderedBlocks.length, reorderedTargets]);
+
+  // Finished when BOTH sides are done
+  const stdDone = stdRevealed >= originalBlocks.length;
+  const pieDone = pieRevealed >= reorderedBlocks.length;
+  useEffect(() => {
+    if (switched && stdDone && pieDone) {
+      const t = setTimeout(() => setFinished(true), 400);
+      return () => clearTimeout(t);
+    }
+  }, [switched, stdDone, pieDone]);
+
+  const play = useCallback(() => {
+    setSwitched(false);
+    setStdRevealed(0);
+    setPieRevealed(0);
+    setFinished(false);
+    setTimeout(() => setSwitched(true), 100);
+  }, []);
+
+  // Auto-play on scroll into view
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !hasAutoPlayed.current) {
+          hasAutoPlayed.current = true;
+          setTimeout(() => setSwitched(true), 800);
+        }
+      },
+      { threshold: 0.35 },
+    );
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, []);
+
+  const overlayClass = (state: BlockState) => {
+    switch (state) {
+      case 'cached': return styles.overlayCached;
+      case 'invalidated': return styles.overlayInvalidated;
+      case 'changed': return styles.overlayChanged;
+      default: return '';
+    }
+  };
+
+  const heightForTokens = (tokens: number) =>
+    Math.max(18, Math.round((tokens / totalTokens) * 480));
+
+  const cn = (...classes: (string | false | undefined)[]) =>
+    classes.filter(Boolean).join(' ');
+
+  const cachedOriginal = stdDone
+    ? originalBlocks.reduce((sum, b, i) => sum + (originalTargets[i] === 'cached' ? b.tokens : 0), 0)
+    : 0;
+  const cachedReordered = pieDone
+    ? reorderedBlocks.reduce((sum, b, i) => sum + (reorderedTargets[i] === 'cached' ? b.tokens : 0), 0)
+    : 0;
+
+  return (
+    <div ref={ref} className={styles.wrapper}>
+      {/* Side by side diagrams */}
+      <div className={styles.sideBySide}>
+        {/* Standard side */}
+        <div className={styles.column}>
+          <h4 className={styles.columnTitle}>Standard Serving (original layout)</h4>
+          <div className={styles.blockStack}>
+            {originalBlocks.map((b, i) => {
+              const revealed = i < stdRevealed;
+              const target = originalTargets[i];
+              return (
+                <div
+                  key={`orig-${i}`}
+                  className={styles.block}
+                  style={{ height: heightForTokens(b.tokens) }}
+                  title={`${b.shortName} (${b.tokens} tok) — ${b.stability}`}
+                >
+                  <div className={cn(styles.blockOverlay, revealed && overlayClass(target), revealed && styles.blockWiped)} />
+                  <span className={styles.blockLabel}>{b.shortName}</span>
+                  <span className={styles.blockTokens}>{b.tokens}</span>
+                </div>
+              );
+            })}
+          </div>
+          {stdDone && switched && (
+            <div className={styles.stats}>
+              <span className={styles.statCached}>
+                {cachedOriginal.toLocaleString()} cached
+              </span>
+              <span className={styles.statReprefill}>
+                {standardReprefill.toLocaleString()} re-prefilled
+              </span>
+            </div>
+          )}
+        </div>
+
+        {/* Pie side */}
+        <div className={styles.column}>
+          <h4 className={styles.columnTitle}>Pie (reordered layout)</h4>
+          <div className={styles.blockStack}>
+            {reorderedBlocks.map((b, i) => {
+              const revealed = i < pieRevealed;
+              const target = reorderedTargets[i];
+              return (
+                <div
+                  key={`reord-${i}`}
+                  className={styles.block}
+                  style={{ height: heightForTokens(b.tokens) }}
+                  title={`${b.shortName} (${b.tokens} tok) — ${b.stability}`}
+                >
+                  <div className={cn(styles.blockOverlay, revealed && overlayClass(target), revealed && styles.blockWiped)} />
+                  <span className={styles.blockLabel}>{b.shortName}</span>
+                  <span className={styles.blockTokens}>{b.tokens}</span>
+                </div>
+              );
+            })}
+          </div>
+          {pieDone && switched && (
+            <div className={styles.stats}>
+              <span className={styles.statCached}>
+                {cachedReordered.toLocaleString()} cached
+              </span>
+              <span className={styles.statReprefill}>
+                {pieReprefill.toLocaleString()} re-prefilled
+              </span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className={styles.legend}>
+        <div className={styles.legendItem}>
+          <span className={cn(styles.legendDot, styles.dotCached)} />
+          <span>Cached</span>
+        </div>
+        <div className={styles.legendItem}>
+          <span className={cn(styles.legendDot, styles.dotChanged)} />
+          <span>Changed</span>
+        </div>
+        <div className={styles.legendItem}>
+          <span className={cn(styles.legendDot, styles.dotInvalidated)} />
+          <span>Cascade invalidated</span>
+        </div>
+      </div>
+
+      {/* Replay */}
+      <div className={cn(styles.replayRow, finished && styles.replayVisible)}>
+        <button className={styles.replayBtn} onClick={play}>&#8635; Replay</button>
+      </div>
+
+      {/* Summary — below replay */}
+      {stdDone && pieDone && switched && (
+        <div className={styles.summaryBar}>
+          <span className={styles.summaryLabel}>Tokens needing recomputation</span>
+          <span className={styles.summaryDetail}>
+            {standardReprefill.toLocaleString()} &rarr; {pieReprefill.toLocaleString()}
+          </span>
+          <span className={styles.summaryValue}>{reductionPct}% less recomputation</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/website/src/components/whypieagent/ColdStartRace.module.css
+++ b/website/src/components/whypieagent/ColdStartRace.module.css
@@ -1,0 +1,162 @@
+/* Case 1: Cold Start Race — dark theme */
+
+.container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+@media (max-width: 640px) {
+  .container {
+    grid-template-columns: 1fr;
+  }
+}
+
+.panel {
+  background: #14141e;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid #22222e;
+}
+
+.panelHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: #10101a;
+  border-bottom: 1px solid #22222e;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+.dotRed { background: #ff5f56; }
+.dotYellow { background: #ffbd2e; }
+.dotGreen { background: #27c93f; }
+
+.panelTitle {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.82rem;
+  color: #8080a0;
+  margin: 0;
+  margin-left: 0.5rem;
+}
+
+.panelBody {
+  padding: 1.25rem;
+  min-height: 140px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.progressTrack {
+  height: 28px;
+  background: #12121e;
+  border-radius: 6px;
+  overflow: hidden;
+  position: relative;
+}
+
+.progressFill {
+  height: 100%;
+  border-radius: 6px;
+}
+
+.fillStd {
+  background: linear-gradient(90deg, #3a2e50 0%, #4a3a60 100%);
+}
+
+.fillPie {
+  background: linear-gradient(90deg, #1e3a50 0%, #2a4a60 100%);
+}
+
+.label {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.8rem;
+  color: #6b6b88;
+}
+
+.tokens {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.9rem;
+  color: #d0d0e0;
+  font-weight: 600;
+}
+
+.tokenLabel {
+  color: #6b6b88;
+  font-weight: 400;
+}
+
+.tokenSlash {
+  color: #4a4a60;
+  font-weight: 400;
+}
+
+.stats {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.done {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.8rem;
+  color: #7ec9a0;
+  opacity: 0;
+}
+
+.done.show {
+  animation: fadeIn 0.3s ease-out forwards;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.outer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.replayRow {
+  margin-top: 1.25rem;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  pointer-events: none;
+}
+
+.replayRow.replayVisible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.replayBtn {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.92rem;
+  font-weight: 600;
+  padding: 0;
+  border: none;
+  background: none;
+  color: #505068;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.replayBtn:hover {
+  color: #8090b0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .done.show { animation: none; opacity: 1; }
+}

--- a/website/src/components/whypieagent/ColdStartRace.tsx
+++ b/website/src/components/whypieagent/ColdStartRace.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import styles from './ColdStartRace.module.css';
+
+interface Props {
+  standardTokens: number;
+  pieTokens: number;
+}
+
+const VLLM_DURATION = 3000; // ms
+const PIE_DURATION = 150;   // ms
+
+export default function ColdStartRace({ standardTokens, pieTokens }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [stdProgress, setVllmProgress] = useState(0); // 0..1
+  const [pieProgress, setPieProgress] = useState(0);
+  const [finished, setFinished] = useState(false);
+  const hasAutoPlayed = useRef(false);
+  const animRef = useRef<number | null>(null);
+
+  const play = useCallback(() => {
+    setVllmProgress(0);
+    setPieProgress(0);
+    setFinished(false);
+    let start: number | null = null;
+
+    const step = (ts: number) => {
+      if (!start) start = ts;
+      const elapsed = ts - start;
+      const vP = Math.min(elapsed / VLLM_DURATION, 1);
+      const pP = Math.min(elapsed / PIE_DURATION, 1);
+      setVllmProgress(vP);
+      setPieProgress(pP);
+      if (vP < 1) {
+        animRef.current = requestAnimationFrame(step);
+      } else {
+        setFinished(true);
+      }
+    };
+    if (animRef.current) cancelAnimationFrame(animRef.current);
+    animRef.current = requestAnimationFrame(step);
+  }, []);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !hasAutoPlayed.current) {
+          hasAutoPlayed.current = true;
+          play();
+        }
+      },
+      { threshold: 0.4 },
+    );
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [play]);
+
+  useEffect(() => {
+    return () => { if (animRef.current) cancelAnimationFrame(animRef.current); };
+  }, []);
+
+  const replay = useCallback(() => {
+    setTimeout(() => play(), 50);
+  }, [play]);
+
+  const stdCurrent = Math.round(stdProgress * standardTokens);
+  const pieCurrent = Math.round(pieProgress * pieTokens);
+  const stdDone = stdProgress >= 1;
+  const pieDone = pieProgress >= 1;
+
+  const cn = (...classes: (string | false | undefined)[]) =>
+    classes.filter(Boolean).join(' ');
+
+  return (
+    <div ref={ref} className={styles.outer}>
+      <div className={styles.container}>
+        {/* vLLM panel */}
+        <div className={styles.panel}>
+          <div className={styles.panelHeader}>
+            <span className={cn(styles.dot, styles.dotRed)} />
+            <span className={cn(styles.dot, styles.dotYellow)} />
+            <span className={cn(styles.dot, styles.dotGreen)} />
+            <span className={styles.panelTitle}>Standard Serving</span>
+          </div>
+          <div className={styles.panelBody}>
+            <div className={styles.label}>Prefilling system prompt...</div>
+            <div className={styles.progressTrack}>
+              <div
+                className={cn(styles.progressFill, styles.fillStd)}
+                style={{ width: `${stdProgress * 100}%` }}
+              />
+            </div>
+            <div className={styles.stats}>
+              <span className={styles.tokens}>
+                {stdCurrent.toLocaleString()}{' '}
+                <span className={styles.tokenLabel}>tokens</span>
+              </span>
+              <span className={cn(styles.done, stdDone && styles.show)}>
+                ready
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Pie panel */}
+        <div className={styles.panel}>
+          <div className={styles.panelHeader}>
+            <span className={cn(styles.dot, styles.dotRed)} />
+            <span className={cn(styles.dot, styles.dotYellow)} />
+            <span className={cn(styles.dot, styles.dotGreen)} />
+            <span className={styles.panelTitle}>Pie inferlet</span>
+          </div>
+          <div className={styles.panelBody}>
+            <div className={styles.label}>Loading cached KV state...</div>
+            <div className={styles.progressTrack}>
+              <div
+                className={cn(styles.progressFill, styles.fillPie)}
+                style={{ width: `${pieProgress * 100}%` }}
+              />
+            </div>
+            <div className={styles.stats}>
+              <span className={styles.tokens}>
+                {pieCurrent.toLocaleString()}{' '}
+                <span className={styles.tokenLabel}>tokens</span>
+              </span>
+              <span className={cn(styles.done, pieDone && styles.show)}>
+                ready
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className={cn(styles.replayRow, finished && styles.replayVisible)}>
+        <button className={styles.replayBtn} onClick={replay}>
+          &#8635; Replay
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/whypieagent/FairNotes.module.css
+++ b/website/src/components/whypieagent/FairNotes.module.css
@@ -1,0 +1,94 @@
+/* Fair Notes — dark theme */
+
+.wrapper {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.title {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: clamp(1.5rem, 2.5vw, 2rem);
+  font-weight: 700;
+  text-align: center;
+  margin: 0 0 2rem;
+  color: #f0f0f8;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+.card {
+  border: 1px solid #2a2a3a;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #12121a;
+}
+
+.cardHeader {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  width: 100%;
+  text-align: left;
+  font-family: inherit;
+  transition: background 0.15s ease;
+}
+
+.cardHeader:hover {
+  background: rgba(59, 130, 246, 0.05);
+}
+
+.chevron {
+  font-size: 0.85rem;
+  color: #4a4a60;
+  transition: transform 0.2s ease;
+  flex-shrink: 0;
+}
+
+.chevronOpen {
+  transform: rotate(90deg);
+}
+
+.cardTitle {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 0;
+  color: #e0e0e8;
+}
+
+.cardBody {
+  padding: 0 1.25rem 1.25rem;
+  color: #9090a8;
+  font-size: 0.92rem;
+  line-height: 1.65;
+}
+
+.cardBody ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+}
+
+.cardBody li {
+  margin-bottom: 0.4rem;
+}
+
+.cardBody li:last-child {
+  margin-bottom: 0;
+}
+
+.cardBody strong {
+  color: #c0c0d0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chevron { transition: none; }
+}

--- a/website/src/components/whypieagent/FairNotes.tsx
+++ b/website/src/components/whypieagent/FairNotes.tsx
@@ -1,0 +1,108 @@
+import { useState, ReactNode } from 'react';
+import styles from './FairNotes.module.css';
+
+interface NoteSection {
+  title: string;
+  content: ReactNode;
+}
+
+const NOTES: NoteSection[] = [
+  {
+    title: 'Where standard prefix caching is equally good',
+    content: (
+      <ul>
+        <li>
+          <strong>Same-session multi-turn:</strong> append-only conversation
+          history hits the prefix cache perfectly. Both systems reuse 100% of
+          prior KV.
+        </li>
+        <li>
+          <strong>Same-channel cross-session:</strong> when the system prompt
+          does not change between requests, standard prefix caching reuses the
+          full prefix just like Pie.
+        </li>
+        <li>
+          <strong>Append-only tool results:</strong> tool call outputs appended
+          after the system prompt extend the prefix without invalidation.
+          Standard caching handles this natively.
+        </li>
+      </ul>
+    ),
+  },
+  {
+    title: 'What we do NOT claim',
+    content: (
+      <ul>
+        <li>
+          <strong>Decode speed:</strong> Pie uses the same GPU decode path.
+          Token generation throughput is identical once prefill completes.
+        </li>
+        <li>
+          <strong>Steady-state advantage:</strong> for long-running single-session
+          workloads that never switch context, there is no measurable difference.
+        </li>
+        <li>
+          <strong>Free lunch:</strong> Pie inferlets add a thin coordination
+          layer. The overhead is small (~0.6ms per IPC round-trip) but nonzero.
+        </li>
+      </ul>
+    ),
+  },
+  {
+    title: 'Alternatives to Pie',
+    content: (
+      <ul>
+        <li>
+          <strong>Prompt reordering:</strong> an application could reorder its
+          own prompt to put dynamic sections at the end. Pie's inferlet does
+          this transparently without upstream changes.
+        </li>
+        <li>
+          <strong>CPU KV offloading:</strong> some inference systems support
+          offloading evicted KV blocks to CPU DRAM (~2s reload). Under no
+          memory pressure, both approaches retain KV equally.
+        </li>
+        <li>
+          <strong>Warm-up requests:</strong> sending a dummy request on cold
+          start populates the prefix cache. Pie's checkpoint approach works
+          across engine restarts without extra orchestration.
+        </li>
+      </ul>
+    ),
+  },
+];
+
+function CollapsibleNote({ title, content }: NoteSection) {
+  const [open, setOpen] = useState(false);
+  const cn = (...classes: (string | false | undefined)[]) =>
+    classes.filter(Boolean).join(' ');
+
+  return (
+    <div className={styles.card}>
+      <button
+        className={styles.cardHeader}
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+      >
+        <span className={cn(styles.chevron, open && styles.chevronOpen)}>
+          &#9654;
+        </span>
+        <h4 className={styles.cardTitle}>{title}</h4>
+      </button>
+      {open && <div className={styles.cardBody}>{content}</div>}
+    </div>
+  );
+}
+
+export default function FairNotes() {
+  return (
+    <div className={styles.wrapper}>
+      <h3 className={styles.title}>Honest Assessment</h3>
+      <div className={styles.grid}>
+        {NOTES.map((note) => (
+          <CollapsibleNote key={note.title} {...note} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/website/src/components/whypieagent/MultiSessionTimeline.module.css
+++ b/website/src/components/whypieagent/MultiSessionTimeline.module.css
@@ -1,0 +1,382 @@
+/* Case 3: Vertical progress + memory view */
+
+.wrapper {
+  max-width: 880px;
+  margin: 0 auto;
+}
+
+/* Memory row: two memory views side by side */
+.memRow {
+  display: flex;
+  gap: 0;
+  justify-content: center;
+}
+
+.memCol {
+  flex: 1;
+  max-width: 400px;
+}
+
+.memColSpacer {
+  width: 40px;
+  flex-shrink: 0;
+}
+
+.systemTitle {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: #9898b0;
+  text-align: center;
+  margin: 0 0 1rem;
+  letter-spacing: 0.02em;
+}
+
+/* Progress row: two timelines with time arrow between, top-aligned */
+.progressRow {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  margin-top: 1rem;
+}
+
+.progressCol {
+  flex: 1;
+  max-width: 400px;
+}
+
+.timeArrowCol {
+  width: 40px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+  align-self: stretch;
+}
+
+/* ─── Memory view ─── */
+
+.memoryView {
+  width: 100%;
+}
+
+.memTitle {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.65rem;
+  color: #606078;
+  text-align: center;
+  margin-bottom: 0.5rem;
+  letter-spacing: 0.03em;
+}
+
+.memSlots {
+  display: flex;
+  gap: 6px;
+}
+
+.memSlot {
+  flex: 1;
+  display: flex;
+  gap: 3px;
+}
+
+.memSlotLabel {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.6rem;
+  font-weight: 600;
+  writing-mode: horizontal-tb;
+  display: flex;
+  align-items: center;
+  padding-right: 4px;
+  flex-shrink: 0;
+}
+
+/* Session color themes for slot labels */
+.memSlotS1 .memSlotLabel { color: #8aaad0; }
+.memSlotS2 .memSlotLabel { color: #c0a080; }
+
+.memBlock {
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.55rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.12);
+  border: 1px dashed #22222e;
+  z-index: 0;
+  overflow: hidden;
+  position: relative;
+  background: #0e0e16;
+  transition: color 0.3s ease, border-color 0.3s ease;
+}
+
+.memBlockLabel {
+  position: relative;
+  z-index: 1;
+}
+
+/* Inner fill driven by --mem-fill and --mem-evict custom properties.
+   --mem-fill: 0-100% how much is filled (grows from left)
+   --mem-evict: 0-100% how much is evicted (clips from left) */
+.memBlock::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  border-radius: 2px;
+  z-index: 0;
+  clip-path: inset(0 calc(100% - var(--mem-fill, 0%)) 0 var(--mem-evict, 0%));
+}
+
+.memBlockSys {
+  height: 36px;
+  flex: 1;
+}
+
+.memBlockConv {
+  height: 36px;
+  flex: 2.5;
+}
+
+.memBlock.memFilled {
+  border-style: solid;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+/* Session 1 memory colors (blue tones) */
+.memS1Sys.memFilled { border-color: #2a3a60; }
+.memS1Sys::after { background: #1a2848; }
+
+.memS1Conv.memFilled { border-color: #263050; }
+.memS1Conv::after { background: #162040; }
+
+/* Session 2 memory colors (warm tones) */
+.memS2Sys.memFilled { border-color: #3a3228; }
+.memS2Sys::after { background: #2a2218; }
+
+.memS2Conv.memFilled { border-color: #322e26; }
+.memS2Conv::after { background: #221e16; }
+
+/* Section sub-header between memory and timeline */
+.sectionTitle {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.62rem;
+  color: #606078;
+  letter-spacing: 0.03em;
+  margin-top: 0.25rem;
+}
+
+/* ─── Vertical timeline ─── */
+
+.timeline {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  border-radius: 6px;
+  overflow: hidden;
+  position: relative;
+}
+
+.phase {
+  position: relative;
+  overflow: hidden;
+}
+
+.phaseBg {
+  position: absolute;
+  inset: 0;
+  background: #10101a;
+}
+
+.phaseFill {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+}
+
+.phaseLabel {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding: 0 0.6rem;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.68rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  opacity: 0.2;
+  transition: opacity 0.3s ease;
+}
+
+.phaseLabelVisible {
+  opacity: 1;
+}
+
+/* Session label colors */
+.phaseS1 .phaseLabel { color: rgba(138, 170, 208, 0.8); }
+.phaseS2 .phaseLabel { color: rgba(192, 160, 128, 0.8); }
+
+.importedTag {
+  color: #7ec9a0;
+  font-weight: 600;
+}
+
+.cacheHit {
+  position: absolute;
+  right: 0.6rem;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 1;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.62rem;
+  font-weight: 600;
+  color: #7ec9a0;
+}
+
+/* Phase fill colors — session-themed */
+.phaseSysS1 { background: #1a2848; }
+.phaseConvS1 { background: #162040; }
+.phaseReprefillS1 {
+  background: repeating-linear-gradient(
+    -45deg,
+    #1a2848,
+    #1a2848 4px,
+    #0e1830 4px,
+    #0e1830 8px
+  );
+}
+.phaseImportS1 { background: #1a3a28; }
+
+.phaseSysS2 { background: #2a2218; }
+.phaseConvS2 { background: #221e16; }
+.phaseReprefillS2 { background: #3a2018; }
+.phaseImportS2 { background: #1a3a28; }
+
+.doneLabel {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #7ec9a0;
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* ─── Time direction arrow ─── */
+
+.timeArrow {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.75rem;
+  color: #404058;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.6rem;
+  letter-spacing: 0.04em;
+}
+
+.timeArrowLine {
+  width: 1px;
+  height: 24px;
+  background: #404058;
+  position: relative;
+}
+
+.timeArrowLine::after {
+  content: '';
+  position: absolute;
+  bottom: -1px;
+  left: -3px;
+  width: 0;
+  height: 0;
+  border-top: 5px solid #404058;
+  border-left: 3.5px solid transparent;
+  border-right: 3.5px solid transparent;
+}
+
+/* ─── Legend ─── */
+
+.legend {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.legendItem {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.68rem;
+  color: #787890;
+}
+
+.legendDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.dotSys { background: #1a2848; border: 1px solid #2a3a60; }
+.dotConv { background: #162040; border: 1px solid #263050; }
+.dotReprefill {
+  background: repeating-linear-gradient(
+    -45deg,
+    #1a2848,
+    #1a2848 2px,
+    #0e1830 2px,
+    #0e1830 4px
+  );
+  border: 1px solid #2a3a60;
+}
+.dotImport { background: #1a3a28; border: 1px solid #2a5a38; }
+
+/* ─── Replay ─── */
+
+.replayRow {
+  margin-top: 0.75rem;
+  text-align: center;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  pointer-events: none;
+}
+
+.replayRow.replayVisible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.replayBtn {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.92rem;
+  font-weight: 600;
+  padding: 0;
+  border: none;
+  background: none;
+  color: #505068;
+  cursor: pointer;
+  transition: color 0.15s ease;
+}
+
+.replayBtn:hover {
+  color: #8090b0;
+}

--- a/website/src/components/whypieagent/MultiSessionTimeline.tsx
+++ b/website/src/components/whypieagent/MultiSessionTimeline.tsx
@@ -1,0 +1,384 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import styles from './MultiSessionTimeline.module.css';
+
+interface Props {
+  sessions?: number;
+}
+
+/*
+  Vertical progress + memory view, side by side for Standard vs Pie.
+
+  Timeline (top to bottom):
+    Phase 1: Session 1 — prefill sys prompt + conversation
+    Phase 2: Session 2 — arrives, evicts session 1
+    Phase 3: Session 1 — returns, needs sys prompt again
+
+  Memory view shows KV cache state at each phase:
+    Standard: Session 2 evicts ALL of Session 1
+    Pie: Session 2 evicts conversation but sys prompt stays (pinned)
+
+  On Session 1 return:
+    Standard: re-prefill sys prompt (slow)
+    Pie: cache hit on sys prompt (instant)
+*/
+
+interface Phase {
+  label: string;
+  session: 1 | 2;
+  type: 'sysprompt' | 'conversation' | 'reprefill' | 'import';
+  /** Duration in time units */
+  time: number;
+}
+
+const STD_PHASES: Phase[] = [
+  { label: 'S1: prefill sys prompt',  session: 1, type: 'sysprompt',    time: 10 },
+  { label: 'S1: conversation',        session: 1, type: 'conversation', time: 18 },
+  { label: 'S2: prefill sys prompt',  session: 2, type: 'sysprompt',    time: 10 },
+  { label: 'S2: conversation',        session: 2, type: 'conversation', time: 18 },
+  { label: 'S1: re-prefill sys prompt', session: 1, type: 'reprefill', time: 10 },
+  { label: 'S1: conversation',        session: 1, type: 'conversation', time: 14 },
+];
+// total = 80
+
+const PIE_PHASES: Phase[] = [
+  { label: 'S1: sys prompt (imported)', session: 1, type: 'import',       time: 3 },
+  { label: 'S1: conversation',        session: 1, type: 'conversation', time: 18 },
+  { label: 'S2: sys prompt (imported)', session: 2, type: 'import',     time: 3 },
+  { label: 'S2: conversation',        session: 2, type: 'conversation', time: 18 },
+  { label: 'S1: sys prompt (imported)', session: 1, type: 'import',     time: 3 },
+  { label: 'S1: conversation',        session: 1, type: 'conversation', time: 14 },
+];
+// total = 59
+
+const STD_TOTAL = STD_PHASES.reduce((s, p) => s + p.time, 0);
+const PIE_TOTAL = PIE_PHASES.reduce((s, p) => s + p.time, 0); // 59
+const ANIM_DURATION = 8000;
+
+// Memory block state: fill = right edge (0..1), evict = left edge (0..1)
+// fill=1, evict=0 → fully visible. fill=1, evict=0.5 → right half visible (evicting from left).
+// fill=0.5, evict=0 → left half visible (filling from left).
+interface MemBlock { fill: number; evict: number; }
+interface MemState {
+  s1Sys: MemBlock;
+  s1Conv: MemBlock;
+  s2Sys: MemBlock;
+  s2Conv: MemBlock;
+}
+const EMPTY: MemBlock = { fill: 0, evict: 0 };
+const FULL: MemBlock = { fill: 1, evict: 0 };
+
+function getMemState(
+  phases: Phase[],
+  currentIdx: number,
+  progress: number,
+  isPie: boolean,
+): MemState {
+  // Pie: both sys prompts pre-warmed from start
+  const state: MemState = isPie
+    ? { s1Sys: { ...FULL }, s1Conv: { ...EMPTY }, s2Sys: { ...FULL }, s2Conv: { ...EMPTY } }
+    : { s1Sys: { ...EMPTY }, s1Conv: { ...EMPTY }, s2Sys: { ...EMPTY }, s2Conv: { ...EMPTY } };
+
+  for (let i = 0; i <= currentIdx && i < phases.length; i++) {
+    const p = phases[i];
+    const isActive = i === currentIdx;
+    const t = isActive ? progress : 1;
+
+    // S1 first round — sysprompt phase: sys fills gradually
+    if (p.session === 1 && i < 4 && p.type === 'sysprompt' && !isPie) {
+      state.s1Sys = isActive
+        ? { fill: Math.min(1, t * 1.2), evict: 0 }
+        : { fill: 1, evict: 0 };
+    }
+    // S1 first round — conversation phase: sys done, conv fills gradually
+    if (p.session === 1 && i < 4 && p.type === 'conversation') {
+      state.s1Sys = { fill: 1, evict: 0 };
+      state.s1Conv = isActive
+        ? { fill: Math.min(1, t * 1.5), evict: 0 }
+        : { fill: 1, evict: 0 };
+    }
+
+    // S2 sysprompt phase: sys fills gradually (Standard only, Pie already has it)
+    if (p.session === 2 && p.type === 'sysprompt' && !isPie) {
+      state.s2Sys = isActive
+        ? { fill: Math.min(1, t * 1.2), evict: 0 }
+        : { fill: 1, evict: 0 };
+    }
+    // S2 import phase (Pie): sys already cached, just a quick import
+    if (p.session === 2 && p.type === 'import') {
+      // sys already full (pre-warmed), nothing to fill
+    }
+
+    // S2 conversation — S2 conv fills, then S1 eviction starts at t=0.3
+    if (p.session === 2 && p.type === 'conversation') {
+      state.s2Sys = { fill: 1, evict: 0 };
+      state.s2Conv = isActive
+        ? { fill: Math.min(1, t * 1.5), evict: 0 }
+        : { fill: 1, evict: 0 };
+
+      const evictT = Math.max(0, t - 0.3) / 0.7;
+      if (isPie) {
+        state.s1Conv = { fill: 1, evict: Math.min(1, evictT * 2) };
+      } else {
+        state.s1Sys = { fill: 1, evict: Math.min(1, evictT * 2.5) };
+        state.s1Conv = { fill: 1, evict: Math.min(0.85, Math.max(0, evictT - 0.3) * 1.5) };
+      }
+    }
+
+    // S1 re-prefill phase (Standard): evict old S1 conv sliver first,
+    // then evict S2 sys to make room, while S1 sys fills
+    if (i >= 4 && p.session === 1 && p.type === 'reprefill') {
+      // S1 remaining conv sliver evicts first (oldest)
+      state.s1Conv = { fill: 1, evict: Math.min(1, (isActive ? t : 1) * 3) };
+      // S2 sys starts evicting as S1 sys needs the space
+      const s2SysEvict = Math.min(1, Math.max(0, (isActive ? t : 1) - 0.2) * 2);
+      state.s2Sys = { fill: 1, evict: s2SysEvict };
+      // S1 sys fills gradually
+      state.s1Sys = isActive
+        ? { fill: Math.min(1, t * 1.2), evict: 0 }
+        : { fill: 1, evict: 0 };
+    }
+
+    // S1 import phase (Pie, 3rd round): sys already cached, just evict S2 conv
+    if (i >= 4 && p.session === 1 && p.type === 'import') {
+      // Pie: S2 conv starts evicting to make room for S1 conv
+      state.s2Conv = { fill: 1, evict: Math.min(0.5, (isActive ? t : 1) * 1) };
+    }
+
+    // S1 returns — conversation phase
+    if (i >= 4 && p.session === 1 && p.type === 'conversation') {
+      state.s1Sys = { fill: 1, evict: 0 };
+      state.s1Conv = isActive
+        ? { fill: Math.min(1, t * 1.5), evict: 0 }
+        : { fill: 1, evict: 0 };
+
+      // Continue evicting S2 as S1 conv grows
+      const evictT = Math.max(0, t - 0.1) / 0.9;
+      if (isPie) {
+        // Pie: finish evicting S2 conv
+        state.s2Conv = { fill: 1, evict: Math.min(1, 0.5 + evictT * 0.5) };
+      } else {
+        // Standard: S2 sys already evicted during reprefill. Now S2 conv evicts.
+        state.s2Sys = { fill: 1, evict: 1 }; // fully gone
+        state.s2Conv = { fill: 1, evict: Math.min(0.85, evictT * 1.5) };
+      }
+    }
+  }
+  return state;
+}
+
+// Map time to phase index and progress within phase
+function timeToPhaseInfo(phases: Phase[], totalTime: number, clock: number) {
+  const t = Math.min(clock, totalTime);
+  let remaining = t;
+  for (let i = 0; i < phases.length; i++) {
+    if (remaining <= phases[i].time) {
+      return { index: i, progress: remaining / phases[i].time };
+    }
+    remaining -= phases[i].time;
+  }
+  return { index: phases.length - 1, progress: 1 };
+}
+
+export default function MultiSessionTimeline(_props: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [clock, setClock] = useState(0); // 0..STD_TOTAL
+  const [finished, setFinished] = useState(false);
+  const hasAutoPlayed = useRef(false);
+  const animRef = useRef<number | null>(null);
+
+  const play = useCallback(() => {
+    setClock(0);
+    setFinished(false);
+    let start: number | null = null;
+    const step = (ts: number) => {
+      if (!start) start = ts;
+      const p = Math.min((ts - start) / ANIM_DURATION, 1) * STD_TOTAL;
+      setClock(p);
+      if (p < STD_TOTAL) {
+        animRef.current = requestAnimationFrame(step);
+      } else {
+        setFinished(true);
+      }
+    };
+    if (animRef.current) cancelAnimationFrame(animRef.current);
+    animRef.current = requestAnimationFrame(step);
+  }, []);
+
+  useEffect(() => {
+    if (!ref.current) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !hasAutoPlayed.current) {
+          hasAutoPlayed.current = true;
+          play();
+        }
+      },
+      { threshold: 0.3 },
+    );
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [play]);
+
+  useEffect(() => {
+    return () => { if (animRef.current) cancelAnimationFrame(animRef.current); };
+  }, []);
+
+  const stdInfo = timeToPhaseInfo(STD_PHASES, STD_TOTAL, clock);
+  const pieInfo = timeToPhaseInfo(PIE_PHASES, PIE_TOTAL, Math.min(clock, PIE_TOTAL));
+  const pieDone = clock >= PIE_TOTAL;
+
+  const stdMem = getMemState(STD_PHASES, stdInfo.index, stdInfo.progress, false);
+  const pieMem = getMemState(PIE_PHASES, pieInfo.index, pieInfo.progress, true);
+
+  const cn = (...c: (string | false | undefined)[]) => c.filter(Boolean).join(' ');
+
+  const phaseClass = (type: Phase['type'], session: 1 | 2) => {
+    if (type === 'sysprompt') return session === 1 ? styles.phaseSysS1 : styles.phaseSysS2;
+    if (type === 'conversation') return session === 1 ? styles.phaseConvS1 : styles.phaseConvS2;
+    if (type === 'reprefill') return styles.phaseReprefillS1;
+    if (type === 'import') return session === 1 ? styles.phaseSysS1 : styles.phaseSysS2;
+    return '';
+  };
+
+  const sessionClass = (session: 1 | 2) => session === 1 ? styles.phaseS1 : styles.phaseS2;
+
+  const renderTimeline = (phases: Phase[], total: number, info: { index: number; progress: number }, _done: boolean) => {
+    // Height proportional to total time — Standard is taller, Pie is shorter
+    const heightPx = Math.round((total / STD_TOTAL) * 700);
+    return (
+      <div className={styles.timeline} style={{ height: `${heightPx}px` }}>
+        {phases.map((p, i) => {
+          const heightPct = (p.time / total) * 100;
+          const isPast = i < info.index || _done;
+          const isActive = i === info.index && !_done;
+          const isFuture = !isPast && !isActive;
+
+          // Continuous fill: past=100%, active=partial, future=0%
+          const fillPct = isPast ? 100 : isActive ? info.progress * 100 : 0;
+
+          return (
+            <div
+              key={i}
+              className={cn(styles.phase, sessionClass(p.session))}
+              style={{ height: `${heightPct}%` }}
+            >
+              {/* Background (unfilled / future) */}
+              <div className={styles.phaseBg} />
+              {/* Fill overlay — grows from top */}
+              <div
+                className={cn(styles.phaseFill, phaseClass(p.type, p.session))}
+                style={{ height: `${fillPct}%` }}
+              />
+              {/* Label — highlight (imported) in green */}
+              <span className={cn(styles.phaseLabel, (isPast || isActive) && styles.phaseLabelVisible)}>
+                {p.label.includes('(imported)')
+                  ? <>{p.label.replace(' (imported)', '')}<span className={styles.importedTag}>&nbsp;(imported)</span></>
+                  : p.label
+                }
+              </span>
+              {p.type === 'import' && isPast && (
+                <span className={styles.cacheHit}>cache hit!</span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const renderMemBlock = (block: MemBlock, type: 'sys' | 'conv', sessionClass: string) => {
+    const hasContent = block.fill > 0.01 && block.evict < 0.99;
+    return (
+      <div
+        className={cn(
+          styles.memBlock,
+          type === 'sys' ? styles.memBlockSys : styles.memBlockConv,
+          sessionClass,
+          hasContent && styles.memFilled,
+        )}
+        style={{
+          '--mem-fill': `${Math.round(block.fill * 100)}%`,
+          '--mem-evict': `${Math.round(block.evict * 100)}%`,
+        } as React.CSSProperties}
+      >
+        <span className={styles.memBlockLabel}>{type === 'sys' ? 'sys' : 'conv'}</span>
+      </div>
+    );
+  };
+
+  const renderMemory = (mem: MemState, label: string) => (
+    <div className={styles.memoryView}>
+      <div className={styles.memTitle}>{label}</div>
+      <div className={styles.memSlots}>
+        <div className={cn(styles.memSlot, styles.memSlotS1)}>
+          <div className={styles.memSlotLabel}>S1</div>
+          {renderMemBlock(mem.s1Sys, 'sys', styles.memS1Sys)}
+          {renderMemBlock(mem.s1Conv, 'conv', styles.memS1Conv)}
+        </div>
+        <div className={cn(styles.memSlot, styles.memSlotS2)}>
+          <div className={styles.memSlotLabel}>S2</div>
+          {renderMemBlock(mem.s2Sys, 'sys', styles.memS2Sys)}
+          {renderMemBlock(mem.s2Conv, 'conv', styles.memS2Conv)}
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <div ref={ref} className={styles.wrapper}>
+      {/* Memory views side by side */}
+      <div className={styles.memRow}>
+        <div className={styles.memCol}>
+          <h4 className={styles.systemTitle}>Standard Serving</h4>
+          {renderMemory(stdMem, 'KV Cache')}
+        </div>
+        <div className={styles.memColSpacer} />
+        <div className={styles.memCol}>
+          <h4 className={styles.systemTitle}>Pie</h4>
+          {renderMemory(pieMem, 'KV Cache')}
+        </div>
+      </div>
+
+      {/* Progress timelines with time arrow in between, bottom-aligned */}
+      <div className={styles.progressRow}>
+        <div className={styles.progressCol}>
+          <div className={styles.sectionTitle}>Progress</div>
+          {renderTimeline(STD_PHASES, STD_TOTAL, stdInfo, false)}
+        </div>
+
+        <div className={styles.timeArrowCol}>
+          <div className={styles.timeArrow}>
+            <span>time</span>
+            <div className={styles.timeArrowLine} />
+          </div>
+        </div>
+
+        <div className={styles.progressCol}>
+          <div className={styles.sectionTitle}>Progress</div>
+          {renderTimeline(PIE_PHASES, PIE_TOTAL, pieInfo, pieDone)}
+        </div>
+      </div>
+
+      {/* Legend */}
+      <div className={styles.legend}>
+        <div className={styles.legendItem}>
+          <span className={cn(styles.legendDot, styles.dotSys)} /> System prompt
+        </div>
+        <div className={styles.legendItem}>
+          <span className={cn(styles.legendDot, styles.dotConv)} /> Conversation
+        </div>
+        <div className={styles.legendItem}>
+          <span className={cn(styles.legendDot, styles.dotReprefill)} /> Re-prefill
+        </div>
+        <div className={styles.legendItem}>
+          <span className={cn(styles.legendDot, styles.dotImport)} /> KV import
+        </div>
+      </div>
+
+      {/* &#8635; Replay */}
+      <div className={cn(styles.replayRow, finished && styles.replayVisible)}>
+        <button className={styles.replayBtn} onClick={play}>&#8635; Replay</button>
+      </div>
+    </div>
+  );
+}

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -33,3 +33,44 @@
 }
 
 /* src/css/custom.css */
+
+/* === /whypieagent dark theme: re-skin navbar + footer to match page === */
+html.whypieagent-dark {
+  background: #0a0a0f;
+}
+html.whypieagent-dark body {
+  background: #0a0a0f;
+}
+html.whypieagent-dark .navbar {
+  background: #0a0a0f;
+  border-bottom: 1px solid #2a2a3a;
+  box-shadow: none;
+}
+html.whypieagent-dark .navbar__title,
+html.whypieagent-dark .navbar__link,
+html.whypieagent-dark .navbar__brand,
+html.whypieagent-dark .navbar__toggle {
+  color: #e0e0e8;
+}
+html.whypieagent-dark .navbar__link:hover,
+html.whypieagent-dark .navbar__link--active {
+  color: #f48b69;
+}
+html.whypieagent-dark .navbar-sidebar,
+html.whypieagent-dark .navbar-sidebar__brand {
+  background: #0a0a0f;
+  color: #e0e0e8;
+}
+html.whypieagent-dark .footer {
+  background: #0a0a0f;
+  color: #a8a8b3;
+  border-top: 1px solid #2a2a3a;
+}
+html.whypieagent-dark .footer a,
+html.whypieagent-dark .footer__link-item,
+html.whypieagent-dark .footer__title {
+  color: #e0e0e8;
+}
+html.whypieagent-dark .footer__copyright {
+  color: #808090;
+}

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -34,43 +34,43 @@
 
 /* src/css/custom.css */
 
-/* === /whypieagent dark theme: re-skin navbar + footer to match page === */
-html.whypieagent-dark {
+/* === /whypieagent dark theme: re-skin navbar + footer to match page ===
+   Scoped to body.whypieagent-dark because Docusaurus actively manages the
+   <html> className on route changes and clobbers any class added there. */
+body.whypieagent-dark,
+body.whypieagent-dark html {
   background: #0a0a0f;
 }
-html.whypieagent-dark body {
-  background: #0a0a0f;
-}
-html.whypieagent-dark .navbar {
+body.whypieagent-dark .navbar {
   background: #0a0a0f;
   border-bottom: 1px solid #2a2a3a;
   box-shadow: none;
 }
-html.whypieagent-dark .navbar__title,
-html.whypieagent-dark .navbar__link,
-html.whypieagent-dark .navbar__brand,
-html.whypieagent-dark .navbar__toggle {
+body.whypieagent-dark .navbar__title,
+body.whypieagent-dark .navbar__link,
+body.whypieagent-dark .navbar__brand,
+body.whypieagent-dark .navbar__toggle {
   color: #e0e0e8;
 }
-html.whypieagent-dark .navbar__link:hover,
-html.whypieagent-dark .navbar__link--active {
+body.whypieagent-dark .navbar__link:hover,
+body.whypieagent-dark .navbar__link--active {
   color: #f48b69;
 }
-html.whypieagent-dark .navbar-sidebar,
-html.whypieagent-dark .navbar-sidebar__brand {
+body.whypieagent-dark .navbar-sidebar,
+body.whypieagent-dark .navbar-sidebar__brand {
   background: #0a0a0f;
   color: #e0e0e8;
 }
-html.whypieagent-dark .footer {
+body.whypieagent-dark .footer {
   background: #0a0a0f;
   color: #a8a8b3;
   border-top: 1px solid #2a2a3a;
 }
-html.whypieagent-dark .footer a,
-html.whypieagent-dark .footer__link-item,
-html.whypieagent-dark .footer__title {
+body.whypieagent-dark .footer a,
+body.whypieagent-dark .footer__link-item,
+body.whypieagent-dark .footer__title {
   color: #e0e0e8;
 }
-html.whypieagent-dark .footer__copyright {
+body.whypieagent-dark .footer__copyright {
   color: #808090;
 }

--- a/website/src/pages/whypieagent.module.css
+++ b/website/src/pages/whypieagent.module.css
@@ -1,0 +1,173 @@
+/* === Layout (scoped to this page; the Docusaurus theme is preserved elsewhere) === */
+
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: #0a0a0f;
+  color: #e0e0e8;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
+    sans-serif;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.page *,
+.page *::before,
+.page *::after {
+  box-sizing: border-box;
+}
+
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: #0a0a0f;
+  color: #e0e0e8;
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 1rem;
+}
+
+/* === Header === */
+
+.header {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding: 1.25rem 2rem;
+  border-bottom: 1px solid #2a2a3a;
+  background: #0a0a0f;
+}
+
+.logo {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: #3b82f6;
+  letter-spacing: -0.02em;
+}
+
+.logoSub {
+  font-size: 0.82rem;
+  color: #6b6b80;
+  letter-spacing: 0.02em;
+}
+
+/* === Hero === */
+
+.hero {
+  text-align: center;
+  padding: clamp(5rem, 10vw, 9rem) 1.5rem clamp(4rem, 8vw, 7rem);
+  background: radial-gradient(
+    ellipse 80% 60% at 50% 100%,
+    rgba(59, 130, 246, 0.08) 0%,
+    transparent 70%
+  );
+}
+
+.heroTitle {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  font-weight: 900;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  color: #f0f0f8;
+}
+
+.accent {
+  color: #3b82f6;
+}
+
+.heroSubtitle {
+  font-size: clamp(1rem, 1.4vw, 1.15rem);
+  max-width: 58ch;
+  margin: 1.5rem auto 0;
+  color: #9090a8;
+  line-height: 1.75;
+}
+
+/* === Case Sections === */
+
+.caseSection {
+  padding: 14rem 0;
+}
+
+.caseSectionAlt {
+  padding: 14rem 0;
+  background: #0e0e16;
+}
+
+.caseHeader {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.caseLabel {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #3b82f6;
+  margin: 0 0 0.5rem;
+}
+
+.caseTitle {
+  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', monospace;
+  font-size: clamp(1.5rem, 2.5vw, 2rem);
+  font-weight: 700;
+  color: #f0f0f8;
+  margin: 0 0 0.75rem;
+}
+
+.caseDescription {
+  color: #9090a8;
+  max-width: 55ch;
+  margin: 0 auto;
+  line-height: 1.65;
+}
+
+.fairNote {
+  margin: 2rem auto 0;
+  max-width: 600px;
+  font-size: 0.78rem;
+  color: #505068;
+  line-height: 1.55;
+}
+
+.fairNote strong {
+  color: #606078;
+  font-weight: 500;
+}
+
+/* === Footer === */
+
+.footer {
+  text-align: center;
+  padding: 3rem 1rem 2rem;
+  border-top: 1px solid #1a1a28;
+  color: #6b6b80;
+  font-size: 0.85rem;
+  margin-top: auto;
+}
+
+.disclaimerSection {
+  padding: 2rem 0;
+}
+
+.disclaimer {
+  max-width: 620px;
+  margin: 0 auto;
+  font-size: 0.72rem;
+  color: #404058;
+  line-height: 1.6;
+  text-align: center;
+}

--- a/website/src/pages/whypieagent.tsx
+++ b/website/src/pages/whypieagent.tsx
@@ -48,6 +48,13 @@ function WhyPieAgentContent() {
   const [data, setData] = useState<DemoData | null>(null);
 
   useEffect(() => {
+    document.documentElement.classList.add('whypieagent-dark');
+    return () => {
+      document.documentElement.classList.remove('whypieagent-dark');
+    };
+  }, []);
+
+  useEffect(() => {
     fetch(dataUrl)
       .then((r) => r.json())
       .then(setData)
@@ -155,9 +162,8 @@ function WhyPieAgentContent() {
               approaches. They do not represent exact measurements or benchmarks.
               Actual performance varies by model, hardware, workload, and
               configuration. Token counts are derived from prompt structure
-              analysis of a real agentic system prompt. Timing proportions in
-              Case 3 are schematic. Measured benchmarks will be published
-              separately.
+              analysis of a real agentic system prompt. Timing proportions
+              are schematic.
             </p>
           </div>
         </section>

--- a/website/src/pages/whypieagent.tsx
+++ b/website/src/pages/whypieagent.tsx
@@ -48,9 +48,18 @@ function WhyPieAgentContent() {
   const [data, setData] = useState<DemoData | null>(null);
 
   useEffect(() => {
-    document.documentElement.classList.add('whypieagent-dark');
+    const CLS = 'whypieagent-dark';
+    const ensure = () => {
+      if (!document.body.classList.contains(CLS)) {
+        document.body.classList.add(CLS);
+      }
+    };
+    ensure();
+    const obs = new MutationObserver(ensure);
+    obs.observe(document.body, { attributes: true, attributeFilter: ['class'] });
     return () => {
-      document.documentElement.classList.remove('whypieagent-dark');
+      obs.disconnect();
+      document.body.classList.remove(CLS);
     };
   }, []);
 

--- a/website/src/pages/whypieagent.tsx
+++ b/website/src/pages/whypieagent.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from 'react';
+import Layout from '@theme/Layout';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import styles from './whypieagent.module.css';
+import ColdStartRace from '@site/src/components/whypieagent/ColdStartRace';
+import ChannelSwitchDiagram from '@site/src/components/whypieagent/ChannelSwitchDiagram';
+import MultiSessionTimeline from '@site/src/components/whypieagent/MultiSessionTimeline';
+import BenchmarkResults from '@site/src/components/whypieagent/BenchmarkResults';
+
+interface DemoData {
+  total_tokens: number;
+  sections: Array<{
+    name: string;
+    token_start: number;
+    token_end: number;
+    tokens: number;
+    stability: 'static' | 'dynamic';
+  }>;
+  divergence_original: number;
+  divergence_reordered: number;
+  case1: {
+    vllm_prefill_tokens: number;
+    pie_prefill_tokens: number;
+  };
+  case2: {
+    vllm_reprefill_tokens: number;
+    pie_reprefill_tokens: number;
+    reduction_pct: number;
+  };
+  case3: {
+    sessions: number;
+  };
+  benchmarks: null | {
+    platform?: string;
+    date?: string;
+    rows: Array<{
+      scenario: string;
+      standard: string;
+      pie: string;
+      improvement: string;
+    }>;
+  };
+}
+
+function WhyPieAgentContent() {
+  const dataUrl = useBaseUrl('/data/demo-data.json');
+  const [data, setData] = useState<DemoData | null>(null);
+
+  useEffect(() => {
+    fetch(dataUrl)
+      .then((r) => r.json())
+      .then(setData)
+      .catch(console.error);
+  }, [dataUrl]);
+
+  if (!data) {
+    return (
+      <div className={styles.loading}>
+        <span>Loading...</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.page}>
+      <section className={styles.hero}>
+        <h1 className={styles.heroTitle}>
+          Smarter KV Caching for <span className={styles.accent}>AI Agents</span>
+        </h1>
+        <p className={styles.heroSubtitle}>
+          Agentic workloads switch contexts, juggle sessions, and restart often.
+          Pie keeps the right data in cache so your model spends less time
+          re-computing what it already knows.
+        </p>
+      </section>
+
+      <main>
+        <section className={styles.caseSection}>
+          <div className={styles.container}>
+            <div className={styles.caseHeader}>
+              <p className={styles.caseLabel}>Case 1</p>
+              <h2 className={styles.caseTitle}>Cold Start</h2>
+              <p className={styles.caseDescription}>
+                The system prompt is already cached before the first request arrives.
+              </p>
+            </div>
+
+            <ColdStartRace
+              standardTokens={data.case1.vllm_prefill_tokens}
+              pieTokens={data.case1.pie_prefill_tokens}
+            />
+          </div>
+        </section>
+
+        <section className={styles.caseSectionAlt}>
+          <div className={styles.container}>
+            <div className={styles.caseHeader}>
+              <p className={styles.caseLabel}>Case 2</p>
+              <h2 className={styles.caseTitle}>Channel Switch</h2>
+              <p className={styles.caseDescription}>
+                A small change in the middle of the prompt invalidates everything after it.
+                Reordering the prompt keeps the cache stable.
+              </p>
+            </div>
+
+            <ChannelSwitchDiagram
+              sections={data.sections}
+              totalTokens={data.total_tokens}
+              divergenceOriginal={data.divergence_original}
+              divergenceReordered={data.divergence_reordered}
+              standardReprefill={data.case2.vllm_reprefill_tokens}
+              pieReprefill={data.case2.pie_reprefill_tokens}
+              reductionPct={data.case2.reduction_pct}
+            />
+
+            <p className={styles.fairNote}>
+              <strong>Note:</strong> the upstream application could reorder
+              its prompt to achieve the same effect. Pie's inferlet does this
+              transparently without requiring upstream changes.
+            </p>
+          </div>
+        </section>
+
+        <section className={styles.caseSection}>
+          <div className={styles.container}>
+            <div className={styles.caseHeader}>
+              <p className={styles.caseLabel}>Case 3</p>
+              <h2 className={styles.caseTitle}>Session Resume Under Memory Pressure</h2>
+              <p className={styles.caseDescription}>
+                When sessions compete for GPU memory, idle KV gets evicted.
+                Pie pins the system prompt so it never needs re-prefilling.
+              </p>
+            </div>
+
+            <MultiSessionTimeline />
+          </div>
+        </section>
+
+        <section className={styles.caseSectionAlt}>
+          <div className={styles.container}>
+            <BenchmarkResults
+              case1={data.case1}
+              case2={data.case2}
+              benchmarks={data.benchmarks}
+            />
+          </div>
+        </section>
+
+        <section className={styles.disclaimerSection}>
+          <div className={styles.container}>
+            <p className={styles.disclaimer}>
+              The visualizations on this page are illustrative diagrams designed
+              to aid understanding of structural differences between serving
+              approaches. They do not represent exact measurements or benchmarks.
+              Actual performance varies by model, hardware, workload, and
+              configuration. Token counts are derived from prompt structure
+              analysis of a real agentic system prompt. Timing proportions in
+              Case 3 are schematic. Measured benchmarks will be published
+              separately.
+            </p>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}
+
+export default function WhyPieAgent(): JSX.Element {
+  return (
+    <Layout
+      title="Why Pie for Agents"
+      description="Smarter KV caching for AI agents: how Pie handles cold start, channel switch, and multi-session workloads."
+    >
+      <BrowserOnly>{() => <WhyPieAgentContent />}</BrowserOnly>
+    </Layout>
+  );
+}

--- a/website/static/data/demo-data.json
+++ b/website/static/data/demo-data.json
@@ -1,0 +1,210 @@
+{
+  "total_tokens": 7059,
+  "total_chars": 28236,
+  "sections": [
+    {
+      "name": "## Tooling",
+      "token_start": 13,
+      "token_end": 1049,
+      "tokens": 1035,
+      "stability": "static"
+    },
+    {
+      "name": "## Tool Call Style",
+      "token_start": 1049,
+      "token_end": 1312,
+      "tokens": 263,
+      "stability": "static"
+    },
+    {
+      "name": "## Safety",
+      "token_start": 1312,
+      "token_end": 1452,
+      "tokens": 140,
+      "stability": "static"
+    },
+    {
+      "name": "## OpenClaw CLI Quick Reference",
+      "token_start": 1452,
+      "token_end": 1542,
+      "tokens": 89,
+      "stability": "static"
+    },
+    {
+      "name": "## Skills (mandatory)",
+      "token_start": 1542,
+      "token_end": 2297,
+      "tokens": 755,
+      "stability": "static"
+    },
+    {
+      "name": "## Memory Recall",
+      "token_start": 2297,
+      "token_end": 2383,
+      "tokens": 85,
+      "stability": "static"
+    },
+    {
+      "name": "## OpenClaw Self-Update + ## Workspace",
+      "token_start": 2383,
+      "token_end": 2643,
+      "tokens": 260,
+      "stability": "static"
+    },
+    {
+      "name": "## Documentation + ## Current Date & Time + ## Workspace Files (injected)",
+      "token_start": 2643,
+      "token_end": 2784,
+      "tokens": 141,
+      "stability": "static"
+    },
+    {
+      "name": "## Reply Tags",
+      "token_start": 2784,
+      "token_end": 2927,
+      "tokens": 142,
+      "stability": "static"
+    },
+    {
+      "name": "## Messaging",
+      "token_start": 2927,
+      "token_end": 3057,
+      "tokens": 130,
+      "stability": "static"
+    },
+    {
+      "name": "## Inbound Context (trusted metadata) + ## Reactions",
+      "token_start": 3194,
+      "token_end": 3348,
+      "tokens": 154,
+      "stability": "dynamic"
+    },
+    {
+      "name": "# Project Context + ## /home/node/.openclaw/workspace/AGENTS.md + ## First Run",
+      "token_start": 3348,
+      "token_end": 3470,
+      "tokens": 122,
+      "stability": "static"
+    },
+    {
+      "name": "## Session Startup",
+      "token_start": 3470,
+      "token_end": 3550,
+      "tokens": 80,
+      "stability": "static"
+    },
+    {
+      "name": "## Memory + ## Red Lines + ## External vs Internal + ## Group Chats",
+      "token_start": 3550,
+      "token_end": 4057,
+      "tokens": 507,
+      "stability": "static"
+    },
+    {
+      "name": "## Tools",
+      "token_start": 4460,
+      "token_end": 4613,
+      "tokens": 153,
+      "stability": "static"
+    },
+    {
+      "name": "## \ud83d\udc93 Heartbeats - Be Proactive! + ## Make It Yours + ## /home/node/.openclaw/workspace/SOUL.md",
+      "token_start": 4613,
+      "token_end": 5374,
+      "tokens": 761,
+      "stability": "static"
+    },
+    {
+      "name": "## Core Truths + ## Boundaries + ## Vibe + ## Continuity + ## /home/node/.openclaw/workspace/TOOLS.md + ## What Goes Here + ## Examples + ## Why Separate? + ## /home/node/.openclaw/workspace/IDENTITY.md + ## /home/node/.openclaw/workspace/USER.md + ## Context + ## /home/node/.openclaw/workspace/HEARTBEAT.md + ## /home/node/.openclaw/workspace/BOOTSTRAP.md",
+      "token_start": 5393,
+      "token_end": 6378,
+      "tokens": 985,
+      "stability": "static"
+    },
+    {
+      "name": "## The Conversation",
+      "token_start": 6429,
+      "token_end": 6557,
+      "tokens": 127,
+      "stability": "static"
+    },
+    {
+      "name": "## After You Know Who You Are + ## Connect (Optional) + ## When You're Done",
+      "token_start": 6557,
+      "token_end": 6741,
+      "tokens": 184,
+      "stability": "static"
+    },
+    {
+      "name": "## Silent Replies",
+      "token_start": 6741,
+      "token_end": 6824,
+      "tokens": 83,
+      "stability": "static"
+    },
+    {
+      "name": "## Heartbeats",
+      "token_start": 6824,
+      "token_end": 6961,
+      "tokens": 136,
+      "stability": "static"
+    },
+    {
+      "name": "## Runtime",
+      "token_start": 6961,
+      "token_end": 7059,
+      "tokens": 97,
+      "stability": "dynamic"
+    }
+  ],
+  "divergence_original": 3234,
+  "divergence_reordered": 6833,
+  "common_prefix_pct_original": 45.8,
+  "common_prefix_pct_reordered": 96.8,
+  "case1": {
+    "vllm_prefill_tokens": 6758,
+    "pie_prefill_tokens": 124,
+    "description": "First request to fresh engine (Pie has prewarmed stable prefix)"
+  },
+  "case2": {
+    "vllm_reprefill_tokens": 3825,
+    "pie_reprefill_tokens": 30,
+    "reduction_pct": 99.2,
+    "description": "Channel switch Telegram -> Discord (section reordering keeps stable prefix intact)"
+  },
+  "case3": {
+    "sessions": 4,
+    "context_tokens": 7059,
+    "description": "Session pinning under memory pressure (illustrative \u2014 pinning at scale is future work)"
+  },
+  "benchmarks": {
+    "platform": "A100 SXM4 80GB \u00b7 Qwen3-8B \u00b7 max_model_len=16384",
+    "date": "2026-04-13",
+    "rows": [
+      {
+        "scenario": "Cold start: fresh agent session",
+        "standard": "6,758 tok\n1,023 ms",
+        "pie": "124 tok\n292 ms",
+        "improvement": "98%"
+      },
+      {
+        "scenario": "Multi-tenant fleet: per user, 8 diverse workspaces",
+        "standard": "991 tok\n306 ms",
+        "pie": "130 tok\n223 ms",
+        "improvement": "87%"
+      },
+      {
+        "scenario": "Channel switch: Telegram \u2192 Discord",
+        "standard": "3,825 tok\n461 ms",
+        "pie": "30 tok\n218 ms",
+        "improvement": "99%"
+      },
+      {
+        "scenario": "Removing redundant information: API tools already in system prompt",
+        "standard": "16,375 tok\n\u2014",
+        "pie": "6,727 tok\n\u2014",
+        "improvement": "59%"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Migrate the standalone `pieclaw/demo-site` (React + Vite "Why Pie for Agents" demo) into the Docusaurus website at `/whypieagent`, so it's reachable at `https://pie-project.org/whypieagent`.
- Re-skin the Docusaurus navbar and footer to match the page's dark palette, scoped to this route only.
- Tighten the results-table footnote and the page disclaimer.

## Details
- New page at `website/src/pages/whypieagent.tsx` plus the Cold-Start, Channel-Switch, Multi-Session, and Benchmark-Results components under `website/src/components/whypieagent/`.
- Demo data shipped at `website/static/data/demo-data.json`.
- Dark-skin navbar/footer:
  - Toggles `body.whypieagent-dark` while the page is mounted.
  - A `MutationObserver` re-applies the class if Docusaurus' Layout machinery rewrites `body.className` on render (a previous attempt that toggled `html.whypieagent-dark` did not stick after hydration).
  - All re-skin rules live in `website/src/css/custom.css` under `body.whypieagent-dark …` selectors, so other routes are untouched.

## Test plan
- [x] `npm run build` succeeds (Docusaurus 3.9.2).
- [x] `npm run serve` → `/whypieagent`: navbar background is `rgb(10, 10, 15)`, body has `whypieagent-dark` class.
- [x] Navigate away to `/`: navbar reverts to white, body class removed (cleanup verified).
- [x] All four cases (Cold Start, Channel Switch, Multi-Session, Results) render and animate as in the standalone demo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a comprehensive "Why Pie for Agents" page featuring interactive performance demonstrations and comparisons.
  * Introduced animated visualizations showcasing cold-start performance, memory optimization, and multi-session processing scenarios.
  * Added benchmark comparison tables with performance metrics and improvements.
  * Included collapsible reference notes providing detailed assessment information.

* **Styling**
  * Applied dark theme styling to the new page and components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->