### PR TITLE
Fix command syntax in README for text-completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Then configure and run:
 
 ```bash
 pie config init
-pie run text-completion --prompt "The capital of France is"
+pie run text-completion -- --prompt "The capital of France is"
 ```
 
 ## Project Layout


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Quick Start command syntax for text completion. Users now need to pass the prompt argument through a `--` separator when running commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->