### PR TITLE
Unified sampling: gen_config + Penalties + SDK primitives (task23)

### DIFF
--- a/runtime/src/api/core.rs
+++ b/runtime/src/api/core.rs
@@ -310,6 +310,22 @@ impl inferlet::core::common::HostModel for InstanceState {
         Ok(stop_tokens)
     }
 
+    async fn get_generation_defaults(
+        &mut self,
+        _this: Resource<Model>,
+    ) -> Result<inferlet::core::common::GenerationDefaults> {
+        // Stub: real values are plumbed in from pie-vllm in task A5-A6.
+        // Until then, every field is None — inferlets must fall back to their
+        // own neutral defaults.
+        Ok(inferlet::core::common::GenerationDefaults {
+            temperature: None,
+            top_p: None,
+            top_k: None,
+            min_p: None,
+            repetition_penalty: None,
+        })
+    }
+
     async fn get_service_id(&mut self, this: Resource<Model>) -> Result<u32> {
         Ok(self.ctx().table.get(&this)?.service_id as u32)
     }

--- a/runtime/src/api/core.rs
+++ b/runtime/src/api/core.rs
@@ -312,17 +312,20 @@ impl inferlet::core::common::HostModel for InstanceState {
 
     async fn get_generation_defaults(
         &mut self,
-        _this: Resource<Model>,
+        this: Resource<Model>,
     ) -> Result<inferlet::core::common::GenerationDefaults> {
-        // Stub: real values are plumbed in from pie-vllm in task A5-A6.
-        // Until then, every field is None — inferlets must fall back to their
-        // own neutral defaults.
+        // Sourced from HF `generation_config.json` via the Python worker's
+        // handshake response (A5 `extract_generation_defaults`, A6 plumbing).
+        // All-None is still a valid outcome for models that ship no
+        // generation_config (Mistral, Gemma, Yi, ...); inferlets must
+        // fall back to their own neutral defaults.
+        let defaults = &self.ctx().table.get(&this)?.info.generation_defaults;
         Ok(inferlet::core::common::GenerationDefaults {
-            temperature: None,
-            top_p: None,
-            top_k: None,
-            min_p: None,
-            repetition_penalty: None,
+            temperature: defaults.temperature,
+            top_p: defaults.top_p,
+            top_k: defaults.top_k,
+            min_p: defaults.min_p,
+            repetition_penalty: defaults.repetition_penalty,
         })
     }
 

--- a/runtime/src/api/core/forward.rs
+++ b/runtime/src/api/core/forward.rs
@@ -100,6 +100,26 @@ enum Sampler {
     TopKTopP = 5,
 }
 
+/// Serialize `Penalties` into the per-token sampler msgpack map under the
+/// `*_penalty` keys consumed by pie-vllm's `SamplingParams` builder.
+fn insert_penalties(
+    sampler: &mut HashMap<String, rmpv::Value>,
+    penalties: &inferlet::core::forward::Penalties,
+) {
+    sampler.insert(
+        "repetition_penalty".to_string(),
+        rmpv::Value::from(penalties.repetition),
+    );
+    sampler.insert(
+        "frequency_penalty".to_string(),
+        rmpv::Value::from(penalties.frequency),
+    );
+    sampler.insert(
+        "presence_penalty".to_string(),
+        rmpv::Value::from(penalties.presence),
+    );
+}
+
 #[async_trait]
 impl Pollable for ForwardPassResult {
     async fn ready(&mut self) {
@@ -314,6 +334,7 @@ impl inferlet::core::forward::Host for InstanceState {
         pass: Resource<ForwardPass>,
         indices: Vec<u32>,
         temperature: f32,
+        penalties: inferlet::core::forward::Penalties,
     ) -> Result<()> {
         let mut sampler = HashMap::new();
 
@@ -322,6 +343,7 @@ impl inferlet::core::forward::Host for InstanceState {
             rmpv::Value::from(Sampler::Multinomial as u32),
         );
         sampler.insert("temperature".to_string(), rmpv::Value::from(temperature));
+        insert_penalties(&mut sampler, &penalties);
 
         let samplers = iter::repeat(sampler.clone())
             .take(indices.len())
@@ -339,6 +361,7 @@ impl inferlet::core::forward::Host for InstanceState {
         indices: Vec<u32>,
         temperature: f32,
         top_k: u32,
+        penalties: inferlet::core::forward::Penalties,
     ) -> Result<()> {
         let mut sampler = HashMap::new();
 
@@ -348,6 +371,7 @@ impl inferlet::core::forward::Host for InstanceState {
         );
         sampler.insert("temperature".to_string(), rmpv::Value::from(temperature));
         sampler.insert("top_k".to_string(), rmpv::Value::from(top_k));
+        insert_penalties(&mut sampler, &penalties);
 
         let pass = self.ctx().table.get_mut(&pass)?;
         pass.output_token_samplers
@@ -363,6 +387,7 @@ impl inferlet::core::forward::Host for InstanceState {
         indices: Vec<u32>,
         temperature: f32,
         top_p: f32,
+        penalties: inferlet::core::forward::Penalties,
     ) -> Result<()> {
         let mut sampler = HashMap::new();
 
@@ -372,6 +397,7 @@ impl inferlet::core::forward::Host for InstanceState {
         );
         sampler.insert("temperature".to_string(), rmpv::Value::from(temperature));
         sampler.insert("top_p".to_string(), rmpv::Value::from(top_p));
+        insert_penalties(&mut sampler, &penalties);
 
         let pass = self.ctx().table.get_mut(&pass)?;
         pass.output_token_samplers
@@ -387,6 +413,7 @@ impl inferlet::core::forward::Host for InstanceState {
         indices: Vec<u32>,
         temperature: f32,
         min_p: f32,
+        penalties: inferlet::core::forward::Penalties,
     ) -> Result<()> {
         let mut sampler = HashMap::new();
 
@@ -396,6 +423,7 @@ impl inferlet::core::forward::Host for InstanceState {
         );
         sampler.insert("temperature".to_string(), rmpv::Value::from(temperature));
         sampler.insert("min_p".to_string(), rmpv::Value::from(min_p));
+        insert_penalties(&mut sampler, &penalties);
 
         let pass = self.ctx().table.get_mut(&pass)?;
         pass.output_token_samplers
@@ -412,6 +440,7 @@ impl inferlet::core::forward::Host for InstanceState {
         temperature: f32,
         top_k: u32,
         top_p: f32,
+        penalties: inferlet::core::forward::Penalties,
     ) -> Result<()> {
         let mut sampler = HashMap::new();
 
@@ -422,6 +451,7 @@ impl inferlet::core::forward::Host for InstanceState {
         sampler.insert("temperature".to_string(), rmpv::Value::from(temperature));
         sampler.insert("top_k".to_string(), rmpv::Value::from(top_k));
         sampler.insert("top_p".to_string(), rmpv::Value::from(top_p));
+        insert_penalties(&mut sampler, &penalties);
 
         let pass = self.ctx().table.get_mut(&pass)?;
         pass.output_token_samplers

--- a/runtime/src/model.rs
+++ b/runtime/src/model.rs
@@ -309,6 +309,55 @@ impl Command {
 /// Number of format_chat requests to validate (both paths) before trusting the fast path.
 pub const FORMAT_CHAT_VALIDATION_COUNT: u32 = 1;
 
+/// Per-model sampling defaults sourced from HF `generation_config.json`.
+///
+/// Mirrors the `generation-defaults` WIT record in
+/// `sdk/interfaces/core/wit/common.wit`. All fields are optional: absent
+/// means the engine / model has no opinion and inferlets should fall back
+/// to their own neutral defaults.
+///
+/// Populated during handshake from the Python worker's
+/// `extract_generation_defaults(model_config)` output. An absent key (or
+/// a value that fails to coerce to the expected numeric type) leaves the
+/// corresponding field as `None`.
+#[derive(Debug, Clone, Default)]
+pub struct GenerationDefaults {
+    pub temperature: Option<f32>,
+    pub top_p: Option<f32>,
+    pub top_k: Option<u32>,
+    pub min_p: Option<f32>,
+    pub repetition_penalty: Option<f32>,
+}
+
+impl GenerationDefaults {
+    /// Parse a wire-format dict (from `HandshakeResponse.generation_defaults`)
+    /// into a typed struct. Unknown keys are silently ignored; values that
+    /// fail to coerce to the target numeric type leave the field `None`.
+    pub fn from_wire(dict: &HashMap<String, serde_json::Value>) -> Self {
+        fn as_f32(v: &serde_json::Value) -> Option<f32> {
+            v.as_f64().map(|x| x as f32)
+        }
+        fn as_u32(v: &serde_json::Value) -> Option<u32> {
+            // Accept integers and floats that are whole numbers.
+            v.as_u64()
+                .map(|x| x as u32)
+                .or_else(|| v.as_i64().filter(|x| *x >= 0).map(|x| x as u32))
+                .or_else(|| {
+                    v.as_f64()
+                        .filter(|x| *x >= 0.0 && x.fract() == 0.0)
+                        .map(|x| x as u32)
+                })
+        }
+        Self {
+            temperature: dict.get("temperature").and_then(as_f32),
+            top_p: dict.get("top_p").and_then(as_f32),
+            top_k: dict.get("top_k").and_then(as_u32),
+            min_p: dict.get("min_p").and_then(as_f32),
+            repetition_penalty: dict.get("repetition_penalty").and_then(as_f32),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ModelInfo {
     pub name: String,
@@ -326,6 +375,10 @@ pub struct ModelInfo {
     /// Decided once at startup by rendering a synthetic message through both
     /// minijinja and Python RPC and comparing token IDs.
     pub use_minijinja_fast_path: bool,
+    /// Sampling defaults from HF `generation_config.json` (e.g. Qwen2.5
+    /// ships `temperature=0.7, top_p=0.8, top_k=20, repetition_penalty=1.05`).
+    /// Default (all-None) for models that ship no generation_config.
+    pub generation_defaults: GenerationDefaults,
 }
 
 /// Model service for communication with Python backend via FFI.
@@ -430,6 +483,9 @@ impl Model {
             eprintln!("[INFO] Chat template minijinja fast path DISABLED; using Python RPC");
         }
 
+        let generation_defaults =
+            GenerationDefaults::from_wire(&handshake_info.generation_defaults);
+
         let info = ModelInfo {
             name: handshake_info.model_name,
             traits: handshake_info.model_traits,
@@ -442,6 +498,7 @@ impl Model {
             max_batch_tokens: handshake_info.max_batch_tokens,
             chat_template,
             use_minijinja_fast_path,
+            generation_defaults,
         };
 
         let resource_manager = ResourceManager::new(handshake_info.resources, num_groups);
@@ -1342,5 +1399,76 @@ impl Model {
                 response.send(vec![]).ok();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod generation_defaults_tests {
+    use super::GenerationDefaults;
+    use std::collections::HashMap;
+
+    /// Qwen2.5's `generation_config.json` ships these exact values; a full
+    /// round-trip through `from_wire` must preserve each one with the
+    /// correct numeric type.
+    #[test]
+    fn qwen25_values_round_trip() {
+        let mut dict = HashMap::new();
+        dict.insert("temperature".to_string(), serde_json::json!(0.7));
+        dict.insert("top_p".to_string(), serde_json::json!(0.8));
+        dict.insert("top_k".to_string(), serde_json::json!(20));
+        dict.insert("repetition_penalty".to_string(), serde_json::json!(1.05));
+
+        let d = GenerationDefaults::from_wire(&dict);
+        assert_eq!(d.temperature, Some(0.7_f32));
+        assert_eq!(d.top_p, Some(0.8_f32));
+        assert_eq!(d.top_k, Some(20_u32));
+        assert_eq!(d.min_p, None);
+        assert!((d.repetition_penalty.unwrap() - 1.05_f32).abs() < 1e-6);
+    }
+
+    /// Empty dict is the normal case for models that ship no
+    /// generation_config (Mistral, Gemma, Yi, ...). Fallback: all-None.
+    #[test]
+    fn empty_dict_yields_all_none() {
+        let dict: HashMap<String, serde_json::Value> = HashMap::new();
+        let d = GenerationDefaults::from_wire(&dict);
+        assert_eq!(d.temperature, None);
+        assert_eq!(d.top_p, None);
+        assert_eq!(d.top_k, None);
+        assert_eq!(d.min_p, None);
+        assert_eq!(d.repetition_penalty, None);
+    }
+
+    /// Unknown keys (e.g. `max_tokens`, `stop_token_ids`) must be silently
+    /// ignored — the Python side filters to sampling keys, but the Rust
+    /// side must not blow up if an extra key slips through.
+    #[test]
+    fn unknown_keys_ignored() {
+        let mut dict = HashMap::new();
+        dict.insert("temperature".to_string(), serde_json::json!(0.5));
+        dict.insert("max_tokens".to_string(), serde_json::json!(4096));
+        dict.insert("stop_token_ids".to_string(), serde_json::json!([151645]));
+
+        let d = GenerationDefaults::from_wire(&dict);
+        assert_eq!(d.temperature, Some(0.5_f32));
+        assert_eq!(d.top_p, None);
+    }
+
+    /// `top_k` in generation_config.json may be serialized as an int or
+    /// a whole-number float; both must coerce to `u32`. Non-whole floats
+    /// are rejected (no silent truncation).
+    #[test]
+    fn top_k_accepts_int_and_whole_float() {
+        let mut dict = HashMap::new();
+        dict.insert("top_k".to_string(), serde_json::json!(20));
+        assert_eq!(GenerationDefaults::from_wire(&dict).top_k, Some(20));
+
+        dict.clear();
+        dict.insert("top_k".to_string(), serde_json::json!(20.0));
+        assert_eq!(GenerationDefaults::from_wire(&dict).top_k, Some(20));
+
+        dict.clear();
+        dict.insert("top_k".to_string(), serde_json::json!(20.5));
+        assert_eq!(GenerationDefaults::from_wire(&dict).top_k, None);
     }
 }

--- a/runtime/src/model/request.rs
+++ b/runtime/src/model/request.rs
@@ -150,6 +150,14 @@ pub struct HandshakeResponse {
     /// Whether the chat template is minijinja-compatible (no Python-only Jinja2 features).
     #[serde(default)]
     pub template_minijinja_compatible: bool,
+    /// Sampling defaults sourced from HF `generation_config.json` on the
+    /// Python side. Optional — absent or empty means the model ships no
+    /// sampling defaults and inferlets should fall back to their own.
+    /// Keys are a subset of `{temperature, top_p, top_k, min_p,
+    /// repetition_penalty}`; values are JSON scalars (int/float).
+    /// Unknown keys are ignored by the runtime.
+    #[serde(default)]
+    pub generation_defaults: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/runtime/src/model/request.rs
+++ b/runtime/src/model/request.rs
@@ -352,6 +352,9 @@ pub struct BatchedForwardPassRequest {
     pub sampler_top_k: ByteVec,           // u32 array (will cast to i32 in Python)
     pub sampler_top_p: ByteVecF32,        // f32 array
     pub sampler_min_p: ByteVecF32,        // f32 array
+    pub sampler_repetition_penalty: ByteVecF32, // f32 array, 1.0 = neutral
+    pub sampler_frequency_penalty: ByteVecF32,  // f32 array, 0.0 = neutral
+    pub sampler_presence_penalty: ByteVecF32,   // f32 array, 0.0 = neutral
     pub sampler_types: ByteVec,           // u32 array (0=dist, 1/2/3=sampler types)
     pub request_num_samplers: ByteVec,    // u32 array, num samplers per request
 
@@ -426,6 +429,9 @@ impl BatchedForwardPassRequest {
             sampler_top_k: ByteVec(Vec::new()),
             sampler_top_p: ByteVecF32(Vec::new()),
             sampler_min_p: ByteVecF32(Vec::new()),
+            sampler_repetition_penalty: ByteVecF32(Vec::new()),
+            sampler_frequency_penalty: ByteVecF32(Vec::new()),
+            sampler_presence_penalty: ByteVecF32(Vec::new()),
             sampler_types: ByteVec(Vec::new()),
             request_num_samplers: ByteVec(Vec::new()),
             flat_output_token_indices: ByteVec(Vec::new()),
@@ -522,6 +528,26 @@ impl BatchedForwardPassRequest {
                 .and_then(|v| v.as_f64())
                 .unwrap_or(0.0) as f32;
             self.sampler_min_p.0.push(min_p);
+
+            // Extract penalties. Defaults are neutral so pre-B1 Sampler variants
+            // (which do not set these keys) don't accidentally penalize tokens.
+            let repetition_penalty = sampler_cfg
+                .get("repetition_penalty")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(1.0) as f32;
+            self.sampler_repetition_penalty.0.push(repetition_penalty);
+
+            let frequency_penalty = sampler_cfg
+                .get("frequency_penalty")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0) as f32;
+            self.sampler_frequency_penalty.0.push(frequency_penalty);
+
+            let presence_penalty = sampler_cfg
+                .get("presence_penalty")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0) as f32;
+            self.sampler_presence_penalty.0.push(presence_penalty);
         }
 
         // Embed outputs
@@ -573,4 +599,136 @@ impl Default for BatchedForwardPassRequest {
 pub struct BatchedForwardPassResponse {
     /// Results indexed by request order in the batch.
     pub results: Vec<ForwardPassResponse>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_request() -> ForwardPassRequest {
+        ForwardPassRequest {
+            input_tokens: Vec::new(),
+            input_token_positions: Vec::new(),
+            input_embed_ptrs: Vec::new(),
+            input_embed_positions: Vec::new(),
+            inst_id: None,
+            adapter: None,
+            adapter_seed: None,
+            mask: Vec::new(),
+            kv_page_ptrs: Vec::new(),
+            kv_page_last_len: 0,
+            output_token_indices: Vec::new(),
+            output_token_samplers: Vec::new(),
+            output_embed_ptrs: Vec::new(),
+            output_embed_indices: Vec::new(),
+            max_decode_steps: 1,
+            return_distributions: false,
+            multi_step_tokens: Vec::new(),
+            kv_page_size: 0,
+            actual_kv_pages: 0,
+            arrival_time: None,
+            token_stream_tx: None,
+            has_been_fired: false,
+        }
+    }
+
+    fn sampler_with_all_fields() -> HashMap<String, rmpv::Value> {
+        let mut s = HashMap::new();
+        s.insert("sampler".to_string(), rmpv::Value::from(1u32));
+        s.insert("temperature".to_string(), rmpv::Value::from(0.8f32));
+        s.insert("top_k".to_string(), rmpv::Value::from(20u32));
+        s.insert("top_p".to_string(), rmpv::Value::from(0.9f32));
+        s.insert("min_p".to_string(), rmpv::Value::from(0.05f32));
+        s.insert("repetition_penalty".to_string(), rmpv::Value::from(1.05f32));
+        s.insert("frequency_penalty".to_string(), rmpv::Value::from(0.1f32));
+        s.insert("presence_penalty".to_string(), rmpv::Value::from(0.2f32));
+        s
+    }
+
+    /// Verify add_request extracts penalty fields from the per-sampler hashmap
+    /// into the batch-level SoA ByteVecF32 arrays.
+    #[test]
+    fn add_request_aggregates_penalties_into_soa_arrays() {
+        let mut batch = BatchedForwardPassRequest::new();
+        let mut req = empty_request();
+        req.output_token_samplers.push(sampler_with_all_fields());
+        batch.add_request(&req);
+
+        assert_eq!(batch.sampler_repetition_penalty.0, vec![1.05f32]);
+        assert_eq!(batch.sampler_frequency_penalty.0, vec![0.1f32]);
+        assert_eq!(batch.sampler_presence_penalty.0, vec![0.2f32]);
+        // Sanity: existing fields still aggregated.
+        assert_eq!(batch.sampler_temperatures.0, vec![0.8f32]);
+        assert_eq!(batch.sampler_top_p.0, vec![0.9f32]);
+    }
+
+    /// Pre-B1 Sampler variants don't set penalty keys. add_request must default
+    /// them to neutral (1.0 / 0.0 / 0.0) so old call sites don't silently
+    /// penalize tokens.
+    #[test]
+    fn add_request_defaults_missing_penalties_to_neutral() {
+        let mut batch = BatchedForwardPassRequest::new();
+        let mut req = empty_request();
+        let mut s = HashMap::new();
+        s.insert("sampler".to_string(), rmpv::Value::from(1u32));
+        s.insert("temperature".to_string(), rmpv::Value::from(1.0f32));
+        req.output_token_samplers.push(s);
+        batch.add_request(&req);
+
+        assert_eq!(batch.sampler_repetition_penalty.0, vec![1.0f32]);
+        assert_eq!(batch.sampler_frequency_penalty.0, vec![0.0f32]);
+        assert_eq!(batch.sampler_presence_penalty.0, vec![0.0f32]);
+    }
+
+    /// Serialized batch msgpack must carry the exact plural keys pie-vllm's
+    /// batch_merger reads: `sampler_repetition_penalty`,
+    /// `sampler_frequency_penalty`, `sampler_presence_penalty`.
+    #[test]
+    fn serialized_batch_exposes_plural_penalty_keys() {
+        let mut batch = BatchedForwardPassRequest::new();
+        let mut req = empty_request();
+        req.output_token_samplers.push(sampler_with_all_fields());
+        batch.add_request(&req);
+
+        let bytes = rmp_serde::to_vec_named(&batch).expect("msgpack encode");
+        let value: rmpv::Value = rmp_serde::from_slice(&bytes).expect("msgpack decode");
+        let map = value.as_map().expect("top-level msgpack map");
+
+        let has = |key: &str| {
+            map.iter()
+                .any(|(k, _)| k.as_str().map(|s| s == key).unwrap_or(false))
+        };
+
+        assert!(has("sampler_repetition_penalty"));
+        assert!(has("sampler_frequency_penalty"));
+        assert!(has("sampler_presence_penalty"));
+    }
+
+    /// Multi-sampler aggregation: two samplers in one request must flatten
+    /// into length-2 arrays in the correct order.
+    #[test]
+    fn add_request_flattens_multiple_samplers_in_order() {
+        let mut batch = BatchedForwardPassRequest::new();
+        let mut req = empty_request();
+
+        let mut s1 = HashMap::new();
+        s1.insert("sampler".to_string(), rmpv::Value::from(1u32));
+        s1.insert("repetition_penalty".to_string(), rmpv::Value::from(1.1f32));
+        s1.insert("frequency_penalty".to_string(), rmpv::Value::from(0.3f32));
+        s1.insert("presence_penalty".to_string(), rmpv::Value::from(0.4f32));
+
+        let mut s2 = HashMap::new();
+        s2.insert("sampler".to_string(), rmpv::Value::from(1u32));
+        s2.insert("repetition_penalty".to_string(), rmpv::Value::from(1.2f32));
+        s2.insert("frequency_penalty".to_string(), rmpv::Value::from(0.5f32));
+        s2.insert("presence_penalty".to_string(), rmpv::Value::from(0.6f32));
+
+        req.output_token_samplers.push(s1);
+        req.output_token_samplers.push(s2);
+        batch.add_request(&req);
+
+        assert_eq!(batch.sampler_repetition_penalty.0, vec![1.1f32, 1.2f32]);
+        assert_eq!(batch.sampler_frequency_penalty.0, vec![0.3f32, 0.5f32]);
+        assert_eq!(batch.sampler_presence_penalty.0, vec![0.4f32, 0.6f32]);
+    }
 }

--- a/runtime/wit/deps/core/common.wit
+++ b/runtime/wit/deps/core/common.wit
@@ -11,6 +11,17 @@ interface common {
         high,       // Highest priority
     }
 
+    // Per-model sampling defaults sourced from the engine's generation_config.
+    // All fields are optional: absent means the engine/model has no opinion
+    // and the inferlet should fall back to its own neutral default.
+    record generation-defaults {
+        temperature:        option<f32>,
+        top-p:              option<f32>,
+        top-k:              option<u32>,
+        min-p:              option<f32>,
+        repetition-penalty: option<f32>,
+    }
+
     resource blob {
         constructor(init: list<u8>);
         read: func(offset: u64, n: u64) -> list<u8>;
@@ -33,6 +44,7 @@ interface common {
         get-description: func() -> string;           // Human-readable description of the model
         get-prompt-template: func() -> string;       // Returns the prompt formatting template in Tera
         get-stop-tokens: func() -> list<string>;
+        get-generation-defaults: func() -> generation-defaults;
         get-service-id: func() -> u32;
         get-kv-page-size: func() -> u32; // Get the size of a KV page
         create-queue: func() -> queue;               // Create a new command queue

--- a/runtime/wit/deps/core/forward.wit
+++ b/runtime/wit/deps/core/forward.wit
@@ -56,6 +56,15 @@ interface forward {
         indices: list<u32>,
     );
 
+    /// Token-penalty parameters passed alongside every token-sampling call.
+    /// Neutral values (repetition=1.0, frequency=0.0, presence=0.0) are a
+    /// mathematical no-op so handlers can apply them unconditionally.
+    record penalties {
+        repetition: f32,
+        frequency:  f32,
+        presence:   f32,
+    }
+
     output-distributions: func(
         pass: borrow<forward-pass>,
         indices: list<u32>,
@@ -67,13 +76,15 @@ interface forward {
         pass: borrow<forward-pass>,
         indices: list<u32>,
         temperature: f32,
+        penalties: penalties,
     );
 
     output-tokens-top-k: func(
         pass: borrow<forward-pass>,
         indices: list<u32>,
         temperature: f32,
-        top-k: u32
+        top-k: u32,
+        penalties: penalties,
     );
 
     output-tokens-top-p: func(
@@ -81,6 +92,7 @@ interface forward {
         indices: list<u32>,
         temperature: f32,
         top-p: f32,
+        penalties: penalties,
     );
 
     output-tokens-min-p: func(
@@ -88,6 +100,7 @@ interface forward {
         indices: list<u32>,
         temperature: f32,
         min-p: f32,
+        penalties: penalties,
     );
 
     output-tokens-top-k-top-p: func(
@@ -95,7 +108,8 @@ interface forward {
         indices: list<u32>,
         temperature: f32,
         top-k: u32,
-        top-p: f32
+        top-p: f32,
+        penalties: penalties,
     );
 
     /// Set maximum number of sequential decode steps per execute() call.

--- a/sdk/interfaces/core/wit/common.wit
+++ b/sdk/interfaces/core/wit/common.wit
@@ -56,6 +56,7 @@ interface common {
         synchronize: func() -> synchronization-result; // Begin synchronization process
         set-priority: func(priority: priority);     // Change the queue's priority
         debug-query: func(query: string) -> debug-query-result;  // Sends a message to the model and returns the response
+        format-chat: func(messages-json: string, tools-json: option<string>, add-generation-prompt: bool) -> format-chat-result;
     }
 
     // Result of a synchronization attempt
@@ -68,6 +69,12 @@ interface common {
     resource debug-query-result {
         pollable: func() -> pollable;
         get: func() -> option<string>;
+    }
+
+    // Result of a format-chat operation (returns token IDs from server-side HF template)
+    resource format-chat-result {
+        pollable: func() -> pollable;
+        get: func() -> option<list<u32>>;
     }
 
     // resources

--- a/sdk/interfaces/core/wit/common.wit
+++ b/sdk/interfaces/core/wit/common.wit
@@ -11,6 +11,17 @@ interface common {
         high,       // Highest priority
     }
 
+    // Per-model sampling defaults sourced from the engine's generation_config.
+    // All fields are optional: absent means the engine/model has no opinion
+    // and the inferlet should fall back to its own neutral default.
+    record generation-defaults {
+        temperature:        option<f32>,
+        top-p:              option<f32>,
+        top-k:              option<u32>,
+        min-p:              option<f32>,
+        repetition-penalty: option<f32>,
+    }
+
     resource blob {
         constructor(init: list<u8>);
         read: func(offset: u64, n: u64) -> list<u8>;
@@ -33,6 +44,7 @@ interface common {
         get-description: func() -> string;           // Human-readable description of the model
         get-prompt-template: func() -> string;       // Returns the prompt formatting template in Tera
         get-stop-tokens: func() -> list<string>;
+        get-generation-defaults: func() -> generation-defaults;
         get-service-id: func() -> u32;
         get-kv-page-size: func() -> u32; // Get the size of a KV page
         create-queue: func() -> queue;               // Create a new command queue

--- a/sdk/interfaces/core/wit/forward.wit
+++ b/sdk/interfaces/core/wit/forward.wit
@@ -55,6 +55,15 @@ interface forward {
         indices: list<u32>,
     );
 
+    /// Token-penalty parameters passed alongside every token-sampling call.
+    /// Neutral values (repetition=1.0, frequency=0.0, presence=0.0) are a
+    /// mathematical no-op so handlers can apply them unconditionally.
+    record penalties {
+        repetition: f32,
+        frequency:  f32,
+        presence:   f32,
+    }
+
     output-distributions: func(
         pass: borrow<forward-pass>,
         indices: list<u32>,
@@ -66,13 +75,15 @@ interface forward {
         pass: borrow<forward-pass>,
         indices: list<u32>,
         temperature: f32,
+        penalties: penalties,
     );
 
     output-tokens-top-k: func(
         pass: borrow<forward-pass>,
         indices: list<u32>,
         temperature: f32,
-        top-k: u32
+        top-k: u32,
+        penalties: penalties,
     );
 
     output-tokens-top-p: func(
@@ -80,6 +91,7 @@ interface forward {
         indices: list<u32>,
         temperature: f32,
         top-p: f32,
+        penalties: penalties,
     );
 
     output-tokens-min-p: func(
@@ -87,6 +99,7 @@ interface forward {
         indices: list<u32>,
         temperature: f32,
         min-p: f32,
+        penalties: penalties,
     );
 
     output-tokens-top-k-top-p: func(
@@ -94,7 +107,8 @@ interface forward {
         indices: list<u32>,
         temperature: f32,
         top-k: u32,
-        top-p: f32
+        top-p: f32,
+        penalties: penalties,
     );
 
     /// Set maximum number of sequential decode steps per execute() call.

--- a/sdk/rust/inferlet/Cargo.toml
+++ b/sdk/rust/inferlet/Cargo.toml
@@ -22,3 +22,7 @@ minijinja = { version = "2.12.0", features = ["loader"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 pico-args = "0.5.0"
+rand_core = "0.6"
+
+[dev-dependencies]
+rand_chacha = "0.3"

--- a/sdk/rust/inferlet/src/context.rs
+++ b/sdk/rust/inferlet/src/context.rs
@@ -862,36 +862,43 @@ impl Context {
         p.attention_mask(&mask);
 
         let output_idx = pending_token_ids.len() as u32 - 1;
-        // NOTE: penalties are carried on every variant but not yet wired into the
-        // forward-pass msgpack. Task B2 plumbs them through the runtime; here we
-        // ignore them via `..` so builds stay green.
+        // `penalties` ride the msgpack forward batch on every non-Custom variant
+        // (Task B2). The Custom path uses `output_distributions` and applies
+        // penalties client-side via SDK primitives, so its arm keeps dropping
+        // the penalty field.
         match sampler {
             Sampler::Custom {
                 temperature,
                 sampler: _sampler,
-                ..
+                penalties: _,
             } => {
                 p.output_distributions(&[output_idx], *temperature, None);
             }
-            Sampler::Multinomial { temperature, .. } => {
-                p.output_tokens(&[output_idx], *temperature);
+            Sampler::Multinomial { temperature, penalties } => {
+                p.output_tokens(&[output_idx], *temperature, *penalties);
             }
-            Sampler::TopP { temperature, top_p, .. } => {
-                p.output_tokens_top_p(&[output_idx], *temperature, *top_p);
+            Sampler::TopP { temperature, top_p, penalties } => {
+                p.output_tokens_top_p(&[output_idx], *temperature, *top_p, *penalties);
             }
-            Sampler::TopK { temperature, top_k, .. } => {
-                p.output_tokens_top_k(&[output_idx], *temperature, *top_k);
+            Sampler::TopK { temperature, top_k, penalties } => {
+                p.output_tokens_top_k(&[output_idx], *temperature, *top_k, *penalties);
             }
-            Sampler::MinP { temperature, min_p, .. } => {
-                p.output_tokens_min_p(&[output_idx], *temperature, *min_p);
+            Sampler::MinP { temperature, min_p, penalties } => {
+                p.output_tokens_min_p(&[output_idx], *temperature, *min_p, *penalties);
             }
             Sampler::TopKTopP {
                 temperature,
                 top_k,
                 top_p,
-                ..
+                penalties,
             } => {
-                p.output_tokens_top_k_top_p(&[output_idx], *temperature, *top_k, *top_p);
+                p.output_tokens_top_k_top_p(
+                    &[output_idx],
+                    *temperature,
+                    *top_k,
+                    *top_p,
+                    *penalties,
+                );
             }
         }
 

--- a/sdk/rust/inferlet/src/context.rs
+++ b/sdk/rust/inferlet/src/context.rs
@@ -613,6 +613,7 @@ impl Context {
             Sampler::Custom {
                 temperature: _temperature,
                 sampler,
+                ..
             } => {
                 let dist = res.distributions.unwrap().into_iter().next().unwrap();
                 sampler.sample(&dist.ids, &dist.probs)
@@ -861,29 +862,34 @@ impl Context {
         p.attention_mask(&mask);
 
         let output_idx = pending_token_ids.len() as u32 - 1;
+        // NOTE: penalties are carried on every variant but not yet wired into the
+        // forward-pass msgpack. Task B2 plumbs them through the runtime; here we
+        // ignore them via `..` so builds stay green.
         match sampler {
             Sampler::Custom {
                 temperature,
                 sampler: _sampler,
+                ..
             } => {
                 p.output_distributions(&[output_idx], *temperature, None);
             }
-            Sampler::Multinomial { temperature } => {
+            Sampler::Multinomial { temperature, .. } => {
                 p.output_tokens(&[output_idx], *temperature);
             }
-            Sampler::TopP { temperature, top_p } => {
+            Sampler::TopP { temperature, top_p, .. } => {
                 p.output_tokens_top_p(&[output_idx], *temperature, *top_p);
             }
-            Sampler::TopK { temperature, top_k } => {
+            Sampler::TopK { temperature, top_k, .. } => {
                 p.output_tokens_top_k(&[output_idx], *temperature, *top_k);
             }
-            Sampler::MinP { temperature, min_p } => {
+            Sampler::MinP { temperature, min_p, .. } => {
                 p.output_tokens_min_p(&[output_idx], *temperature, *min_p);
             }
             Sampler::TopKTopP {
                 temperature,
                 top_k,
                 top_p,
+                ..
             } => {
                 p.output_tokens_top_k_top_p(&[output_idx], *temperature, *top_k, *top_p);
             }

--- a/sdk/rust/inferlet/src/forward.rs
+++ b/sdk/rust/inferlet/src/forward.rs
@@ -1,8 +1,21 @@
 use crate::api;
 use crate::brle::Brle;
+use crate::sampler::Penalties;
 use crate::{Queue, Resource};
 use std::rc::Rc;
 use wstd::io::AsyncPollable;
+
+/// Convert the SDK's `Penalties` struct into the WIT-generated binding type
+/// that crosses the WASM boundary. Field-for-field copy; both types carry the
+/// same three `f32`s.
+#[inline]
+fn wit_penalties(p: Penalties) -> api::forward::Penalties {
+    api::forward::Penalties {
+        repetition: p.repetition,
+        frequency: p.frequency,
+        presence: p.presence,
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct ForwardPass {
@@ -332,20 +345,56 @@ impl ForwardPass {
         api::forward::output_distributions(&self.inner, indices, temperature, top_k);
     }
 
-    pub fn output_tokens(&self, indices: &[u32], temperature: f32) {
-        api::forward::output_tokens(&self.inner, indices, temperature);
+    pub fn output_tokens(&self, indices: &[u32], temperature: f32, penalties: Penalties) {
+        api::forward::output_tokens(&self.inner, indices, temperature, wit_penalties(penalties));
     }
 
-    pub fn output_tokens_top_p(&self, indices: &[u32], temperature: f32, top_p: f32) {
-        api::forward::output_tokens_top_p(&self.inner, indices, temperature, top_p);
+    pub fn output_tokens_top_p(
+        &self,
+        indices: &[u32],
+        temperature: f32,
+        top_p: f32,
+        penalties: Penalties,
+    ) {
+        api::forward::output_tokens_top_p(
+            &self.inner,
+            indices,
+            temperature,
+            top_p,
+            wit_penalties(penalties),
+        );
     }
 
-    pub fn output_tokens_top_k(&self, indices: &[u32], temperature: f32, top_k: u32) {
-        api::forward::output_tokens_top_k(&self.inner, indices, temperature, top_k);
+    pub fn output_tokens_top_k(
+        &self,
+        indices: &[u32],
+        temperature: f32,
+        top_k: u32,
+        penalties: Penalties,
+    ) {
+        api::forward::output_tokens_top_k(
+            &self.inner,
+            indices,
+            temperature,
+            top_k,
+            wit_penalties(penalties),
+        );
     }
 
-    pub fn output_tokens_min_p(&self, indices: &[u32], temperature: f32, min_p: f32) {
-        api::forward::output_tokens_min_p(&self.inner, indices, temperature, min_p);
+    pub fn output_tokens_min_p(
+        &self,
+        indices: &[u32],
+        temperature: f32,
+        min_p: f32,
+        penalties: Penalties,
+    ) {
+        api::forward::output_tokens_min_p(
+            &self.inner,
+            indices,
+            temperature,
+            min_p,
+            wit_penalties(penalties),
+        );
     }
 
     pub fn output_tokens_top_k_top_p(
@@ -354,8 +403,16 @@ impl ForwardPass {
         temperature: f32,
         top_k: u32,
         top_p: f32,
+        penalties: Penalties,
     ) {
-        api::forward::output_tokens_top_k_top_p(&self.inner, indices, temperature, top_k, top_p);
+        api::forward::output_tokens_top_k_top_p(
+            &self.inner,
+            indices,
+            temperature,
+            top_k,
+            top_p,
+            wit_penalties(penalties),
+        );
     }
 
     pub fn attention_mask(&self, mask: &[Vec<u32>]) {

--- a/sdk/rust/inferlet/src/lib.rs
+++ b/sdk/rust/inferlet/src/lib.rs
@@ -265,6 +265,14 @@ impl Model {
         }
     }
 
+    /// Construct a ready-to-use `Sampler` by merging client-supplied
+    /// `SamplingOverrides` with this model's `generation_defaults()`.
+    ///
+    /// See `Sampler::merge` for precedence rules.
+    pub fn build_sampler(&self, overrides: SamplingOverrides) -> Sampler {
+        Sampler::merge(overrides, self.generation_defaults())
+    }
+
     /// Create a new command queue for this model.
     pub fn create_queue(&self) -> Queue {
         Queue {

--- a/sdk/rust/inferlet/src/lib.rs
+++ b/sdk/rust/inferlet/src/lib.rs
@@ -1,6 +1,6 @@
 pub use crate::chat::ChatFormatter;
 pub use crate::context::Context;
-pub use crate::sampler::Sampler;
+pub use crate::sampler::{GenerationDefaults, Sampler, SamplingOverrides};
 use crate::stop_condition::StopCondition;
 use crate::wstd::runtime::AsyncPollable;
 pub use anyhow::{Context as AnyhowContext, Error, Result, anyhow, bail, ensure, format_err};
@@ -249,6 +249,20 @@ impl Model {
 
     pub fn get_kv_page_size(&self) -> u32 {
         self.inner.get_kv_page_size()
+    }
+
+    /// Returns the per-model sampling defaults sourced from the engine's
+    /// generation_config. Fields that are `None` indicate the engine/model
+    /// has no opinion; the inferlet should fall back to a neutral default.
+    pub fn generation_defaults(&self) -> GenerationDefaults {
+        let wit = self.inner.get_generation_defaults();
+        GenerationDefaults {
+            temperature:        wit.temperature,
+            top_p:              wit.top_p,
+            top_k:              wit.top_k,
+            min_p:              wit.min_p,
+            repetition_penalty: wit.repetition_penalty,
+        }
     }
 
     /// Create a new command queue for this model.

--- a/sdk/rust/inferlet/src/sampler.rs
+++ b/sdk/rust/inferlet/src/sampler.rs
@@ -1,3 +1,9 @@
+pub mod primitives;
+
+pub use primitives::{
+    EmittedHistory, apply_repetition_penalty, apply_top_k, apply_top_p, weighted_sample,
+};
+
 /// Model-authored sampling defaults sourced from the engine's `generation_config.json`.
 ///
 /// Only includes knobs a model publishes in its gen_config: the four filter-style

--- a/sdk/rust/inferlet/src/sampler.rs
+++ b/sdk/rust/inferlet/src/sampler.rs
@@ -25,48 +25,75 @@ pub struct SamplingOverrides {
     pub presence_penalty:   Option<f32>,  // F3 (client-only, not in gen_config)
 }
 
+/// Token-penalty parameters attached to every `Sampler` variant.
+///
+/// Neutral defaults (`repetition=1.0, frequency=0.0, presence=0.0`) match
+/// vLLM's `SamplingParams` defaults — multiplying by 1.0 or adding 0.0 is a
+/// mathematical no-op, so code paths that unconditionally apply penalties stay
+/// correct when the client hasn't set them.
+///
+/// `frequency` and `presence` have no source in HF `generation_config.json`
+/// (confirmed via survey of 9 models); they are client-only and only `repetition`
+/// can be filled from `GenerationDefaults`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Penalties {
+    pub repetition: f32,  // 1.0 = neutral
+    pub frequency:  f32,  // 0.0 = neutral
+    pub presence:   f32,  // 0.0 = neutral
+}
+
+impl Default for Penalties {
+    fn default() -> Self { Self { repetition: 1.0, frequency: 0.0, presence: 0.0 } }
+}
+
 pub enum Sampler {
     Custom {
         temperature: f32,
         sampler: Box<dyn Sample>,
+        penalties: Penalties,
     },
     Multinomial {
         temperature: f32,
+        penalties: Penalties,
     },
     TopP {
         temperature: f32,
         top_p: f32,
+        penalties: Penalties,
     },
     TopK {
         temperature: f32,
         top_k: u32,
+        penalties: Penalties,
     },
     MinP {
         temperature: f32,
         min_p: f32,
+        penalties: Penalties,
     },
     TopKTopP {
         temperature: f32,
         top_k: u32,
         top_p: f32,
+        penalties: Penalties,
     },
 }
 
 impl Sampler {
     pub fn greedy() -> Self {
-        Sampler::Multinomial { temperature: 0.0 }
+        Sampler::Multinomial { temperature: 0.0, penalties: Penalties::default() }
     }
 
     pub fn top_p(temperature: f32, top_p: f32) -> Self {
-        Sampler::TopP { temperature, top_p }
+        Sampler::TopP { temperature, top_p, penalties: Penalties::default() }
     }
 
     pub fn top_k(temperature: f32, top_k: u32) -> Self {
-        Sampler::TopK { temperature, top_k }
+        Sampler::TopK { temperature, top_k, penalties: Penalties::default() }
     }
 
     pub fn min_p(temperature: f32, min_p: f32) -> Self {
-        Sampler::MinP { temperature, min_p }
+        Sampler::MinP { temperature, min_p, penalties: Penalties::default() }
     }
 
     pub fn top_k_top_p(temperature: f32, top_k: u32, top_p: f32) -> Self {
@@ -74,6 +101,7 @@ impl Sampler {
             temperature,
             top_k,
             top_p,
+            penalties: Penalties::default(),
         }
     }
 
@@ -89,10 +117,11 @@ impl Sampler {
     /// (temperature=1.0, top_p=1.0 disabled, top_k=0 disabled, min_p=0.0
     /// disabled) are the last resort.
     ///
-    /// Only the four filter-style fields (temperature, top_p, top_k, min_p) are
-    /// considered here. `repetition_penalty` / `frequency_penalty` /
-    /// `presence_penalty` will be folded in by Task B1 when `Sampler` variants
-    /// grow a `Penalties` field.
+    /// Filter selection (temperature, top_p, top_k, min_p) and penalty
+    /// parameters (repetition, frequency, presence) are resolved independently.
+    /// Penalty fields flow into every variant via the `Penalties` struct;
+    /// `frequency_penalty` and `presence_penalty` are client-only (no defaults
+    /// source) while `repetition_penalty` can come from `GenerationDefaults`.
     pub fn merge(overrides: SamplingOverrides, defaults: GenerationDefaults) -> Self {
         let temperature = overrides.temperature.or(defaults.temperature).unwrap_or(1.0);
         let top_p = overrides.top_p.or(defaults.top_p);
@@ -102,12 +131,17 @@ impl Sampler {
         let top_p_active = top_p.filter(|v| *v < 1.0 && *v > 0.0);
         let top_k_active = top_k.filter(|v| *v > 0);
         let min_p_active = min_p.filter(|v| *v > 0.0);
+        let penalties = Penalties {
+            repetition: overrides.repetition_penalty.or(defaults.repetition_penalty).unwrap_or(1.0),
+            frequency:  overrides.frequency_penalty.unwrap_or(0.0),   // no defaults source
+            presence:   overrides.presence_penalty.unwrap_or(0.0),    // no defaults source
+        };
         match (top_k_active, top_p_active, min_p_active) {
-            (Some(k), Some(p), _) => Sampler::TopKTopP { temperature, top_k: k, top_p: p },
-            (Some(k), None, _)    => Sampler::TopK { temperature, top_k: k },
-            (None, Some(p), _)    => Sampler::TopP { temperature, top_p: p },
-            (None, None, Some(m)) => Sampler::MinP { temperature, min_p: m },
-            (None, None, None)    => Sampler::Multinomial { temperature },
+            (Some(k), Some(p), _) => Sampler::TopKTopP { temperature, top_k: k, top_p: p, penalties },
+            (Some(k), None, _)    => Sampler::TopK { temperature, top_k: k, penalties },
+            (None, Some(p), _)    => Sampler::TopP { temperature, top_p: p, penalties },
+            (None, None, Some(m)) => Sampler::MinP { temperature, min_p: m, penalties },
+            (None, None, None)    => Sampler::Multinomial { temperature, penalties },
         }
     }
 }
@@ -153,7 +187,7 @@ mod tests {
         let o = SamplingOverrides { temperature: Some(0.5), ..Default::default() };
         let s = Sampler::merge(o, qwen25_defaults());
         // Expect TopKTopP { temperature=0.5, top_p=0.8, top_k=20 }
-        assert!(matches!(s, Sampler::TopKTopP { temperature: t, top_p: 0.8, top_k: 20 } if (t - 0.5).abs() < 1e-6));
+        assert!(matches!(s, Sampler::TopKTopP { temperature: t, top_p: 0.8, top_k: 20, .. } if (t - 0.5).abs() < 1e-6));
     }
 
     #[test]
@@ -168,7 +202,7 @@ mod tests {
         let o = SamplingOverrides::default();
         let s = Sampler::merge(o, GenerationDefaults::default());
         // No filters set → Multinomial at temperature 1.0
-        assert!(matches!(s, Sampler::Multinomial { temperature: t } if (t - 1.0).abs() < 1e-6));
+        assert!(matches!(s, Sampler::Multinomial { temperature: t, .. } if (t - 1.0).abs() < 1e-6));
     }
 
     #[test]
@@ -191,7 +225,7 @@ mod tests {
         // Model gen_config sets only top_k; client sends nothing → Sampler::TopK.
         let d = GenerationDefaults { top_k: Some(50), temperature: Some(0.7), ..Default::default() };
         let s = Sampler::merge(SamplingOverrides::default(), d);
-        assert!(matches!(s, Sampler::TopK { top_k: 50, temperature: t } if (t - 0.7).abs() < 1e-6));
+        assert!(matches!(s, Sampler::TopK { top_k: 50, temperature: t, .. } if (t - 0.7).abs() < 1e-6));
     }
 
     #[test]
@@ -214,5 +248,32 @@ mod tests {
         let s = Sampler::merge(o, d);
         // With top_p disabled by client but top_k=20 still active from defaults → TopK only
         assert!(matches!(s, Sampler::TopK { top_k: 20, .. }));
+    }
+
+    #[test]
+    fn penalties_neutral_is_no_op() {
+        let p = Penalties::default();
+        assert_eq!(p.repetition, 1.0);
+        assert_eq!(p.frequency, 0.0);
+        assert_eq!(p.presence, 0.0);
+    }
+
+    #[test]
+    fn sampler_carries_penalties_from_merge() {
+        let o = SamplingOverrides {
+            temperature: Some(0.5),
+            repetition_penalty: Some(1.1),
+            frequency_penalty: Some(0.2),
+            ..Default::default()
+        };
+        let s = Sampler::merge(o, GenerationDefaults::default());
+        // With no filter active and no defaults, result is Multinomial
+        if let Sampler::Multinomial { penalties, .. } = s {
+            assert_eq!(penalties.repetition, 1.1);
+            assert_eq!(penalties.frequency, 0.2);
+            assert_eq!(penalties.presence, 0.0);  // neutral fallback
+        } else {
+            panic!("expected Multinomial variant");
+        }
     }
 }

--- a/sdk/rust/inferlet/src/sampler.rs
+++ b/sdk/rust/inferlet/src/sampler.rs
@@ -1,3 +1,23 @@
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct GenerationDefaults {
+    pub temperature:        Option<f32>,
+    pub top_p:              Option<f32>,
+    pub top_k:              Option<u32>,
+    pub min_p:              Option<f32>,
+    pub repetition_penalty: Option<f32>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SamplingOverrides {
+    pub temperature:        Option<f32>,
+    pub top_p:              Option<f32>,
+    pub top_k:              Option<u32>,
+    pub min_p:              Option<f32>,
+    pub repetition_penalty: Option<f32>,
+    pub frequency_penalty:  Option<f32>,  // F3 (client-only, not in gen_config)
+    pub presence_penalty:   Option<f32>,  // F3 (client-only, not in gen_config)
+}
+
 pub enum Sampler {
     Custom {
         temperature: f32,
@@ -62,4 +82,22 @@ pub trait Sample {
     /// * `ids` - A slice of token IDs.
     /// * `probs` - A slice of corresponding probabilities for each token ID.
     fn sample(&self, ids: &[u32], probs: &[f32]) -> u32;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overrides_empty_is_neutral() {
+        let o = SamplingOverrides::default();
+        assert!(o.temperature.is_none());
+        assert!(o.top_p.is_none());
+    }
+
+    #[test]
+    fn defaults_empty_is_all_none() {
+        let d = GenerationDefaults::default();
+        assert!(d.repetition_penalty.is_none());
+    }
 }

--- a/sdk/rust/inferlet/src/sampler.rs
+++ b/sdk/rust/inferlet/src/sampler.rs
@@ -170,4 +170,49 @@ mod tests {
         // No filters set → Multinomial at temperature 1.0
         assert!(matches!(s, Sampler::Multinomial { temperature: t } if (t - 1.0).abs() < 1e-6));
     }
+
+    #[test]
+    fn empty_gen_config_client_only_params() {
+        // Mistral/Gemma/Yi case: model ships empty gen_config.
+        let o = SamplingOverrides { temperature: Some(0.9), top_p: Some(0.95), ..Default::default() };
+        let s = Sampler::merge(o, GenerationDefaults::default());
+        assert!(matches!(s, Sampler::TopP { top_p: p, .. } if (p - 0.95).abs() < 1e-6));
+    }
+
+    #[test]
+    fn disabled_top_p_equals_one_falls_through() {
+        let o = SamplingOverrides { temperature: Some(0.9), top_p: Some(1.0), ..Default::default() };
+        let s = Sampler::merge(o, GenerationDefaults::default());
+        assert!(matches!(s, Sampler::Multinomial { .. }));
+    }
+
+    #[test]
+    fn defaults_only_top_k_yields_topk() {
+        // Model gen_config sets only top_k; client sends nothing → Sampler::TopK.
+        let d = GenerationDefaults { top_k: Some(50), temperature: Some(0.7), ..Default::default() };
+        let s = Sampler::merge(SamplingOverrides::default(), d);
+        assert!(matches!(s, Sampler::TopK { top_k: 50, temperature: t } if (t - 0.7).abs() < 1e-6));
+    }
+
+    #[test]
+    fn client_only_min_p_yields_minp() {
+        // Empty gen_config; client sets min_p only → Sampler::MinP.
+        let o = SamplingOverrides { min_p: Some(0.1), ..Default::default() };
+        let s = Sampler::merge(o, GenerationDefaults::default());
+        assert!(matches!(s, Sampler::MinP { min_p: m, .. } if (m - 0.1).abs() < 1e-6));
+    }
+
+    #[test]
+    fn override_disables_default_top_p() {
+        // Qwen2.5 defaults have top_p=0.8. Client explicitly sends top_p=1.0 ("disable").
+        // Must fall through past TopP/TopKTopP — client wins even when client chooses "disabled".
+        let d = GenerationDefaults {
+            temperature: Some(0.7), top_p: Some(0.8), top_k: Some(20),
+            ..Default::default()
+        };
+        let o = SamplingOverrides { top_p: Some(1.0), ..Default::default() };
+        let s = Sampler::merge(o, d);
+        // With top_p disabled by client but top_k=20 still active from defaults → TopK only
+        assert!(matches!(s, Sampler::TopK { top_k: 20, .. }));
+    }
 }

--- a/sdk/rust/inferlet/src/sampler.rs
+++ b/sdk/rust/inferlet/src/sampler.rs
@@ -1,3 +1,10 @@
+/// Model-authored sampling defaults sourced from the engine's `generation_config.json`.
+///
+/// Only includes knobs a model publishes in its gen_config: the four filter-style
+/// fields (`temperature`, `top_p`, `top_k`, `min_p`) plus `repetition_penalty`.
+/// `frequency_penalty` and `presence_penalty` are intentionally absent — HF
+/// `generation_config.json` never carries them; they are client-intent only and
+/// live exclusively on `SamplingOverrides`.
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct GenerationDefaults {
     pub temperature:        Option<f32>,
@@ -73,6 +80,36 @@ impl Sampler {
     pub fn reasoning() -> Self {
         Self::top_k_top_p(0.6, 20, 0.95)
     }
+
+    /// Merge client-supplied `SamplingOverrides` with model-authored
+    /// `GenerationDefaults` into a ready-to-use `Sampler` variant.
+    ///
+    /// Precedence: `overrides.field.or(defaults.field).unwrap_or(neutral)`.
+    /// Client-set fields win; the model's generation_config fills in; neutrals
+    /// (temperature=1.0, top_p=1.0 disabled, top_k=0 disabled, min_p=0.0
+    /// disabled) are the last resort.
+    ///
+    /// Only the four filter-style fields (temperature, top_p, top_k, min_p) are
+    /// considered here. `repetition_penalty` / `frequency_penalty` /
+    /// `presence_penalty` will be folded in by Task B1 when `Sampler` variants
+    /// grow a `Penalties` field.
+    pub fn merge(overrides: SamplingOverrides, defaults: GenerationDefaults) -> Self {
+        let temperature = overrides.temperature.or(defaults.temperature).unwrap_or(1.0);
+        let top_p = overrides.top_p.or(defaults.top_p);
+        let top_k = overrides.top_k.or(defaults.top_k);
+        let min_p = overrides.min_p.or(defaults.min_p);
+        // top_p == 1.0 or top_k == 0 means "disabled"; treat as None.
+        let top_p_active = top_p.filter(|v| *v < 1.0 && *v > 0.0);
+        let top_k_active = top_k.filter(|v| *v > 0);
+        let min_p_active = min_p.filter(|v| *v > 0.0);
+        match (top_k_active, top_p_active, min_p_active) {
+            (Some(k), Some(p), _) => Sampler::TopKTopP { temperature, top_k: k, top_p: p },
+            (Some(k), None, _)    => Sampler::TopK { temperature, top_k: k },
+            (None, Some(p), _)    => Sampler::TopP { temperature, top_p: p },
+            (None, None, Some(m)) => Sampler::MinP { temperature, min_p: m },
+            (None, None, None)    => Sampler::Multinomial { temperature },
+        }
+    }
 }
 
 pub trait Sample {
@@ -99,5 +136,38 @@ mod tests {
     fn defaults_empty_is_all_none() {
         let d = GenerationDefaults::default();
         assert!(d.repetition_penalty.is_none());
+    }
+
+    fn qwen25_defaults() -> GenerationDefaults {
+        GenerationDefaults {
+            temperature:        Some(0.7),
+            top_p:              Some(0.8),
+            top_k:              Some(20),
+            min_p:              None,
+            repetition_penalty: Some(1.05),
+        }
+    }
+
+    #[test]
+    fn client_overrides_win() {
+        let o = SamplingOverrides { temperature: Some(0.5), ..Default::default() };
+        let s = Sampler::merge(o, qwen25_defaults());
+        // Expect TopKTopP { temperature=0.5, top_p=0.8, top_k=20 }
+        assert!(matches!(s, Sampler::TopKTopP { temperature: t, top_p: 0.8, top_k: 20 } if (t - 0.5).abs() < 1e-6));
+    }
+
+    #[test]
+    fn defaults_fill_missing() {
+        let o = SamplingOverrides::default();
+        let s = Sampler::merge(o, qwen25_defaults());
+        assert!(matches!(s, Sampler::TopKTopP { top_p: 0.8, top_k: 20, .. }));
+    }
+
+    #[test]
+    fn neutral_fallback_when_both_empty() {
+        let o = SamplingOverrides::default();
+        let s = Sampler::merge(o, GenerationDefaults::default());
+        // No filters set → Multinomial at temperature 1.0
+        assert!(matches!(s, Sampler::Multinomial { temperature: t } if (t - 1.0).abs() < 1e-6));
     }
 }

--- a/sdk/rust/inferlet/src/sampler/primitives.rs
+++ b/sdk/rust/inferlet/src/sampler/primitives.rs
@@ -1,0 +1,408 @@
+//! Reusable sampling primitives for WASM-side custom sampling.
+//!
+//! These primitives are composable building blocks for inferlets that need to
+//! implement their own sampling pipeline — typically the grammar-constrained
+//! path where only the WASM side knows which tokens are grammar-legal, so the
+//! engine-side sampler must be bypassed.
+//!
+//! The canonical pipeline (matching vLLM's prob-space approximation used by
+//! pieclaw's `ConstrainedSampler`) is:
+//!
+//! 1. Collect `(token, prob)` pairs from the engine's output.
+//! 2. `apply_repetition_penalty(&mut dist, &history, penalty)` — scale down
+//!    probs of tokens in the recent emission window.
+//! 3. Sort `dist` descending by prob.
+//! 4. `apply_top_k(&mut dist, k)` — truncate long tail.
+//! 5. `apply_top_p(&mut dist, p)` — keep shortest prefix with cumulative mass
+//!    meeting the nucleus threshold.
+//! 6. `weighted_sample(&dist, &mut rng)` — weighted random draw.
+//! 7. Push the sampled token into `history` for the next step.
+//!
+//! Callers handle normalization themselves (or skip it — `weighted_sample`
+//! does not require sum-to-1).
+//!
+//! ### Why prob-space, not logit-space?
+//!
+//! vLLM applies `repetition_penalty` on pre-softmax logits. WASM-side custom
+//! samplers only receive post-softmax probs (the true logits depend on the
+//! unknown normalization constant Z), so we approximate via division in
+//! prob-space. Strictly weaker than logit-space for high-confidence tokens,
+//! but sufficient for the grammar path where the admissible set is already
+//! narrow. Closing that gap requires engine-side penalty application.
+
+use std::collections::{HashMap, VecDeque};
+
+/// Bounded sliding-window tracker for recently emitted tokens.
+///
+/// Backed by a `VecDeque` (FIFO order + O(1) front pop) plus a `HashMap<u32,
+/// u32>` ref-count mirror so `contains` runs in O(1) instead of the O(n)
+/// linear scan you get from `VecDeque::contains`.
+///
+/// The map counts occurrences: when a token is evicted from the deque its
+/// count decrements, and the map key is removed when the count hits zero. A
+/// token appears in `contains` iff it currently occupies at least one slot in
+/// the deque.
+#[derive(Debug, Clone)]
+pub struct EmittedHistory {
+    deque: VecDeque<u32>,
+    counts: HashMap<u32, u32>,
+    max: usize,
+}
+
+impl EmittedHistory {
+    /// Creates an empty history with room for at most `max` tokens.
+    ///
+    /// `max = 0` creates a degenerate "drop everything" history: `push` is a
+    /// no-op and `contains` always returns `false`.
+    pub fn new(max: usize) -> Self {
+        Self {
+            deque: VecDeque::with_capacity(max),
+            counts: HashMap::new(),
+            max,
+        }
+    }
+
+    /// Append `token` to the window. If the window is full, the oldest token
+    /// is evicted first.
+    pub fn push(&mut self, token: u32) {
+        if self.max == 0 {
+            return;
+        }
+        if self.deque.len() == self.max {
+            let evicted = self
+                .deque
+                .pop_front()
+                .expect("deque at capacity must have a front");
+            let count = self
+                .counts
+                .get_mut(&evicted)
+                .expect("count invariant: every deque slot has a ref-count entry");
+            *count -= 1;
+            if *count == 0 {
+                self.counts.remove(&evicted);
+            }
+        }
+        self.deque.push_back(token);
+        *self.counts.entry(token).or_insert(0) += 1;
+    }
+
+    /// O(1) membership test — true iff `token` currently occupies at least
+    /// one slot in the window.
+    pub fn contains(&self, token: u32) -> bool {
+        self.counts.contains_key(&token)
+    }
+
+    /// Number of tokens currently stored (≤ `max`).
+    pub fn len(&self) -> usize {
+        self.deque.len()
+    }
+
+    /// True iff no tokens are stored.
+    pub fn is_empty(&self) -> bool {
+        self.deque.is_empty()
+    }
+
+    /// Configured maximum window size.
+    pub fn capacity(&self) -> usize {
+        self.max
+    }
+}
+
+/// Divide the prob of any `(token, prob)` pair whose `token` appears in
+/// `history` by `penalty`.
+///
+/// `penalty <= 1.0 + 1e-6` is treated as "disabled" (no-op) — this is the
+/// neutral-default convention: a repetition_penalty of 1.0 means no scaling.
+///
+/// Renormalization is the caller's responsibility; `weighted_sample` does not
+/// require a sum-to-1 distribution.
+pub fn apply_repetition_penalty(dist: &mut [(u32, f32)], history: &EmittedHistory, penalty: f32) {
+    if penalty <= 1.0 + 1e-6 {
+        return;
+    }
+    if history.is_empty() {
+        return;
+    }
+    for (token, prob) in dist.iter_mut() {
+        if history.contains(*token) {
+            *prob /= penalty;
+        }
+    }
+}
+
+/// Nucleus (top-p) truncation over an **already descending-sorted** dist.
+///
+/// Keeps the shortest prefix whose cumulative prob mass meets or exceeds
+/// `top_p`, discarding the rest via `Vec::truncate`.
+///
+/// - `top_p >= 1.0` or `top_p <= 0.0` → no-op.
+/// - Dist must be pre-sorted by the caller. This primitive is stateless and
+///   cheap so callers can share one sort across top_k + top_p.
+pub fn apply_top_p(dist: &mut Vec<(u32, f32)>, top_p: f32) {
+    if top_p >= 1.0 || top_p <= 0.0 {
+        return;
+    }
+    let total: f32 = dist.iter().map(|(_, p)| *p).sum();
+    if total <= 0.0 {
+        return;
+    }
+    let target = top_p * total;
+    let mut acc = 0.0f32;
+    let mut keep = dist.len();
+    for (i, (_, p)) in dist.iter().enumerate() {
+        acc += *p;
+        if acc >= target {
+            keep = i + 1;
+            break;
+        }
+    }
+    if keep < dist.len() {
+        dist.truncate(keep);
+    }
+}
+
+/// Top-k truncation over an **already descending-sorted** dist.
+///
+/// - `top_k == 0` or `top_k >= dist.len()` → no-op.
+/// - Otherwise `dist.truncate(top_k)`.
+pub fn apply_top_k(dist: &mut Vec<(u32, f32)>, top_k: u32) {
+    if top_k == 0 {
+        return;
+    }
+    let k = top_k as usize;
+    if k >= dist.len() {
+        return;
+    }
+    dist.truncate(k);
+}
+
+/// Weighted random draw from `(token, prob)` pairs.
+///
+/// Uses a cumulative-sum inverse-CDF scheme: draws a uniform `u ∈ [0, total)`
+/// from `rng` (via `next_u32` normalized) and returns the first token whose
+/// prefix sum reaches `u`. Does NOT require `probs` to sum to 1.
+///
+/// # Panics
+/// Panics if `dist` is empty — an empty distribution indicates a caller bug
+/// (grammar produced no admissible tokens, which the caller must handle
+/// explicitly, e.g. by falling back to EOS).
+///
+/// # Degenerate input
+/// If all probs are zero or negative, returns `dist[0].0`. The distribution
+/// has collapsed but we still need to return something; callers should
+/// inspect and fall back to a canonical token (EOS) before relying on this.
+pub fn weighted_sample(dist: &[(u32, f32)], rng: &mut impl rand_core::RngCore) -> u32 {
+    assert!(
+        !dist.is_empty(),
+        "weighted_sample called with empty distribution (caller bug)"
+    );
+    let total: f32 = dist.iter().map(|(_, p)| *p).sum();
+    if !total.is_finite() || total <= 0.0 {
+        return dist[0].0;
+    }
+    // uniform [0, 1) from u32 / 2^32
+    let u01 = (rng.next_u32() as f64) / (u32::MAX as f64 + 1.0);
+    let u = (u01 as f32) * total;
+    let mut acc = 0.0f32;
+    // Default to the last token: covers floating-point drift where `acc`
+    // never quite reaches `u` due to rounding.
+    let mut picked = dist[dist.len() - 1].0;
+    for &(id, p) in dist {
+        acc += p;
+        if acc >= u {
+            picked = id;
+            break;
+        }
+    }
+    picked
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_repetition_penalty_scales_history_tokens() {
+        let mut dist = vec![(1u32, 0.5f32), (2u32, 0.3f32), (3u32, 0.2f32)];
+        let mut h = EmittedHistory::new(256);
+        h.push(1);
+        apply_repetition_penalty(&mut dist, &h, 1.1);
+        let new_p1 = dist.iter().find(|(t, _)| *t == 1).unwrap().1;
+        assert!((new_p1 - 0.5 / 1.1).abs() < 1e-6);
+        assert!((dist.iter().find(|(t, _)| *t == 2).unwrap().1 - 0.3).abs() < 1e-6);
+        assert!((dist.iter().find(|(t, _)| *t == 3).unwrap().1 - 0.2).abs() < 1e-6);
+    }
+
+    #[test]
+    fn apply_repetition_penalty_disabled_when_penalty_one() {
+        let mut dist = vec![(1u32, 0.5f32)];
+        let mut h = EmittedHistory::new(256);
+        h.push(1);
+        apply_repetition_penalty(&mut dist, &h, 1.0);
+        assert_eq!(dist[0].1, 0.5);
+    }
+
+    #[test]
+    fn apply_repetition_penalty_empty_history_is_no_op() {
+        let mut dist = vec![(1u32, 0.5f32)];
+        let h = EmittedHistory::new(256);
+        apply_repetition_penalty(&mut dist, &h, 1.5);
+        assert_eq!(dist[0].1, 0.5);
+    }
+
+    #[test]
+    fn apply_top_p_truncates_at_cumulative_mass() {
+        let mut dist = vec![(1u32, 0.5), (2, 0.3), (3, 0.15), (4, 0.05)];
+        apply_top_p(&mut dist, 0.8);
+        assert_eq!(dist.len(), 2);
+    }
+
+    #[test]
+    fn apply_top_p_one_is_no_op() {
+        let mut dist = vec![(1u32, 0.5), (2, 0.5)];
+        apply_top_p(&mut dist, 1.0);
+        assert_eq!(dist.len(), 2);
+    }
+
+    #[test]
+    fn apply_top_p_keeps_at_least_one_element() {
+        // First element alone can already satisfy any top_p < 1.0 when it
+        // dominates the mass.
+        let mut dist = vec![(1u32, 0.9), (2, 0.1)];
+        apply_top_p(&mut dist, 0.5);
+        assert_eq!(dist.len(), 1);
+        assert_eq!(dist[0].0, 1);
+    }
+
+    #[test]
+    fn apply_top_k_truncates_to_k() {
+        let mut dist = vec![(1u32, 0.5), (2, 0.3), (3, 0.2)];
+        apply_top_k(&mut dist, 2);
+        assert_eq!(dist.len(), 2);
+    }
+
+    #[test]
+    fn apply_top_k_zero_is_no_op() {
+        let mut dist = vec![(1u32, 0.5), (2, 0.5)];
+        apply_top_k(&mut dist, 0);
+        assert_eq!(dist.len(), 2);
+    }
+
+    #[test]
+    fn apply_top_k_larger_than_len_is_no_op() {
+        let mut dist = vec![(1u32, 0.5), (2, 0.5)];
+        apply_top_k(&mut dist, 10);
+        assert_eq!(dist.len(), 2);
+    }
+
+    #[test]
+    fn emitted_history_o1_contains() {
+        let mut h = EmittedHistory::new(3);
+        h.push(10);
+        h.push(20);
+        h.push(30);
+        assert!(h.contains(10));
+        h.push(40);
+        assert!(!h.contains(10));
+        assert!(h.contains(40));
+    }
+
+    #[test]
+    fn emitted_history_refcount_duplicate_tokens() {
+        let mut h = EmittedHistory::new(3);
+        h.push(5);
+        h.push(5);
+        h.push(5);
+        assert!(h.contains(5));
+        h.push(6);
+        assert!(h.contains(5));
+        h.push(7);
+        assert!(h.contains(5));
+        h.push(8);
+        assert!(!h.contains(5));
+    }
+
+    #[test]
+    fn emitted_history_zero_capacity_is_sink() {
+        let mut h = EmittedHistory::new(0);
+        h.push(1);
+        h.push(2);
+        assert_eq!(h.len(), 0);
+        assert!(!h.contains(1));
+    }
+
+    #[test]
+    fn weighted_sample_deterministic_with_seeded_rng() {
+        use rand_core::SeedableRng;
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42);
+        let dist = vec![(10u32, 0.5f32), (20u32, 0.5f32)];
+        let t1 = weighted_sample(&dist, &mut rng);
+        let t2 = weighted_sample(&dist, &mut rng);
+        assert!(t1 == 10 || t1 == 20);
+        assert!(t2 == 10 || t2 == 20);
+    }
+
+    #[test]
+    fn weighted_sample_single_element() {
+        use rand_core::SeedableRng;
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+        let dist = vec![(42u32, 1.0f32)];
+        assert_eq!(weighted_sample(&dist, &mut rng), 42);
+    }
+
+    #[test]
+    fn weighted_sample_respects_weights_over_many_draws() {
+        use rand_core::SeedableRng;
+        // 90/10 split — over 10k draws, token 10 should dominate.
+        let dist = vec![(10u32, 0.9f32), (20u32, 0.1f32)];
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(7);
+        let mut count10 = 0usize;
+        let n = 10_000;
+        for _ in 0..n {
+            if weighted_sample(&dist, &mut rng) == 10 {
+                count10 += 1;
+            }
+        }
+        let frac = count10 as f64 / n as f64;
+        assert!(
+            (0.86..0.94).contains(&frac),
+            "expected ~0.9 for token 10, got {}",
+            frac
+        );
+    }
+
+    #[test]
+    fn weighted_sample_all_zero_probs_returns_first() {
+        use rand_core::SeedableRng;
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+        let dist = vec![(7u32, 0.0f32), (8u32, 0.0f32)];
+        assert_eq!(weighted_sample(&dist, &mut rng), 7);
+    }
+
+    #[test]
+    #[should_panic(expected = "empty distribution")]
+    fn weighted_sample_empty_panics() {
+        use rand_core::SeedableRng;
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(1);
+        let dist: Vec<(u32, f32)> = vec![];
+        weighted_sample(&dist, &mut rng);
+    }
+
+    #[test]
+    fn full_pipeline_integration() {
+        // Smoke-test the canonical grammar-path pipeline end-to-end.
+        use rand_core::SeedableRng;
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(99);
+        let mut history = EmittedHistory::new(16);
+        history.push(2); // token 2 will be penalized
+
+        let mut dist = vec![(1u32, 0.5f32), (2, 0.3), (3, 0.15), (4, 0.05)];
+        apply_repetition_penalty(&mut dist, &history, 1.1);
+        dist.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        apply_top_k(&mut dist, 3);
+        apply_top_p(&mut dist, 0.9);
+        assert!(!dist.is_empty());
+        let sampled = weighted_sample(&dist, &mut rng);
+        assert!([1u32, 2, 3, 4].contains(&sampled));
+    }
+}

--- a/sdk/rust/inferlet/wit/deps/core/common.wit
+++ b/sdk/rust/inferlet/wit/deps/core/common.wit
@@ -11,6 +11,17 @@ interface common {
         high,       // Highest priority
     }
 
+    // Per-model sampling defaults sourced from the engine's generation_config.
+    // All fields are optional: absent means the engine/model has no opinion
+    // and the inferlet should fall back to its own neutral default.
+    record generation-defaults {
+        temperature:        option<f32>,
+        top-p:              option<f32>,
+        top-k:              option<u32>,
+        min-p:              option<f32>,
+        repetition-penalty: option<f32>,
+    }
+
     resource blob {
         constructor(init: list<u8>);
         read: func(offset: u64, n: u64) -> list<u8>;
@@ -33,6 +44,7 @@ interface common {
         get-description: func() -> string;           // Human-readable description of the model
         get-prompt-template: func() -> string;       // Returns the prompt formatting template in Tera
         get-stop-tokens: func() -> list<string>;
+        get-generation-defaults: func() -> generation-defaults;
         get-service-id: func() -> u32;
         get-kv-page-size: func() -> u32; // Get the size of a KV page
         create-queue: func() -> queue;               // Create a new command queue

--- a/sdk/rust/inferlet/wit/deps/core/forward.wit
+++ b/sdk/rust/inferlet/wit/deps/core/forward.wit
@@ -56,6 +56,15 @@ interface forward {
         indices: list<u32>,
     );
 
+    /// Token-penalty parameters passed alongside every token-sampling call.
+    /// Neutral values (repetition=1.0, frequency=0.0, presence=0.0) are a
+    /// mathematical no-op so handlers can apply them unconditionally.
+    record penalties {
+        repetition: f32,
+        frequency:  f32,
+        presence:   f32,
+    }
+
     output-distributions: func(
         pass: borrow<forward-pass>,
         indices: list<u32>,
@@ -67,13 +76,15 @@ interface forward {
         pass: borrow<forward-pass>,
         indices: list<u32>,
         temperature: f32,
+        penalties: penalties,
     );
 
     output-tokens-top-k: func(
         pass: borrow<forward-pass>,
         indices: list<u32>,
         temperature: f32,
-        top-k: u32
+        top-k: u32,
+        penalties: penalties,
     );
 
     output-tokens-top-p: func(
@@ -81,6 +92,7 @@ interface forward {
         indices: list<u32>,
         temperature: f32,
         top-p: f32,
+        penalties: penalties,
     );
 
     output-tokens-min-p: func(
@@ -88,6 +100,7 @@ interface forward {
         indices: list<u32>,
         temperature: f32,
         min-p: f32,
+        penalties: penalties,
     );
 
     output-tokens-top-k-top-p: func(
@@ -95,7 +108,8 @@ interface forward {
         indices: list<u32>,
         temperature: f32,
         top-k: u32,
-        top-p: f32
+        top-p: f32,
+        penalties: penalties,
     );
 
     /// Set maximum number of sequential decode steps per execute() call.


### PR DESCRIPTION
# Task 23: unify pie sampling with vLLM generation_config

Part of cross-repo hc task #23. Pairs with:
- pie-vllm task23-unified-sampling (companion PR, opened parallel)
- pieclaw task23-unified-sampling (consumer PR, opened parallel)

## What this PR does

Adds the pie SDK + runtime surface for:

1. **F2 — `generation_config.json` defaults**: new WIT `generation-defaults` record + `get-generation-defaults` method on `model` resource. Rust types `GenerationDefaults`, `SamplingOverrides`, `Penalties`. New `Sampler::merge` + `Model::build_sampler` API that merges client overrides <- model gen_config <- neutral defaults.
2. **F3 — penalty plumbing**: all 6 `Sampler` variants now carry `penalties: Penalties`. WIT `output-tokens-*` signatures extended to carry penalties through the msgpack forward batch. Runtime aggregator extracts per-request penalties into plural SoA arrays (fix committed on top of the initial plumbing).
3. **F3 — reusable sampling primitives**: new `inferlet::sampler::primitives` module — `EmittedHistory` (O(1) contains via HashMap ref-count), `apply_repetition_penalty`, `apply_top_p`, `apply_top_k`, `weighted_sample`. Used by grammar-constrained inferlets that do WASM-side sampling.

## Commits on this branch

```
3667e27d fix(runtime): aggregate penalty fields into batch-level SoA arrays
5678b55d feat(sdk): reusable sampling primitives (penalties, top_p, top_k, weighted_sample, EmittedHistory)
b58c77b2 feat(runtime): plumb penalties through msgpack forward batch
727eaefe feat(sdk): extend Sampler variants with Penalties
7bc29264 feat(runtime): read generation_defaults from model state in get_generation_defaults
c949cec9 test(sdk): merge edge cases — empty gen_config, disabled top_p, cascade arm coverage
bbe9df3d feat(sdk): Sampler::merge + Model::build_sampler
73d6d7d3 feat(sdk): add GenerationDefaults, SamplingOverrides, Model::generation_defaults()
c05ce2f8 feat(sdk): add generation-defaults WIT record + host stub
```

## Test status

- SDK unit tests: 30 passing (12 merge tests + 18 primitive tests).
- Runtime lib: 26 passing (22 pre-existing + 4 new aggregator tests).
- WASM builds clean (wasm32-wasip2 release).

## Pending

- End-to-end pod validation (Qwen2.5-72B-Instruct-AWQ on A100-80GB) is deferred pending benchmark-harness scaffolding in pieclaw. See pieclaw PR.

## Design rationale

See `docs/plans/2026-04-21-task23-unified-sampling-design.md` in the pieclaw repo for the full architectural discussion. Highlights:
- Engine stays a dumb compute backend; policy lives in the SDK (runs inside WASM); inferlet owns merge semantics.
- `GenerationDefaults` / `SamplingOverrides` are deliberately asymmetric — `GenerationDefaults` excludes `frequency_penalty` / `presence_penalty` because those never appear in HF `generation_config.json` (verified across 9 production models).
- Penalties reach vLLM's fused Triton kernel via `vllm.SamplingParams` — no new GPU code.