### PR TITLE
Fix silent exception swallowing in pie run

### DIFF
--- a/pie/src/pie_cli/run.py
+++ b/pie/src/pie_cli/run.py
@@ -154,9 +154,9 @@ def run(
 
         if isinstance(e, manager.EngineError):
             console.print(f"[red]✗[/red] {e}")
-            manager.terminate_engine_and_backend(server_handle, backend_processes)
-            raise typer.Exit(1)
-    except Exception as e:
-        console.print(f"[red]✗[/red] Error: {e}")
+        else:
+            console.print(f"[red]✗[/red] Error: {e}")
+            import traceback
+            traceback.print_exc()
         manager.terminate_engine_and_backend(server_handle, backend_processes)
         raise typer.Exit(1)


### PR DESCRIPTION
# Fix silent exception swallowing in `pie run`

## Problem

`pie run` has two consecutive `except Exception` blocks. The first one only handles `EngineError` and exits, which means the second block is unreachable — any non-`EngineError` exception is caught by the first block, silently ignored (no traceback, no error message), and the process exits with code 1.

```python
except Exception as e:
    if isinstance(e, manager.EngineError):
        console.print(f"[red]✗[/red] {e}")
        manager.terminate_engine_and_backend(server_handle, backend_processes)
        raise typer.Exit(1)
except Exception as e:          # <- unreachable
    console.print(f"[red]✗[/red] Error: {e}")
    ...
```

This makes debugging `pie run` failures difficult — the process just exits silently with no output.

## Example

Running `pie run loglikelihood.wasm` (missing `--path` flag) would silently exit with code 1 and no output. The underlying error (positional arg treated as a registry name) was caught by the first block, not matched as `EngineError`, and discarded. With this fix, the actual exception and traceback are printed.

## Fix

Merge the two blocks into a single `except Exception` with an `if/else` on `EngineError`. Non-engine errors now print a traceback before exiting.