### PR TITLE
build(deps): cu129 CUDA extras

### DIFF
--- a/pie/pyproject.toml
+++ b/pie/pyproject.toml
@@ -66,6 +66,11 @@ cu128 = [
     "flashinfer-jit-cache==0.6.8.post1",
 ]
 
+cu129 = [
+    "torch>=2.11.0",
+    "torchao>=0.14.1",
+]
+
 # --- Metal (macOS) ---
 metal = [
     "torch>=2.7.1",
@@ -92,6 +97,11 @@ url = "https://download.pytorch.org/whl/cu128"
 explicit = true
 
 [[tool.uv.index]]
+name = "pytorch-cu129"
+url = "https://download.pytorch.org/whl/cu129"
+explicit = true
+
+[[tool.uv.index]]
 name = "flashinfer-cu128"
 url = "https://flashinfer.ai/whl/cu128"
 explicit = true
@@ -105,9 +115,11 @@ pie-bakery = { path = "../sdk/tools/bakery", editable = true }
 torch = [
     { index = "pytorch-cu126", extra = "cu126" },
     { index = "pytorch-cu128", extra = "cu128" },
+    { index = "pytorch-cu129", extra = "cu129" },
 ]
 torchao = [
     { index = "pytorch-cu128", extra = "cu128" },
+    { index = "pytorch-cu129", extra = "cu129" },
 ]
 
 flashinfer-jit-cache = [
@@ -128,6 +140,7 @@ conflicts = [
     [
         { extra = "cu126" },
         { extra = "cu128" },
+        { extra = "cu129" },
         { extra = "metal" },
     ],
 ]


### PR DESCRIPTION
## TL;DR

- Adds a `cu129` optional-dependencies group parallel to the existing `cu126` / `cu128` ones (plus the matching `[[tool.uv.index]]` and `[tool.uv.sources]` entries).
- Required for any CUDA 12.9 host (RTX 4090 with driver 575.x — and the configuration the deva-trial container exercises end-to-end).
- Strictly additive: the headless-vllm direction discussed in #327 already landed upstream (vllm/sglang extras removed from pyproject), so this PR is now just the cu129 routing on top of the clean layout — no `vllm = []` / `sglang = []` advisory blocks needed.

---

## What

Single commit, single file (`pie/pyproject.toml`), +13 / -0.

```toml
cu129 = [
    "torch>=2.11.0",
    "torchao>=0.14.1",
]
…
[[tool.uv.index]]
name = "pytorch-cu129"
url = "https://download.pytorch.org/whl/cu129"
explicit = true
…
torch = [
    { index = "pytorch-cu126", extra = "cu126" },
    { index = "pytorch-cu128", extra = "cu128" },
    { index = "pytorch-cu129", extra = "cu129" },
]
torchao = [
    { index = "pytorch-cu128", extra = "cu128" },
    { index = "pytorch-cu129", extra = "cu129" },
]
…
conflicts = [
    [
        { extra = "cu126" },
        { extra = "cu128" },
        { extra = "cu129" },
        { extra = "metal" },
    ],
]
```

## Why cu129 specifically

CUDA 12.9 is the version most lab/cloud RTX 4090 setups land on (drivers 575.x; drivers 570.x cap at 12.8 and 580.x+ are needed for 13.x). Without a `cu129` extra, `uv sync` resolves torch through the cu128 channel even on cu129 hosts, which produces wheel-version mismatches when vllm 0.20.x's release asset is installed manifested into the container.

## What changed since the original PR

- The first version of this PR also flipped `vllm = ["vllm"]` to `vllm = []` (per #327 Option 1, the headless-vllm direction). **That part is now redundant** — upstream landed the headless transition independently (the vllm and sglang extras have been removed from pyproject entirely; users install per the official guides). Rebased on top of the new pyproject layout, this PR is strictly the cu129 routing addition.
- Originally bundled with two warmup-hygiene fixes (#333). Those are tracked separately.

## Validation

`uv sync --extra cu129` resolves cleanly against the current upstream pyproject. The cu129 stack has been carried in `shsym:features/vllm-opt` and exercised end-to-end on ECL RTX 4090s for the past several weeks (Qwen3-0.6B / Qwen3-8B, vllm + native drivers).

## Relationship to other PRs

- **#326** — rand_mv compute-capability auto-detect. Soft prereq for actually loading on sm_89; not duplicated here.
- **#327** — headless-vllm direction discussion; this PR no longer needs to ship that change (already done upstream).
- **#330** — the #328 reasoning bug fix. Independent from this PR; touches different files.
