### PR TITLE
fix(arch-resolution): own HF→pie arch translation in Python; Rust dispatches on pie name only (closes #328)

### DIFF
--- a/pie/src/pie/capabilities.py
+++ b/pie/src/pie/capabilities.py
@@ -60,8 +60,11 @@ class DriverCapabilities:
     max_batch_size: int
 
     # ── Model-architecture facts ───────────────────────────────────────
-    # First architecture string from the HF config (e.g. "LlamaForCausalLM",
-    # "Qwen3ForCausalLM"). Forwarded to Rust as ModelConfig.arch_name.
+    # Pie internal arch name (lowercase: "qwen3", "llama3", …) — the
+    # dispatch key the Rust runtime expects. Drivers MUST resolve this
+    # via `pie_driver.model.resolve()` from the HF config; raw HF class
+    # names like "Qwen3ForCausalLM" are NOT accepted on the Rust side.
+    # See pie_driver/model/__init__.py and pie-project/pie#328.
     arch_name: str
 
     # Vocabulary size and max context length. Currently Python-only —

--- a/pie/src/pie_driver/hf_utils.py
+++ b/pie/src/pie_driver/hf_utils.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from huggingface_hub.constants import HF_HUB_CACHE
 
-from .model import HF_TO_PIE_ARCH
+from .model import HF_TO_PIE_ARCH, resolve, UnknownArchitectureError
 
 
 
@@ -118,10 +118,8 @@ def check_pie_compatibility(config: dict | None) -> tuple[bool, str]:
     """
     if config is None:
         return False, "no config"
-
-    model_type = config.get("model_type", "")
-    if model_type in HF_TO_PIE_ARCH:
-        return True, HF_TO_PIE_ARCH[model_type]
-
-    return False, f"unsupported type: {model_type}"
+    try:
+        return True, resolve(config)
+    except UnknownArchitectureError:
+        return False, f"unsupported type: {config.get('model_type', '')}"
 

--- a/pie/src/pie_driver/loader.py
+++ b/pie/src/pie_driver/loader.py
@@ -62,22 +62,20 @@ class ModelLoader:
         # Load config from HuggingFace config.json
         hf_config = hf_utils.load_hf_config(self.snapshot_dir)
 
-        # Derive architecture from HF model_type
-        hf_model_type = hf_config.get("model_type", "")
-        # Handle case where model_type might be mapped (e.g. llama -> llama3)
-        # We need hf_utils.HF_TO_PIE_ARCH to map it.
-        # If it's not in the map, check if it's already a valid PIE type (less likely but possible)
-        arch_type = hf_utils.HF_TO_PIE_ARCH.get(hf_model_type)
-
-        if arch_type is None:
-            # Basic fallback or error
-            if hf_model_type in hf_utils.HF_TO_PIE_ARCH.values():
+        # Derive pie internal arch name from HF identity. Single source of
+        # truth: pie_driver.model.resolve().
+        from .model import resolve as resolve_pie_arch, UnknownArchitectureError, HF_TO_PIE_ARCH
+        try:
+            arch_type = resolve_pie_arch(hf_config)
+        except UnknownArchitectureError as e:
+            # Soft fallback for callers that already pass a pie internal name
+            # via `model_type` (legacy behavior — kept until external callers
+            # migrate). Strict path is `resolve()`.
+            hf_model_type = hf_config.get("model_type", "")
+            if hf_model_type in HF_TO_PIE_ARCH.values():
                 arch_type = hf_model_type
             else:
-                raise ValueError(
-                    f"Unsupported HuggingFace model_type: '{hf_model_type}'. "
-                    f"Supported types: {list(hf_utils.HF_TO_PIE_ARCH.keys())}"
-                )
+                raise ValueError(str(e)) from e
 
         # Inject PIE type into config for runtime to use
         hf_config["type"] = arch_type

--- a/pie/src/pie_driver/model/__init__.py
+++ b/pie/src/pie_driver/model/__init__.py
@@ -58,69 +58,124 @@ class Buffer(ABC):
 # =============================================================================
 
 
-REGISTRY: dict[str, ModuleType] = {}
-"""Architecture name → module with (ModelConfig, ForwardPass, create_kv_cache, create_adapter_cache)."""
+REGISTRY: dict[str, str | ModuleType] = {}
+"""Architecture name → module path string (lazy) or loaded module (cached after first get_module)."""
 
 HF_TO_PIE_ARCH: dict[str, str] = {}
 """HuggingFace model_type → PIE architecture name."""
 
 
+class UnknownArchitectureError(ValueError):
+    """Raised when an HF config can't be mapped to a pie internal arch."""
+
+
 def register(
     name: str,
-    module: ModuleType,
+    module_path: str,
     *,
     aliases: tuple[str, ...] = (),
     hf_model_types: tuple[str, ...] = (),
 ):
-    """Register a model architecture.
+    """Register a model architecture (lazy — module loads on first ``get_module``).
 
     Args:
-        name: Primary architecture name (e.g., "llama3")
-        module: Module containing ModelConfig, ForwardPass, create_kv_cache, create_adapter_cache
-        aliases: Additional names that map to the same module
-        hf_model_types: HuggingFace model_type strings that map to this architecture
+        name: Primary architecture name (e.g., ``"llama3"``).
+        module_path: Dotted path to the per-arch module (e.g.,
+            ``"pie_driver.model.llama3"``). Imported lazily on first
+            ``get_module(name)`` call so that callers reading only the
+            HF→pie table don't pay the ``pie_kernels`` JIT cost (every
+            per-arch module ``import pie_kernels as ops`` at top-level).
+        aliases: Additional names that map to the same module.
+        hf_model_types: HuggingFace ``model_type`` strings that map to
+            this architecture (populates ``HF_TO_PIE_ARCH``).
     """
-    REGISTRY[name] = module
+    REGISTRY[name] = module_path
     for alias in aliases:
-        REGISTRY[alias] = module
+        REGISTRY[alias] = module_path
     for hf_type in hf_model_types:
         HF_TO_PIE_ARCH[hf_type] = name
 
 
 def get_module(arch_name: str) -> ModuleType:
-    """Look up model module by architecture name.
+    """Look up model module by architecture name (lazy-loads on first call).
 
     Raises:
-        ValueError: If architecture is not registered
+        ValueError: If architecture is not registered.
     """
