### PR TITLE
fix(pie_kernels/cuda/rand_mv): auto-detect compute capability + lazy-resolve all variants

### DIFF
--- a/pie/src/pie_kernels/cuda/rand_mv_new.py
+++ b/pie/src/pie_kernels/cuda/rand_mv_new.py
@@ -53,14 +53,19 @@ else:
         key = (rng_method, rounds)
         if key in _ext_cache:
             return _ext_cache[key]
+        # SM tag is in the name + gencode so a single source tree builds
+        # for whichever GPU is present (A100 sm_80, RTX-30 sm_86, L40 sm_89,
+        # H100 sm_90).
+        cc_major, cc_minor = torch.cuda.get_device_capability()
+        sm_tag = f"{cc_major}{cc_minor}"
         ext = load(
-            name=f"rand_mv_cuda_v13_m{rng_method}_r{rounds}",
+            name=f"rand_mv_cuda_v13_sm{sm_tag}_m{rng_method}_r{rounds}",
             sources=[os.path.join(_HERE, "cuda_kernels.cu")],
             extra_cuda_cflags=[
                 "-O3",
                 "--use_fast_math",
                 "-lineinfo",
-                "-gencode=arch=compute_86,code=sm_86",
+                f"-gencode=arch=compute_{sm_tag},code=sm_{sm_tag}",
                 "-std=c++17",
                 f"-DRNG_METHOD={rng_method}",
                 f"-DPHILOX_ROUNDS={rounds}",
@@ -216,14 +221,14 @@ else:
             # the bound namespace).
             return getattr(self._resolve(), name)
 
-    BM7    = _bind(_get_ext(0,  7))
+    # All four variants are lazy: _get_ext() runs torch.utils.cpp_extension.load
+    # which creates a CUDA primary context as a side effect; doing that at module
+    # import (before the caller's torch.cuda.set_device) breaks the device handle
+    # on some archs.
+    BM7    = _LazyVariant(0,  7)
     BM     = _LazyVariant(0, 10)
     PROBIT = _LazyVariant(1, 10)
     ZIG    = _LazyVariant(2, 10)
-    # BM is the default n_rounds=10 variant — every hot-path top-level call
-    # routes to it. Resolve eagerly so dispatch doesn't pay the __getattr__
-    # tax on the first batch of every fresh run.
-    BM._resolve()
 
     # Public top-level API.
     #


### PR DESCRIPTION
## Summary

Two related issues that together broke pie on Ada (RTX 4090, sm_89) and likely on every GPU other than sm_86 / A100-class hardware:

1. **Hardcoded gencode** — `pie/src/pie_kernels/cuda/rand_mv_new.py:_get_ext` passed `-gencode=arch=compute_86,code=sm_86` unconditionally, so any GPU other than Ampere paid for an arch-mismatched cubin.

2. **Eager compile at module load** — `BM7 = _bind(_get_ext(0, 7))` and `BM._resolve()` called `torch.utils.cpp_extension.load(...)` at module import. That compile creates a CUDA primary context as a side effect; doing it before any caller has had a chance to `torch.cuda.set_device(...)` leaves the device handle in a state where the next set_device returns `cudaErrorDevicesUnavailable`.

This patch fixes both.

## Failure mode

Every entry point that imports `pie_driver.engine` (which pulls in `pie_kernels.rand_mv` and triggers the eager compile) dies on a non-Ampere GPU in the spawned worker:

\`\`\`
File ".../pie_driver/worker.py", line 188, in run_worker
    torch.cuda.set_device(device_str)
torch.AcceleratorError: CUDA error: CUDA-capable device(s) is/are busy or unavailable
\`\`\`

\`nvidia-smi\` shows the device idle. \`torch.cuda.is_available()\` returns True. \`torch.cuda.device_count()\` returns 1. Just \`set_device\` fails — because the eager \`cpp_extension.load\` already grabbed/corrupted the primary context.

The breakage hits \`pie run\`, \`pie serve\`, the dummy / vllm / native driver workers, and any test that imports \`pie_driver.engine\`.

## Why both changes are needed

Either change alone is insufficient on Ada:

| | hardcoded sm_86 | + auto-detect sm_89 | + auto-detect + lazy |
| --- | --- | --- | --- |
| set_device after Engine import (no prior context) | FAIL | **FAIL** | OK |
| set_device BEFORE Engine import (context exists) | OK\* | OK | OK |

\* with set_device first, the primary context already exists, so the eager compile's context-creation side effect is a no-op switch and the device handle survives.

So gencode-only ships a faster cubin for the actual kernel call, but it doesn't unblock pie's spawned worker — that requires the lazy change.

## What this PR does

\`pie/src/pie_kernels/cuda/rand_mv_new.py\`:

\`\`\`python
# In _get_ext():
cc_major, cc_minor = torch.cuda.get_device_capability()
sm_tag = f"{cc_major}{cc_minor}"
ext = load(
    name=f"rand_mv_cuda_v13_sm{sm_tag}_m{rng_method}_r{rounds}",
    ...
    f"-gencode=arch=compute_{sm_tag},code=sm_{sm_tag}",
    ...
)

# At module level — all four variants lazy:
BM7    = _LazyVariant(0,  7)   # was: _bind(_get_ext(0, 7))
BM     = _LazyVariant(0, 10)
PROBIT = _LazyVariant(1, 10)
ZIG    = _LazyVariant(2, 10)
# (removed) BM._resolve()  # was eager
\`\`\`

## Prior art in this repo

\`pie/src/pie_driver_sgl/rand_mv/cuda/rand_mv_new.py\` (commit \`b67ff7b2\` on \`features/deva-integration\`) already uses the auto-detect pattern, with a comment naming the GPUs that need it (\`A100 sm_80, RTX-30 sm_86, L40 sm_89, H100 sm_90\`). The native \`pie_kernels\` copy never got the same treatment.

The sgl sibling still has the eager \`_bind(_get_ext(...))\` pattern though — same load-bearing bug for any caller that hits sgl-driver-via-eager-compile-before-set_device. Worth following up there too; out of scope for this PR.

## Verification (RTX 4090, sm_89)

Reproduced and bisected with isolated test scripts:

| Test | Without fix | With fix |
| --- | --- | --- |
| \`from pie_driver.engine import Engine\` | ~183s (eager nvcc compile of sm_86) | ~5s (truly lazy) |
| \`torch.cuda.set_device("cuda:0")\` after Engine import (no prior context) | **FAIL** cudaErrorDevicesUnavailable | **OK** |
| \`torch.zeros(1, device="cuda:0")\` after | n/a | **OK** shape=torch.Size([1]) |

## Compatibility

- Ampere paths get the same compile they always did (templated string produces \`-gencode=arch=compute_86,code=sm_86\` when sm_tag=86).
- Adds correct support for sm_89 (RTX 4090 / L40), sm_90 (H100), sm_120 (Blackwell, future).
- First call into rand_mv now pays the compile cost where it previously was paid at import; total wall time is the same, the difference is *when* the compile fires.
- \`BM\` no longer pre-resolves at import; the first call goes through \`__getattr__\` -> \`_resolve()\`, ~1µs overhead, which is dominated by the multi-second nvcc compile that runs anyway.