### PR TITLE
fix(server): pre-warm torch.cuda.device_count in main thread

### DIFF
--- a/pie/src/pie/server.py
+++ b/pie/src/pie/server.py
@@ -98,6 +98,19 @@ class Server:
     async def __aenter__(self) -> Server:
         console = Console(quiet=True)
 
+        # Pre-warm CUDA in the main thread before bootstrap. From a fresh
+        # asyncio.to_thread worker, torch.cuda.device_count() can return 0
+        # even with GPUs present — both NVML and CUDA-driver paths falter,
+        # yielding a spurious "no GPUs visible" error. init() is required
+        # because device_count() only caches once torch.cuda._initialized
+        # is True. Both safe to call without a GPU.
+        import torch
+        try:
+            torch.cuda.init()
+        except Exception:
+            pass
+        _ = torch.cuda.device_count()
+
         # Make sure the Python WASM runtime is on disk before the engine
         # spins up. The runtime tarball provides the `componentize-py-runtime`
         # core module that Python inferlets link against; without it,


### PR DESCRIPTION
## TL;DR

- Pre-warm `torch.cuda.device_count()` in the main thread inside `Server.__aenter__` so the first call from the `_bootstrap` worker thread doesn't return 0 (NVML and CUDA-driver paths both falter from a fresh thread context—especially in a Docker container.).
- Touches one file (`pie/src/pie/server.py`), +13 lines. Independent of any deps changes; orthogonal to #327's headless-vllm direction.
- Single commit now — the originally-bundled `fire_batch` 30s→300s timeout fix was made obsolete by upstream's shared-memory zero-copy IPC rewrite (`f01657d9`); dropped from this PR.

---

## What it fixes

From a fresh `asyncio.to_thread` worker, `torch.cuda.device_count()` can return 0 even with GPUs present — both NVML and CUDA-driver fallback paths falter. That manifests as a spurious "no GPUs visible" RuntimeError on first server bring-up. Pre-warming the call in the main thread populates `torch.cuda._cached_device_count` (which `device_count()` only writes once `_initialized` is True), so subsequent calls from any thread return the cached value.

## Validation

Carried in `shsym:features/vllm-opt` and exercised end-to-end on ECL RTX 4090s. The most recent e2e was the #328 reproducer (verified in #330) — that test ran on a build that includes this fix and the engine came up cleanly on a cold container.

## What got dropped from the original PR

The original second commit (`fix(runtime): bump fire_batch timeout 30s -> 300s for first-call warmup`) bumped the JSON-RPC `call_with_timeout` in `runtime/src/device.rs::fire_batch`. Upstream's `f01657d9` (`optim: shared-memory zero-copy IPC for fire_batch`) replaced that call site entirely with a shmem fast path that doesn't go through `call_with_timeout`. The 300s bump is moot against the new code path; dropped rather than rebased.