-    mod = REGISTRY.get(arch_name)
-    if mod is None:
+    entry = REGISTRY.get(arch_name)
+    if entry is None:
         raise ValueError(
             f"Unsupported architecture: {arch_name!r}. "
             f"Registered: {sorted(REGISTRY.keys())}"
         )
-    return mod
+    if isinstance(entry, str):
+        import importlib
+        entry = importlib.import_module(entry)
+        REGISTRY[arch_name] = entry  # cache the loaded module
+    return entry
+
+
+def resolve(hf_config) -> str:
+    """Resolve an HF config object to the pie internal arch name.
+
+    Accepts anything with ``model_type`` and ``architectures`` accessors —
+    a transformers ``PretrainedConfig``, vllm's wrapped ``hf_config`` /
+    ``hf_text_config``, sglang's ``hf_config``, or a plain dict.
+
+    Resolution order:
+        1. ``model_type`` lookup in :data:`HF_TO_PIE_ARCH`.
+        2. (Future) Disambiguate ``LlamaForCausalLM`` between llama2 /
+           llama3 / llama3.1+ via ``rope_scaling.rope_type``.
+
+    Raises :class:`UnknownArchitectureError` rather than silently falling
+    through — that silent fallback is what caused #328.
+    """
+    model_type = _attr_or_key(hf_config, "model_type", "")
+    if model_type in HF_TO_PIE_ARCH:
+        return HF_TO_PIE_ARCH[model_type]
+
+    architectures = _attr_or_key(hf_config, "architectures", []) or []
+    arch0 = architectures[0] if architectures else "<missing>"
+    raise UnknownArchitectureError(
+        f"Cannot resolve HF model to a pie arch name. "
+        f"model_type={model_type!r}, architectures[0]={arch0!r}. "
+        f"Add an entry via register(..., hf_model_types=...) below and ensure "
+        f"runtime/src/model/instruct.rs has a matching arm."
+    )
+
+
+def _attr_or_key(obj, key, default):
+    """Read attribute or dict key, falling back to default."""
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
 
 
 # =============================================================================
