### PR TITLE
Add decode_step_dist_top_k for explicit top_k control

### DIFF
--- a/sdk/rust/inferlet/src/context.rs
+++ b/sdk/rust/inferlet/src/context.rs
@@ -586,6 +586,15 @@ impl Context {
     /// A `Result` containing the `Distribution` over the next possible tokens,
     /// or an error if the generation step could not be performed.
     pub async fn decode_step_dist(&mut self) -> Distribution {
+        self.decode_step_dist_top_k(None).await
+    }
+
+    /// Like `decode_step_dist`, but with an explicit `top_k` parameter
+    /// controlling how many tokens are returned in the distribution.
+    ///
+    /// Use a large value (e.g. 131072) for loglikelihood scoring where you
+    /// need to find arbitrary tokens in the distribution.
+    pub async fn decode_step_dist_top_k(&mut self, top_k: Option<u32>) -> Distribution {
         assert!(
             !self.token_ids_pending.is_empty(),
             "Must have at least one seed token"
@@ -597,13 +606,6 @@ impl Context {
             (last_pos_id..(last_pos_id + pending_token_ids.len() as u32)).collect::<Vec<u32>>();
 
         self.grow_kv_pages(pending_token_ids.len());
-
-        // println!("next token id: {}", next_token_id);
-        // println!("next pos id: {}", next_pos_id);
-        // println!("kv page last len: {}", self.kv_page_last_len);
-        // println!("kv page ids: {:?}", &self.kv_page_ids);
-        // println!("token ids: {:?}", &self.token_ids);
-        // println!("token ids pending: {:?}", &self.token_ids_pending);
 
         let mask = mem::take(&mut self.token_mask_pending)
             .into_iter()
@@ -625,7 +627,7 @@ impl Context {
         p.attention_mask(&mask);
 
         let output_idx = pending_token_ids.len() as u32 - 1;
-        p.output_distributions(&[output_idx], 1.0, None);
+        p.output_distributions(&[output_idx], 1.0, top_k);
 
         let res = p.execute().await;
 


### PR DESCRIPTION
# Add `decode_step_dist_top_k` to inferlet SDK

## Problem

`decode_step_dist()` passes `None` as the `top_k` argument to `output_distributions()`, which defaults to 32 in the runtime (`forward.rs:217`). This means inferlets only receive the probability distribution over the top 32 tokens.

For text generation this is fine (the next token is almost always in the top 32), but it is limiting for many other more advanced inferlets. For instance, for **loglikelihood scoring** (used by MCQ benchmarks like ARC and MMLU), you need to look up the probability of specific continuation tokens that may be anywhere in the vocabulary. Tokens outside the top 32 get a probability of 0.

## Fix

Add `decode_step_dist_top_k(top_k: Option<u32>)` to `Context`, which forwards the `top_k` parameter to `output_distributions()`. The existing `decode_step_dist()` delegates to it with `None`, so this is fully backwards compatible.

Inferlets that need full vocabulary access (e.g. loglikelihood scoring) can call:

```rust
let dist = ctx.decode_step_dist_top_k(Some(131072)).await;
```

## Changes

- `sdk/rust/inferlet/src/context.rs`: Add `decode_step_dist_top_k()`, refactor `decode_step_dist()` to delegate to it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional top-k parameter to control token selection during inference. Users can now customize the maximum number of top-ranked tokens considered when generating model outputs. This enhancement provides more granular control over inference behavior and enables tuning of output diversity and quality based on specific requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->