### PR TITLE
fix(config): escape brace in ${TMPDIR}/pie placeholder

### DIFF
--- a/pie/src/pie/config.py
+++ b/pie/src/pie/config.py
@@ -333,7 +333,7 @@ service_name = "pie"
 #
 # Filesystem
 # allow_fs = false                        # mount /scratch RW; default false
-# fs_scratch_dir = "/var/lib/pie/scratch" # base dir; default ${TMPDIR}/pie
+# fs_scratch_dir = "/var/lib/pie/scratch" # base dir; default ${{TMPDIR}}/pie
 #
 # Network. Filtering is by IP post-DNS — hostnames don't survive DNS,
 # so use IP / CIDR allowlists, or front the inferlet with a proxy.


### PR DESCRIPTION
## TL;DR

Two-character fix in `pie/src/pie/config.py:336`. `create_default_config_content()` returns an f-string, so `\${TMPDIR}/pie` parses `{TMPDIR}` as a Python format expression and raises `NameError` at \`pie config init\` time. Doubling the brace emits a literal `\${TMPDIR}` placeholder, which is the original intent (a shell variable shown in the doc-comment for `fs_scratch_dir`).

## Repro

Fresh container, no existing `~/.cache/pie/config.toml`:

```
$ pie config init
NameError: name 'TMPDIR' is not defined
```

After this PR:

```
$ pie config init
✓ Created /root/.cache/pie/config.toml
```

## Diff

```diff
-# fs_scratch_dir = "/var/lib/pie/scratch" # base dir; default \${TMPDIR}/pie
+# fs_scratch_dir = "/var/lib/pie/scratch" # base dir; default \${{TMPDIR}}/pie
```

## Notes

Surfaced while validating PR #336 e2e on a fresh ECL RTX 4090 image. Only the doc-comment placeholder is affected — the `{DEFAULT_MODEL}` substitution lower in the same f-string is intentional and continues to work. Single line, no behavior change beyond unblocking `pie config init`.