-# Register All Architectures
+# Register All Architectures (lazy — per-arch modules load on demand)
 # =============================================================================
+#
+# `register()` takes a dotted module path string instead of an imported
+# module object so that this file stays cheap to load. The vllm / sgl
+# loaders, the CLI compatibility check, and any other caller that just
+# needs HF_TO_PIE_ARCH or resolve() do NOT trigger the per-arch modules'
+# `import pie_kernels as ops` chain (which JIT-compiles CUDA extensions
+# at import time and is irrelevant on the vllm / sgl path).
+#
+# The native pie_driver path's `get_module(name)` triggers
+# `importlib.import_module` on first dispatch — same modules load,
+# same cost, just deferred until needed.
 
-import torch
-from . import llama3, qwen2, qwen3, qwen3_5, gemma2, gemma3, gemma4, mistral3, olmo3, gpt_oss, phi3, mixtral
-
-register("llama3", llama3, aliases=("l4ma",), hf_model_types=("llama",))
-register("qwen2", qwen2, hf_model_types=("qwen2",))
-register("qwen3", qwen3, hf_model_types=("qwen3",))
-register("qwen3_5", qwen3_5, hf_model_types=("qwen3_5",))
-register("phi3", phi3, hf_model_types=("phi3",))
-register("mixtral", mixtral, hf_model_types=("mixtral",))
-register("gemma2", gemma2, hf_model_types=("gemma2",))
-register("gemma3", gemma3, hf_model_types=("gemma3_text",))
-register("gemma4", gemma4, hf_model_types=("gemma4_text", "gemma4"))
-register("mistral3", mistral3, hf_model_types=("mistral3",))
-register("olmo3", olmo3, hf_model_types=("olmo3",))
-register("gptoss", gpt_oss, hf_model_types=("gptoss", "gpt_oss"))
-
-from . import dummy as _dummy_mod
-register("dummy", _dummy_mod)
+register("llama3",   "pie_driver.model.llama3",   aliases=("l4ma",), hf_model_types=("llama",))
+register("qwen2",    "pie_driver.model.qwen2",                       hf_model_types=("qwen2",))
+register("qwen3",    "pie_driver.model.qwen3",                       hf_model_types=("qwen3",))
+register("qwen3_5",  "pie_driver.model.qwen3_5",                     hf_model_types=("qwen3_5",))
+register("phi3",     "pie_driver.model.phi3",                        hf_model_types=("phi3",))
+register("mixtral",  "pie_driver.model.mixtral",                     hf_model_types=("mixtral",))
+register("gemma2",   "pie_driver.model.gemma2",                      hf_model_types=("gemma2",))
+register("gemma3",   "pie_driver.model.gemma3",                      hf_model_types=("gemma3_text",))
+register("gemma4",   "pie_driver.model.gemma4",                      hf_model_types=("gemma4_text", "gemma4"))
+register("mistral3", "pie_driver.model.mistral3",                    hf_model_types=("mistral3",))
+register("olmo3",    "pie_driver.model.olmo3",                       hf_model_types=("olmo3",))
+register("gptoss",   "pie_driver.model.gpt_oss",                     hf_model_types=("gptoss", "gpt_oss"))
+register("dummy",    "pie_driver.model.dummy")

