### PR TITLE
fix(runtime): accept HF CamelCase arch names so vllm/sgl drivers enable thinking (closes #328)

### DIFF
--- a/runtime/src/model/instruct.rs
+++ b/runtime/src/model/instruct.rs
@@ -103,27 +103,96 @@ pub trait Instruct: Send + Sync {
 }
 
 /// Create the appropriate instruct implementation for the given architecture.
+///
+/// Accepts both pie's lowercase internal arch names (e.g. `"qwen3"`, what the
+/// `pie_driver` path forwards) and the HuggingFace `architectures[0]` strings
+/// (e.g. `"Qwen3ForCausalLM"`, what the `pie_driver_vllm` / `pie_driver_sgl`
+/// paths forward — see `pie/src/pie/capabilities.py::DriverCapabilities`).
+///
+/// **Why both forms:** `pie_driver/loader.py` translates HF `model_type` →
+/// pie internal name via `HF_TO_PIE_ARCH` before the handshake, but
+/// `pie_driver_vllm/loader.py` and `pie_driver_sgl/loader.py` forward
+/// `architectures[0]` verbatim. Without aliasing, any model loaded through
+/// the vllm/sgl drivers silently falls through to the `_` arm, which uses
+/// `has_thinking: false` and `has_tools: false` — that was the root cause of
+/// pie-project/pie#328 (Qwen3 `.with_reasoning()` returning empty `thinking`).
+///
+/// `LlamaForCausalLM` is intentionally NOT aliased here: it's used by both
+/// llama2 and llama3 in HF and disambiguation needs config-level signals
+/// (e.g. rope_scaling). The Python driver MUST hand off the disambiguated
+/// pie internal name (`"llama2"` or `"llama3"`) for those.
 pub fn create(arch_name: &str, tokenizer: Arc<Tokenizer>) -> Arc<dyn Instruct> {
     use self::qwen3::{QwenInstruct, ChatMLConfig};
 
     match arch_name {
-        "qwen3" => Arc::new(QwenInstruct::new(tokenizer, ChatMLConfig {
+        "qwen3" | "Qwen3ForCausalLM" => Arc::new(QwenInstruct::new(tokenizer, ChatMLConfig {
             has_thinking: true,
             has_tools: true,
             stop_tokens: &["<|im_end|>", "<|endoftext|>"],
         })),
-        "qwen2" => Arc::new(self::qwen2::new(tokenizer)),
+        "qwen2" | "Qwen2ForCausalLM" | "Qwen2_5ForCausalLM" => Arc::new(self::qwen2::new(tokenizer)),
         "llama2" => Arc::new(self::llama2::LlamaInstruct::new(tokenizer)),
         "llama3" | "l4ma" => Arc::new(self::llama3::LlamaInstruct::new(tokenizer)),
-        "r1" | "deepseek_v3" => Arc::new(self::r1::R1Instruct::new(tokenizer)),
-        "gptoss" | "gpt_oss" => Arc::new(self::gptoss::GptOssInstruct::new(tokenizer)),
-        "gemma2" | "gemma3" => Arc::new(self::gemma2::GemmaInstruct::new(tokenizer)),
-        "mistral3" | "ministral3" => Arc::new(self::mistral3::MistralInstruct::new(tokenizer)),
-        "olmo3" => Arc::new(self::olmo3::OlmoInstruct::new(tokenizer)),
+        "r1" | "deepseek_v3" | "DeepseekV3ForCausalLM" => Arc::new(self::r1::R1Instruct::new(tokenizer)),
+        "gptoss" | "gpt_oss" | "GptOssForCausalLM" => Arc::new(self::gptoss::GptOssInstruct::new(tokenizer)),
+        "gemma2" | "gemma3" | "Gemma2ForCausalLM" | "Gemma3ForCausalLM" | "Gemma3TextForCausalLM"
+            => Arc::new(self::gemma2::GemmaInstruct::new(tokenizer)),
+        "mistral3" | "ministral3" | "Mistral3ForCausalLM" => Arc::new(self::mistral3::MistralInstruct::new(tokenizer)),
+        "olmo3" | "Olmo3ForCausalLM" => Arc::new(self::olmo3::OlmoInstruct::new(tokenizer)),
         _ => Arc::new(QwenInstruct::new(tokenizer, ChatMLConfig {
             has_thinking: false,
             has_tools: false,
             stop_tokens: &["<|im_end|>", "<|endoftext|>"],
         })),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::tokenizer::Tokenizer;
+
+    /// Build a synthetic CharLevel tokenizer that has `<think>` and `</think>`
+    /// at known positions. Used to verify `reasoning_decoder()` returns a real
+    /// `ThinkingDecoder` (not a `NoopReasoningDecoder`) for a given arch_name.
+    fn make_tok() -> Arc<Tokenizer> {
+        let v: Vec<String> = vec![
+            "<|im_start|>", "<|im_end|>", "<|endoftext|>",
+            "system", "\n", "user", "assistant",
+            "<think>", "</think>",
+        ].into_iter().map(String::from).collect();
+        Arc::new(Tokenizer::from_vocab(&v))
+    }
+
+    /// Feeding the `<think>` token MUST transition the reasoning decoder
+    /// into the inside state (`Start` event). If it instead returns
+    /// `Delta("")`, the create() call resolved to `NoopReasoningDecoder`,
+    /// meaning the arch_name fell through to the `_` arm.
+    fn assert_thinking_enabled(arch_name: &str) {
+        let tok = make_tok();
+        let inst = create(arch_name, tok.clone());
+        let think_id = tok.encode("<think>");
+        assert!(!think_id.is_empty(), "<think> must encode to non-empty for {arch_name}");
+        let mut dec = inst.reasoning_decoder();
+        match dec.feed(&think_id) {
+            ReasoningEvent::Start => {}
+            other => panic!(
+                "create({arch_name:?}).reasoning_decoder().feed(<think>) \
+                 expected Start, got {other:?} — arch_name fell through to the \
+                 has_thinking=false fallback arm (this was pie-project/pie#328)"
+            ),
+        }
+    }
+
+    #[test]
+    fn qwen3_internal_name_enables_thinking() {
+        assert_thinking_enabled("qwen3");
+    }
+
+    #[test]
+    fn qwen3_hf_arch_name_enables_thinking() {
+        // Regression: pie_driver_vllm / pie_driver_sgl forward `architectures[0]`
+        // (the HF class name) verbatim. Pie runtime MUST recognise this form.
+        assert_thinking_enabled("Qwen3ForCausalLM");
     }
 }


### PR DESCRIPTION
## What

`runtime/src/model/instruct::create()` only matched pie's lowercase internal arch names (`"qwen3"`, `"qwen2"`, …). It now also accepts the HuggingFace `architectures[0]` strings (`"Qwen3ForCausalLM"`, `"Qwen2ForCausalLM"`, …) that the vllm and sgl drivers forward verbatim through `DriverCapabilities.arch_name`.

Closes #328.

## Why this is the bug for #328

The user-visible symptom: `text-completion` inferlet with `Qwen/Qwen3-0.6B` + `--max_tokens 32` returns `{"thinking": "", "text": "<think>\nOkay, the user…"}` — the literal `<think>` lands in `text` instead of populating `thinking`.

The previous-iteration hypothesis (encode-mismatch in `qwen3.rs:178`) was [falsified by direct probe](https://github.com/pie-project/pie/issues/328#issuecomment-4354989095): both pie's runtime tokenizer and HF correctly encode `<think>` to `[151667]` against the live `Qwen/Qwen3-0.6B/tokenizer.json`, and the unit-test-covered `ThinkingDecoder::feed(&[151667])` deterministically returns `ReasoningEvent::Start`. So the matcher and tokenizer were never the problem.

To find the actual cause I ran `Qwen/Qwen3-0.6B` end-to-end on Apple MPS through `transformers.AutoModelForCausalLM` with the same params (T=0.6, top_p=0.95, max=32) and confirmed the model **does** emit id `151667` as the very first generated token. So the bug is on pie's side, after the model returns ids.

Tracing through `runtime/src/bootstrap.rs:135 → model::register → instruct::create(arch_name, …)` and checking what the Python side actually sends:

| Driver | File | What it forwards as `arch_name` |
| --- | --- | --- |
| `pie_driver` (the hand-rolled path) | `pie_driver/loader.py:65-83` | `hf_utils.HF_TO_PIE_ARCH[hf_model_type]` → `"qwen3"` ✅ |
| `pie_driver_vllm` | `pie_driver_vllm/loader.py:212-220` | `vllm_config.model_config.hf_text_config.architectures[0]` → `"Qwen3ForCausalLM"` ❌ |
| `pie_driver_sgl` | `pie_driver_sgl/loader.py:209` | `sglang_model_config.hf_config.architectures[0]` → `"Qwen3ForCausalLM"` ❌ |

The Rust-side match against `"qwen3"` therefore failed for any model loaded via vllm or sgl, sending Qwen3 (and every other architecture) into the `_` fallback arm:

```rust
_ => Arc::new(QwenInstruct::new(tokenizer, ChatMLConfig {
    has_thinking: false,
    has_tools: false,
    stop_tokens: &["<|im_end|>", "<|endoftext|>"],
})),
```

`has_thinking: false` makes `reasoning_decoder()` return `NoopReasoningDecoder`, whose `feed` always returns `Delta(empty)`. In the SDK pipeline ([`sdk/rust/inferlet/src/context/decoder.rs:107-162`](https://github.com/pie-project/pie/blob/features/deva-integration/sdk/rust/inferlet/src/context/decoder.rs#L107-L162)), `Delta(empty)` while `state == Normal` falls through to the chat decoder, which decodes `[151667]` to the literal string `"<think>"` and emits it as `Event::Text`. Hence `text` accumulates `<think>\n…` while `thinking` stays empty — exactly the reported bug.

I verified the chain by simulating the SDK Decoder pipeline against the actual generated id sequence with a standalone Rust binary that reuses pie's runtime tokenizer. With one-token-per-batch input the simulation produces the *correct* result (`thinking` full, `text` empty), confirming nothing is wrong with `ThinkingDecoder` or `GenericChatDecoder` themselves — the breakage is purely in `arch_name` resolution.

## Fix

Add the unambiguous HF CamelCase aliases to the existing match. `LlamaForCausalLM` is intentionally excluded — HF reuses it across llama2, llama3, and llama3.1+, and disambiguation needs config-level signals (e.g. `rope_scaling`) that aren't visible at this layer. The Python driver must hand off the already-disambiguated pie internal name (`"llama2"` or `"llama3"`) for those.

The doc comment on `create()` documents the contract going forward: both forms are accepted, and the Llama special case is called out.

## Tests

Added `model::instruct::tests::qwen3_internal_name_enables_thinking` and `qwen3_hf_arch_name_enables_thinking` against a synthetic-vocab `Tokenizer` (no GPU / model weights needed). Both verify that `create(arch_name, tok).reasoning_decoder().feed(&tok.encode("<think>"))` returns `ReasoningEvent::Start`. The HF-name test fails on the unfixed code path with a clear panic message that points back at this issue.

```
$ cargo test --lib model::instruct::tests::
running 2 tests
test model::instruct::tests::qwen3_internal_name_enables_thinking ... ok
test model::instruct::tests::qwen3_hf_arch_name_enables_thinking ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 354 filtered out
```

(Pre-existing failure in `qwen3_has_3_stop_tokens` is unrelated to this PR — same failure on upstream HEAD `82ebccbb`. Not touched here.)

## Out of scope (follow-ups worth considering)

- The `_` fallback returns a `QwenInstruct` (ChatML), which is **wrong** for non-Qwen models — Llama, Gemma etc. have totally different chat templates. Today, every unrecognised arch silently produces malformed prompts. A separate PR should either error out on unknown arches or audit which arches still need aliasing here (or, better, push the normalisation up to Python so the contract is "Rust only sees pie internal names" — `pie_driver/loader.py` already does this).
- `pie_driver_vllm` and `pie_driver_sgl` could be aligned with `pie_driver` (use `hf_text_config.model_type` + `HF_TO_PIE_ARCH`) so the HF-vs-internal distinction stops mattering. The comment at `pie_driver_vllm/loader.py:234-236` (avoid pulling pie_kernels) suggests this may want a small lightweight constants module rather than importing `pie_driver.model`.
- `DriverCapabilities.arch_name` docstring (`pie/src/pie/capabilities.py:62-65`) says it forwards the HF CamelCase name, but `pie_driver` actually forwards the disambiguated internal name. The two drivers disagree with each other; fixing that disagreement is what would let this Rust-side aliasing eventually go away.

## Repro / sanity check

Canonical reproducer (pre-fix): `DRIVER=vllm bash docker/run-deva-text-completion-on-ecl.sh --gpu 2 --tag sslee0cs/pie-vllm-engine:deva-trial-fix3` → `{"thinking": "", "text": "<think>\n…"}`. With this PR applied I expect `thinking` to populate while `text` stays empty (or becomes the post-`</think>` answer if generation runs long enough). Haven't been able to verify on hardware yet — happy to wait on a maintainer with GPU access, or to fold in a runtime-side e2e test that pins the bytestream once we have the deva-trial image rebuilt against this branch.
