### PR TITLE
sdk(inferlet): decode_step_and_fill + loud contract docs (silent SSE stall fix)

### DIFF
--- a/sdk/demo/zo-training/inferlets/es-rollout/src/lib.rs
+++ b/sdk/demo/zo-training/inferlets/es-rollout/src/lib.rs
@@ -49,8 +49,7 @@ async fn main(mut args: Args) -> Result<String> {
             let mut generated_token_ids = Vec::new();
 
             loop {
-                let next_token_id = ctx.decode_step(&sampler).await;
-                ctx.fill_token(next_token_id);
+                let next_token_id = ctx.decode_step_and_fill(&sampler).await;
                 generated_token_ids.push(next_token_id);
                 if stop_cond_.check(&generated_token_ids) {
                     break;

--- a/sdk/examples/attention-sink/src/lib.rs
+++ b/sdk/examples/attention-sink/src/lib.rs
@@ -38,9 +38,8 @@ pub async fn generate_with_attention_sink<C: StopCondition>(
     let max_cache_size = attention_sink_initial_size + attention_sink_window_size;
 
     loop {
-        // 1. Decode the next token
-        let next_token_id = ctx.decode_step(sampler).await;
-        ctx.fill_token(next_token_id);
+        // 1. Decode the next token and seed the next step.
+        let next_token_id = ctx.decode_step_and_fill(sampler).await;
         generated_token_ids.push(next_token_id);
 
         // 2. Check if the stop condition is met

--- a/sdk/examples/windowed-attention/src/lib.rs
+++ b/sdk/examples/windowed-attention/src/lib.rs
@@ -19,9 +19,8 @@ pub async fn generate_with_sliding_window<C: StopCondition>(
 
     // The autoregressive generation loop
     loop {
-        // 1. Decode the next token, sample, and add it to the pending buffer.
-        let next_token_id = ctx.decode_step(&sampler).await;
-        ctx.fill_token(next_token_id);
+        // 1. Decode the next token and seed the next step.
+        let next_token_id = ctx.decode_step_and_fill(&sampler).await;
         generated_token_ids.push(next_token_id);
 
         // 2. Check for the stop condition.

--- a/sdk/rust/inferlet/src/context.rs
+++ b/sdk/rust/inferlet/src/context.rs
@@ -602,8 +602,35 @@ impl Context {
     ///
     /// # Returns
     ///
-    /// A `Result` containing the `Distribution` over the next possible tokens,
-    /// or an error if the generation step could not be performed.
+    /// The sampled next-token id. The sampled token is **not** committed to
+    /// pending — callers must seed the next step themselves.
+    ///
+    /// # Contract — per-token loops REQUIRE `fill_token` between calls
+    ///
+    /// The returned token is the seed for the next step but is *not* placed
+    /// in `token_ids_pending` automatically. Calling `decode_step` again
+    /// without an intervening `fill_token(returned)` leaves pending empty
+    /// and trips the `!token_ids_pending.is_empty()` assertion inside
+    /// `prepare_forward_pass`.
+    ///
+    /// Under the pie HTTP runtime that assertion's panic manifests as a
+    /// **silent stream stall**: the WASM handler's future never resolves,
+    /// the SSE response body is left half-open, and the client only
+    /// recovers when its own read timeout fires. The canonical per-token
+    /// loop is:
+    ///
+    /// ```ignore
+    /// loop {
+    ///     let next = ctx.decode_step(&sampler).await;
+    ///     ctx.fill_token(next);           // ← MUST be here
+    ///     generated.push(next);
+    ///     if stop_cond.check(&generated) { break; }
+    /// }
+    /// ```
+    ///
+    /// For per-token loops, prefer [`Context::decode_step_and_fill`], which
+    /// performs the `fill_token` automatically and is impossible to misuse
+    /// in this way.
     pub async fn decode_step(&mut self, sampler: &Sampler) -> u32 {
         let (p, pending_token_ids, position_ids) = self.prepare_forward_pass(sampler, 0);
 
@@ -624,6 +651,27 @@ impl Context {
         self.token_ids.extend(pending_token_ids);
         self.position_ids.extend(position_ids);
 
+        sampled
+    }
+
+    /// Single-step decode that also seeds the next step.
+    ///
+    /// Equivalent to `decode_step` followed by `fill_token(returned)`.
+    /// Prefer this helper for per-token decode loops — it makes the
+    /// `decode_step` → `fill_token` contract un-skippable by construction,
+    /// eliminating the silent-stream-stall failure mode described in
+    /// [`Context::decode_step`]'s documentation.
+    ///
+    /// ```ignore
+    /// loop {
+    ///     let next = ctx.decode_step_and_fill(&sampler).await;
+    ///     generated.push(next);
+    ///     if stop_cond.check(&generated) { break; }
+    /// }
+    /// ```
+    pub async fn decode_step_and_fill(&mut self, sampler: &Sampler) -> u32 {
+        let sampled = self.decode_step(sampler).await;
+        self.fill_token(sampled);
         sampled
     }
 
@@ -813,7 +861,14 @@ impl Context {
     ) -> (ForwardPass, Vec<u32>, Vec<u32>) {
         assert!(
             !self.token_ids_pending.is_empty(),
-            "Must have at least one seed token"
+            "prepare_forward_pass: token_ids_pending is empty. A decode call \
+             (decode_step / decode_n / decode_stream) was made with no seed \
+             token. This is usually caused by a per-token decode_step loop \
+             that forgot to call fill_token(returned) between iterations — \
+             see Context::decode_step docs and prefer decode_step_and_fill. \
+             Under the pie HTTP runtime this panic manifests as a silent \
+             stream stall; the client only recovers via its own read \
+             timeout."
         );
 
         let pending_token_ids = mem::take(&mut self.token_ids_pending);

--- a/std/openresponses-server/src/handler.rs
+++ b/std/openresponses-server/src/handler.rs
@@ -183,8 +183,7 @@ async fn handle_streaming_response(
 
     // Token-by-token generation loop with TRUE streaming
     loop {
-        let next_token_id = ctx.decode_step(&sampler).await;
-        ctx.fill_token(next_token_id);
+        let next_token_id = ctx.decode_step_and_fill(&sampler).await;
         generated_token_ids.push(next_token_id);
 
         // Decode just this token to get the delta text


### PR DESCRIPTION
## Problem

`Context::decode_step` returns the sampled token but does **not** commit it to `token_ids_pending`. Callers must invoke `fill_token(returned)` before the next decode call, or `prepare_forward_pass`'s assertion

```rust
assert!(!self.token_ids_pending.is_empty(), "Must have at least one seed token");
```

fires on the second iteration.

Under the pie HTTP runtime that assertion's panic manifests as a **silent stream stall**, not a visible trap: the WASM handler's future never resolves, the SSE response body is left half-open, and the client only recovers when its own read timeout fires. No error surfaces in the pie-http log (the inner `eprintln!("error: {e:?}")` at `runtime/src/runtime.rs:1217` never runs because the call never returns).

### Reproduction

- Pod: RunPod A100-SXM4-80GB, `sslee0cs/pie-vllm-engine:pieclaw-home`, Qwen2.5-72B-AWQ.
- Inferlet: hermes-openai-compat with a streaming handler whose per-token loop was `for _ in 0..dn { tokens.push(ctx.decode_step(&sampler).await); }` — no `fill_token` between iterations.
- Symptom: 3 SSE chunks out (role + trace comment + 1 content token), then 12+ seconds of silence, client times out. Engine reports `Batches: [9]` (forward passes completed), no trap/panic in pie-http.log.
- Control: adding `ctx.fill_token(tok)` between iterations produces a clean 428 ms stream of 14 events; switching to `decode_n(8)` likewise recovers.

Before/after probe numbers: 3 events → stream wedged vs. 69 events in 2239 ms on the fixed variant.

## What this PR does

This PR does not change the existing contract (doing so would silently break every correct external caller that does `decode_step` + `fill_token`). It adds defensive and ergonomic improvements instead:

1. **New `Context::decode_step_and_fill` helper** — performs `decode_step` followed by `fill_token`. Makes the contract un-skippable by construction. Recommended for per-token loops.
2. **Loud docstring on `decode_step`** — explains (a) the contract and (b) the silent-stream-stall failure mode. Cross-references the new helper.
3. **Actionable assertion message in `prepare_forward_pass`** — spells out the likely root cause ("per-token `decode_step` loop that forgot `fill_token`") and the failure mode, so if the panic does fire, its text points directly at the fix.
4. **In-tree user-facing callers migrated to the new helper** as reference implementations: `sdk/examples/attention-sink`, `sdk/examples/windowed-attention`, `sdk/demo/zo-training/inferlets/es-rollout`, `std/openresponses-server`. Each one becomes 1 line shorter.

Internal callers inside `decode_n` / `decode_stream` fallback paths (`context.rs:670` and `:770`) intentionally keep `decode_step` without auto-fill, because those wrappers have their own caller-fills-last contract.

## Scope explicitly NOT in this PR

**Runtime-side fix** for the "silent" part of the silent stall: when `handle_func.call_async` returns `Err`, the response body should be closed so clients see EOF rather than indefinite silence. That's a separate change in `pie/runtime/src/runtime.rs` and warrants its own review — opening as a follow-up issue.

**Breaking auto-fill semantics on `decode_step`** — would eliminate the contract entirely but silently double-fills every correct external caller (`decode_step`; `fill_token`). Not safe without a deprecation cycle.

## Test plan

- [x] `cargo check --lib` in `sdk/rust/inferlet` — clean
- [x] `cargo build --target wasm32-wasip2 --release` on all four migrated callers — clean (except pre-existing `es-rollout` macro issue on `pieclaw/home` that is unrelated to this change: `"ingim/es_rollout" is not a valid identifier`)
- [x] e2e: re-ran the hermes-openai-compat repro on the same pod after applying `decode_step_and_fill` — stall gone; 14 events in 428 ms, coherent output

## Verified on

`pie@c77fd090` (pieclaw/home tip) + `pie-vllm@9cba3a88`.