--- a/pie/src/pie_driver_sgl/loader.py
+++ b/pie/src/pie_driver_sgl/loader.py
@@ -63,7 +63,7 @@ class LoadedModel:
 
     runner: Any                # sglang.srt.model_executor.model_runner.ModelRunner
     sglang_model_config: Any   # sglang.srt.configs.model_config.ModelConfig
-    arch_type: str             # HF architecture string, e.g. "Qwen3ForCausalLM"
+    arch_type: str             # pie internal arch name (e.g. "qwen3"); resolved via pie_driver.model.resolve()
     snapshot_dir: str | None
     # If True, the loader skipped `runner.init_device_graphs()` and the
     # engine must call it after installing pie's hooks (see engine.py).
@@ -206,8 +206,11 @@ def load_sglang_model(
         )
     _log("Model loaded via SGLang", "INFO")
 
-    arches = list(sglang_model_config.hf_config.architectures)
-    arch_type = arches[0] if arches else "Unknown"
+    # Resolve HF identity to pie's internal arch name (the dispatch key
+    # the Rust runtime expects). See pie_driver/model/__init__.py for why
+    # this lives in Python.
+    from pie_driver.model import resolve as resolve_pie_arch
+    arch_type = resolve_pie_arch(sglang_model_config.hf_config)
 
     snapshot_dir = _resolve_hf_snapshot_dir(config.hf_repo)
     if snapshot_dir is None:

--- a/pie/src/pie_driver_vllm/loader.py
+++ b/pie/src/pie_driver_vllm/loader.py
@@ -60,7 +60,7 @@ class LoadedModel:
     vllm_config: Any           # vllm.config.VllmConfig
     attn_backend: Any          # resolved AttentionBackend class (or None — resolved lazily)
     model_config: Any          # vllm's ModelConfig — exposes vocab_size, num_layers, etc.
-    arch_type: str             # HF architecture string, e.g. "LlamaForCausalLM"
+    arch_type: str             # pie internal arch name (e.g. "llama3"); resolved via pie_driver.model.resolve()
     info: dict
     snapshot_dir: str | None
 
@@ -204,20 +204,19 @@ def load_vllm_model(
         )
         _log("Model weights loaded", "INFO")
 
-    # Architecture string (first arch in the HF config). Used for telemetry
-    # and as the `arch_type` reported back through pie's ready handshake.
-    # Multimodal HF configs (e.g. Qwen3.5) carry `architectures` only on the
-    # top-level config; the inner `text_config` is None there. Fall back to
-    # the outer `hf_config` so multimodal text-only loads still report a name.
+    # Resolve HF identity to pie's internal arch name (the dispatch key
+    # the Rust runtime expects). Multimodal HF configs (e.g. Qwen3.5)
+    # carry `model_type` only on the inner `hf_text_config`; fall through
+    # to the outer `hf_config` so text-only loads still resolve.
+    from pie_driver.model import resolve as resolve_pie_arch
+    try:
+        arch_type = resolve_pie_arch(vllm_config.model_config.hf_text_config)
+    except Exception:
+        arch_type = resolve_pie_arch(vllm_config.model_config.hf_config)
+
     text_arches = vllm_config.model_config.hf_text_config.architectures
     outer_arches = getattr(vllm_config.model_config.hf_config, "architectures", None)
     arches = list(text_arches or outer_arches or [])
