### PR TITLE
fix(runtime): propagate fire_batch Python errors instead of silent empty completions

### DIFF
--- a/runtime/src/model.rs
+++ b/runtime/src/model.rs
@@ -986,6 +986,30 @@ impl Model {
 
         match result {
             Ok(batch_resp) => {
+                // Python raised inside fire_batch: propagate as per-request
+                // instance termination rather than silently dropping into the
+                // "no response → empty tokens" path that used to mask errors
+                // as HTTP 200 + completion_tokens=0 (task #48).
+                if let Some(err_msg) = batch_resp.error.as_ref() {
+                    eprintln!(
+                        "[Error] fire_batch returned error for batch={} reqs={}: {}",
+                        trace_batch_id, batch_size, err_msg
+                    );
+                    for (fp_req, resp_tx) in requests {
+                        // Drop streaming sender so WASM sees the stream end
+                        // before the termination notification arrives.
+                        drop(fp_req.token_stream_tx);
+                        drop(resp_tx);
+                        if let Some(inst_id) = fp_req.inst_id {
+                            terminate_instance_with_exception(
+                                inst_id,
+                                format!("fire_batch failed: {}", err_msg),
+                            );
+                        }
+                    }
+                    return;
+                }
+
                 // Collect all continuations FIRST, then send them in bulk.
                 // This prevents tokio from interleaving the scheduler loop
                 // between individual sends, which causes batch fragmentation

--- a/runtime/src/model/request.rs
+++ b/runtime/src/model/request.rs
@@ -595,10 +595,21 @@ impl Default for BatchedForwardPassRequest {
 }
 
 /// Batched forward pass response from Python via pycrust.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// `error` is populated by the Python fire_batch wrapper when the batch
+/// raised an exception (see pie/src/pie/manager.py). Prior to its addition,
+/// rmp_serde silently discarded the error string because the Rust struct
+/// only had `results`; failed batches manifested on the client as HTTP 200
+/// with completion_tokens=0 (task #48). Callers MUST check `error` before
+/// treating an empty `results` as successful completion.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct BatchedForwardPassResponse {
-    /// Results indexed by request order in the batch.
+    /// Results indexed by request order in the batch. Empty when `error` is set.
+    #[serde(default)]
     pub results: Vec<ForwardPassResponse>,
+    /// Python-side exception string from fire_batch (None on success).
+    #[serde(default)]
+    pub error: Option<String>,
 }
 
 #[cfg(test)]
@@ -730,5 +741,34 @@ mod tests {
         assert_eq!(batch.sampler_repetition_penalty.0, vec![1.1f32, 1.2f32]);
         assert_eq!(batch.sampler_frequency_penalty.0, vec![0.3f32, 0.5f32]);
         assert_eq!(batch.sampler_presence_penalty.0, vec![0.4f32, 0.6f32]);
+    }
+
+    /// Wire-compat with the Python fire_batch error path
+    /// (pie/src/pie/manager.py: `msgpack.packb({"error": str(e), "results": []})`).
+    /// Prior to adding the `error` field this deserialized with a silently
+    /// ignored key and manifested as HTTP 200 + completion_tokens=0 (task #48).
+    #[test]
+    fn batched_response_deserializes_error_from_python() {
+        let err_payload = rmpv::Value::Map(vec![
+            (rmpv::Value::from("error"),
+             rmpv::Value::from("AssertionError at execute_step")),
+            (rmpv::Value::from("results"), rmpv::Value::Array(vec![])),
+        ]);
+        let bytes = rmp_serde::to_vec_named(&err_payload).unwrap();
+        let parsed: BatchedForwardPassResponse = rmp_serde::from_slice(&bytes).unwrap();
+        assert!(parsed.results.is_empty());
+        assert_eq!(parsed.error.as_deref(), Some("AssertionError at execute_step"));
+    }
+
+    /// The success path (no `error` key present) must still deserialize.
+    #[test]
+    fn batched_response_deserializes_ok_without_error_key() {
+        let ok_payload = rmpv::Value::Map(vec![
+            (rmpv::Value::from("results"), rmpv::Value::Array(vec![])),
+        ]);
+        let bytes = rmp_serde::to_vec_named(&ok_payload).unwrap();
+        let parsed: BatchedForwardPassResponse = rmp_serde::from_slice(&bytes).unwrap();
+        assert!(parsed.results.is_empty());
+        assert!(parsed.error.is_none());
     }
 }


### PR DESCRIPTION
## Summary

When the Python worker raises inside `fire_batch` (`pie/src/pie/manager.py:1418-1425` catches the exception and sends `{"error": str(e), "results": []}` on the side-channel), the Rust `BatchedForwardPassResponse` previously only had a `results` field, so `rmp_serde` silently discarded `error`. Every request in the failed batch took the no-response path in `execute_forward_pass_batch`:

- Multi-step: sent `ForwardPassResponse { tokens: [], dists: [] }` to WASM
- Non-multi-step: dropped `resp_tx`, oneshot gave the SDK `Canceled`

The inferlet SDK treats empty tokens as _\"engine returned no tokens — final exit\"_ and breaks out of `generate()`. The client received HTTP 200 with `usage.completion_tokens=0` and `finish_reason=\"stop\"`. An upstream `AssertionError` at `execute_step` thus looked identical to a normal short completion on the wire, masking production incidents.

Observed downstream (pie-hermes task #48): at N=32 on Qwen2.5-72B-AWQ, 54% of requests reported `completion_tokens=0` with zero HTTP errors while the engine log showed `[ERROR] execute_step failed: AssertionError` and `[FIRE-BATCH-SOCK Error]`.

## Changes

1. Add `error: Option<String>` to `BatchedForwardPassResponse` with `#[serde(default)]`. Wire-compatible with existing success payloads (absent key → `None`).
2. On a fire_batch error, propagate via `terminate_instance_with_exception` per request so the client receives a proper error instead of a successful-looking empty completion.
3. Two deserialization unit tests covering the error payload and the backward-compatible success payload.

## Scope

This patch makes the failure **observable**, not **prevented**. The underlying AssertionError that triggers fire_batch failure at high concurrency needs a separate fix once the error surface is clear.

## Test plan

- [x] `cargo test --lib request::tests::batched` — 2 new tests pass
- [x] `cargo check --manifest-path runtime/Cargo.toml` — clean
- [ ] End-to-end: rebuild pie on pod, rerun the N=32 bench from pie-hermes/task #48, confirm clients now see a 5xx instead of HTTP 200 + empty completion (in flight)

## Related

- pie-hermes task #48 (reporter)
- pie-hermes PR #14 (wedge fix that unblocked observation of this bug — without that fix the requests hung at 300s so this codepath never fired)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable server host binding (default `127.0.0.1`).
  * Introduced vLLM backend as an alternative inference engine option.
  * Added server-side chat formatting with HuggingFace template support.
  * Exposed model-level generation defaults (temperature, top-p, top-k, min-p, repetition-penalty).
  * Added token sampling penalties (repetition, frequency, presence) for fine-grained control.
  * Enabled multi-step decode operations per execution call.
  * Improved batch scheduling and request merging for throughput optimization.

* **SDK Enhancements**
  * Rust SDK: streaming token execution and KV cache synchronous export.
  * Python SDK: extended forward pass with actual KV page tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->