### PR TITLE
fix(runtime): propagate full error chain in TerminationCause::Exception

### DIFF
--- a/runtime/src/model.rs
+++ b/runtime/src/model.rs
@@ -213,11 +213,14 @@ pub fn submit_request(
 
 fn terminate_instance_with_exception<T>(inst_id: InstanceId, exception: T)
 where
-    T: ToString,
+    T: std::fmt::Display,
 {
+    // Use anyhow's alternate Display so `anyhow::Error` callers (most of them)
+    // pass through their full error chain instead of just the top-level
+    // message. For `String` callers this is identical to `{}`.
     runtime::Command::TerminateInstance {
         inst_id,
-        notification_to_client: Some(TerminationCause::Exception(exception.to_string())),
+        notification_to_client: Some(TerminationCause::Exception(format!("{exception:#}"))),
     }
     .dispatch();
 }

--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -1410,8 +1410,12 @@ impl Runtime {
                     Err(RuntimeError::Other(runtime_err))
                 }
                 Err(call_err) => {
-                    //eprintln!("Instance {instance_id} call error: {call_err}");
-                    Err(RuntimeError::Other(format!("Call error: {call_err}")))
+                    // Print the full error chain (anyhow's alternate Display)
+                    // so host-function `bail!` messages — e.g. "max batch
+                    // tokens exceeded, input tokens: N, max tokens: M" — reach
+                    // the inferlet status string instead of being collapsed
+                    // into the top-level "error while executing" trap text.
+                    Err(RuntimeError::Other(format!("Call error: {call_err:#}")))
                 }
             };
         }


### PR DESCRIPTION
Host-function errors raised via `bail!` (e.g. "max batch tokens exceeded, input tokens: N, max tokens: M" from forward.rs) were being collapsed into wasmtime's top-level "error while executing" trap text by the time they reached the inferlet status. Users only saw a generic stack trace with no underlying cause.

Two sites lost the chain:

- runtime.rs:1414 — `format!("Call error: {call_err}")` uses Display, which for `wasmtime::Error` (anyhow::Error) prints only the top-level message. Switch to `{call_err:#}` (alternate Display) to walk the source chain and include the original `bail!` message.

- model.rs:214 — `terminate_instance_with_exception<T: ToString>` calls `.to_string()`, again top-level only. Tighten the bound to `Display` and use `{exception:#}`. Identical output for `String` callers; full chain for `anyhow::Error` callers (the common case).