-    if not arches:
-        raise RuntimeError(
-            f"vllm's HF config for {config.hf_repo} has no `architectures` field. "
-            "Pie needs at least one HF architecture string."
-        )
-    arch_type = arches[0]
 
     info = {
         "architecture": {"type": arch_type, "all": arches},
@@ -231,9 +230,7 @@ def load_vllm_model(
     # Snapshot dir: pie's Rust runtime needs a local filesystem path that
     # contains tokenizer.json (and the HF config). vllm's `model_config.model`
     # is just the HF repo name like "Qwen/Qwen3-0.6B", so we resolve it to
-    # the cached snapshot via huggingface_hub. (We avoid `pie_driver.hf_utils`
-    # because it transitively imports `pie_kernels` which JIT-compiles CUDA
-    # extensions; that's heavy and irrelevant on the vllm path.)
+    # the cached snapshot via huggingface_hub.
     snapshot_dir = _resolve_hf_snapshot_dir(config.hf_repo)
     if snapshot_dir is None:
         raise RuntimeError(

--- a/runtime/src/model/instruct.rs
+++ b/runtime/src/model/instruct.rs
@@ -102,7 +102,14 @@ pub trait Instruct: Send + Sync {
     }
 }
 
-/// Create the appropriate instruct implementation for the given architecture.
+/// Dispatch on the pie internal arch name resolved by the Python driver.
+///
+/// HF identity (`architectures[0]` class name, `model_type`, and any
+/// disambiguating config fields like `rope_scaling`) never crosses the FFI
+/// boundary — Python's `pie_driver.model.resolve()` is the single owner
+/// of that translation. See pie-project/pie#328: the regression there
+/// came from the vllm/sgl drivers forwarding a raw HF class name and
+/// Rust silently hitting the fallback arm below.
 pub fn create(arch_name: &str, tokenizer: Arc<Tokenizer>) -> Arc<dyn Instruct> {
     use self::qwen3::{QwenInstruct, ChatMLConfig};
 
@@ -120,10 +127,66 @@ pub fn create(arch_name: &str, tokenizer: Arc<Tokenizer>) -> Arc<dyn Instruct> {
         "gemma2" | "gemma3" => Arc::new(self::gemma2::GemmaInstruct::new(tokenizer)),
         "mistral3" | "ministral3" => Arc::new(self::mistral3::MistralInstruct::new(tokenizer)),
         "olmo3" => Arc::new(self::olmo3::OlmoInstruct::new(tokenizer)),
+        // Silent fallback returns Qwen ChatML — wrong template for non-Qwen
+        // models. Any unrecognised name here means the Python driver skipped
+        // pie_driver.model.resolve() or sent an HF class name; that's the
+        // bug, not a missing arm here.
         _ => Arc::new(QwenInstruct::new(tokenizer, ChatMLConfig {
             has_thinking: false,
             has_tools: false,
             stop_tokens: &["<|im_end|>", "<|endoftext|>"],
         })),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::tokenizer::Tokenizer;
+
+    fn make_tok() -> Arc<Tokenizer> {
+        let v: Vec<String> = vec![
+            "<|im_start|>", "<|im_end|>", "<|endoftext|>",
+            "system", "\n", "user", "assistant",
+            "<think>", "</think>",
+        ].into_iter().map(String::from).collect();
+        Arc::new(Tokenizer::from_vocab(&v))
+    }
+
+    /// Resolved pie internal name -> reasoning enabled. The Python driver
+    /// (pie_driver.model.resolve) is responsible for sending this exact form.
+    #[test]
+    fn qwen3_pie_name_enables_thinking() {
+        let tok = make_tok();
+        let inst = create("qwen3", tok.clone());
+        let mut dec = inst.reasoning_decoder();
+        let think_id = tok.encode("<think>");
+        match dec.feed(&think_id) {
+            ReasoningEvent::Start => {}
+            other => panic!(
+                "create(\"qwen3\") gave a no-op reasoning decoder: {other:?}"
+            ),
+        }
+    }
+
+    /// Raw HF class name MUST hit the fallback arm. Pie runtime is not in the
+    /// business of recognising HF strings — that translation is the Python
+    /// driver's job (#328). If this test starts failing, someone added an
+    /// HF alias to `create()`; remove it and fix the driver instead.
+    #[test]
+    fn hf_class_name_hits_fallback() {
+        let tok = make_tok();
+        let inst = create("Qwen3ForCausalLM", tok.clone());
+        let mut dec = inst.reasoning_decoder();
+        let think_id = tok.encode("<think>");
+        match dec.feed(&think_id) {
+            ReasoningEvent::Delta(s) if s.is_empty() => {}
+            other => panic!(
+                "create(\"Qwen3ForCausalLM\") was supposed to hit the no-op \
+                 fallback (NoopReasoningDecoder always returns Delta(\"\")), \
+                 got {other:?}. Did someone alias an HF class name in \
+                 create()? See #328 — keep HF resolution in pie_driver.model.resolve()."
+            ),
+        }
     }
 }


### PR DESCRIPTION
## TL;DR

- **Pie internal name → `Instruct` impl** is already what Rust dispatches on; we just stopped the vllm/sgl drivers from forwarding HF class names like `Qwen3ForCausalLM` and route them through the same `HF_TO_PIE_ARCH` table the native driver always used.
- **The table stays exactly where it lives today** (`pie_driver/model/__init__.py`); we add `resolve()` next to it, and make the per-arch module imports lazy so callers reading the table don't trigger the `pie_kernels` JIT — no new module file introduced.
- **Two Rust unit tests pin the contract**: a resolved pie name (`"qwen3"`) enables thinking; a raw HF class name (`"Qwen3ForCausalLM"`) hits the silent fallback (regression test for #328). E2E reproducer flips from `{"thinking":"","text":"<think>…"}` to `{"thinking":"\nOkay, …","text":""}`.

Closes #328. Discussion of follow-ups (long-term home, the latent silent-fallback for `qwen3_5` / `phi3` / `mixtral` / `gemma4` / `dummy`, docs-drift) lives in #334.

---

## What was actually broken

`pie_driver_vllm/loader.py:212-220` and `pie_driver_sgl/loader.py:209` forwarded `architectures[0]` verbatim — `"Qwen3ForCausalLM"` for Qwen3-0.6B. Rust matched only `"qwen3"`, so vllm/sgl loads silently fell into the `_` arm with `has_thinking: false` (`NoopReasoningDecoder`, which always emits `Delta(empty)`). In the SDK pipeline that lets the chat decoder render token id 151667 as the literal string `"<think>"` and emit it as `Event::Text`, so reasoning content leaked into `text` while `thinking` stayed empty. The legacy `pie_driver` path was unaffected — its `loader.py:65-83` already translated via `HF_TO_PIE_ARCH`.

## What this PR does

### 1. Single owner for HF → pie translation, in its existing location

`pie_driver/model/__init__.py` already had `HF_TO_PIE_ARCH` and the `register(..., hf_model_types=...)` populator. The PR adds a `resolve(hf_config) → str` function and `UnknownArchitectureError` in the same file, so callers stop reaching for `architectures[0]` themselves:

```python
# pie_driver/model/__init__.py — additions
def resolve(hf_config) -> str:
    """Resolve an HF config to the pie internal arch name.
    Future: rope_scaling-based llama2 vs llama3 disambiguation.
    """
    model_type = _attr_or_key(hf_config, "model_type", "")
    if model_type in HF_TO_PIE_ARCH:
        return HF_TO_PIE_ARCH[model_type]
    raise UnknownArchitectureError(...)
```

Why Python (not Rust) owns this: disambiguating `LlamaForCausalLM` between llama / llama2 / llama3 / llama3.1+ needs `rope_scaling.rope_type`; only the layer that holds the full HF config can do it.

### 2. Make the existing file cheap to import

The reason vllm/sgl couldn't reuse the existing table before: `pie_driver/model/__init__.py:109-110` did `from . import llama3, qwen2, …` at top-level, and every per-arch module under `pie_driver/model/` does `import pie_kernels as ops` (14 occurrences confirmed via grep), which JIT-compiles CUDA extensions at import time — heavy and irrelevant on the vllm/sgl path.

This PR switches `register()` to take a dotted module-path string and `get_module()` to `importlib.import_module` lazily on first dispatch:

```python
# Before
register("llama3", llama3, aliases=("l4ma",), hf_model_types=("llama",))
# After
register("llama3", "pie_driver.model.llama3", aliases=("l4ma",), hf_model_types=("llama",))
```

Same end state for the path that actually needs the module (the native engine still loads `qwen3.py` on its first `get_module("qwen3")` call); clean skip for vllm/sgl which never call `get_module()`. The "we avoid `pie_driver.hf_utils` because it transitively imports `pie_kernels`" comment at `pie_driver_vllm/loader.py:234-236` is now obsolete and dropped.

### 3. Migrate the four loader paths

| Driver | Now |
|---|---|
| `pie_driver_vllm/loader.py` | `from pie_driver.model import resolve` |
| `pie_driver_sgl/loader.py` | same |
| `pie_driver/loader.py` (native) | same (replaces its own `HF_TO_PIE_ARCH.get(...)` block) |
| `pie_driver/hf_utils.py::check_pie_compatibility` (CLI) | same (replaces its own lookup) |

`DriverCapabilities.arch_name`'s docstring updated: was *"first HF architecture string"*, now *"pie internal arch name (lowercase: 'qwen3', 'llama3', …); raw HF class names like 'Qwen3ForCausalLM' are NOT accepted on the Rust side."*

### 4. Rust regression tests

```
$ cargo test --lib model::instruct::tests::
running 2 tests
test model::instruct::tests::qwen3_pie_name_enables_thinking ... ok
test model::instruct::tests::hf_class_name_hits_fallback ... ok

test result: ok. 2 passed
```

`hf_class_name_hits_fallback` is the regression pin — if a future contributor adds an HF alias to `instruct::create()`, this test fails with a panic message pointing back at #328 and asking them to fix the driver instead.

## Diff shape

```
pie/src/pie/capabilities.py         | docstring rewrite
pie/src/pie_driver/hf_utils.py      | check_pie_compatibility() → resolve()
pie/src/pie_driver/loader.py        | replaces HF_TO_PIE_ARCH.get block with resolve()
pie/src/pie_driver/model/__init__.py| add resolve() + UnknownArchitectureError;
                                    | register() takes str path; get_module() lazy
pie/src/pie_driver_sgl/loader.py    | call resolve(); fix stale docstring; drop dead `arches=…`
pie/src/pie_driver_vllm/loader.py   | call resolve(); fix stale docstring; drop avoid-comment
runtime/src/model/instruct.rs       | doc comment + 2 unit tests
```

Net: ~+190 / -75 lines. **No new files added.** Original code structure preserved.

## E2E verification

Built `sslee0cs/pie-vllm-engine:deva-trial-fix328-v3` from this branch (cherry-picked onto `features/vllm-opt` for the cu129 stack), ran the canonical reproducer on ECL with `Qwen/Qwen3-0.6B`, prompt `"What is 2 + 2? Answer in one word."`, max_tokens=32, T=0.6, top_p=0.95, FlashInfer:

**Pre-fix (`deva-trial-fix3`):**
```json
{"thinking":"","text":"<think>\nOkay, the user is asking what 2 plus 2 is, and they want the answer in one word. Let me think. 2 plus"}
```

**Post-fix (this branch):**
```json
{"thinking":"\nOkay, the user is asking what 2 plus 2 is, and they want the answer in one word. Let me think. 2 plus","text":""}
```

Reasoning content lands in `thinking`; `text` stays empty until generation runs past `</think>`.

## Out of scope (covered in #334)

- Long-term home / namespace for the resolver.
- Latent silent-fallback for `qwen3_5`, `phi3`, `mixtral`, `gemma4`, `dummy` — registered in Python without Rust arms; same failure mode as #328 just for different arches.
- `website/docs/models.mdx` hand-maintained mirror.
- llama2 vs llama3 vs llama3.1+ disambiguation via `rope_scaling.rope_type` — referenced in `resolve()` docstring as future work; not load-bearing for #328 (Qwen3's `model_type=qwen3` is unambiguous).
