### PR TITLE
Improve portable runner UX

### DIFF
--- a/driver/portable/README.md
+++ b/driver/portable/README.md
@@ -42,12 +42,9 @@ device = ["cpu"]
 activation_dtype = "bfloat16"
 
 [model.driver.options]
-n_ctx = 4096
-n_gpu_layers = 0
 max_batch_tokens = 10240
 max_batch_size = 512
 max_num_kv_pages = 1024
 ```
 
-`n_gpu_layers = -1` offloads all layers when the selected ggml backend
-supports it.
+The driver prefers the best compiled ggml backend and falls back to CPU.

--- a/driver/portable/dev.toml
+++ b/driver/portable/dev.toml
@@ -15,9 +15,7 @@ spin_us = 0         # 0 = pure busy spin
 # spawning this binary; for local dev, point directly at the snapshot.
 hf_path = "/path/to/huggingface/snapshot"
 # 0 = CPU only, -1 = offload all layers to GPU, N = first N layers on GPU.
-n_gpu_layers = -1   # -1 = all layers on GPU; 0 = CPU only
 # Informational max position. Real KV capacity is total_pages × kv_page_size.
-n_ctx = 4096
 
 # KV cache / batching — Pie's runtime owns page allocation. We allocate a
 # global pool of `max_num_kv_pages` pages of `kv_page_size` token slots each

--- a/driver/portable/dev_gemma4.toml
+++ b/driver/portable/dev_gemma4.toml
@@ -8,8 +8,6 @@ spin_us = 0
 
 [model]
 hf_path = "/root/.cache/huggingface/hub/models--google--gemma-4-E2B-it/snapshots/6b7e72c67d3c4556f42b56d5a68b4b8e864c63b4"
-n_gpu_layers = -1
-n_ctx = 8192
 
 [batching]
 kv_page_size = 32

--- a/driver/portable/dev_gpt_oss.toml
+++ b/driver/portable/dev_gpt_oss.toml
@@ -8,8 +8,6 @@ spin_us = 0
 
 [model]
 hf_path = "/root/.cache/huggingface/hub/models--openai--gpt-oss-20b/snapshots/6cee5e81ee83917806bbde320786a8fb61efebee"
-n_gpu_layers = -1
-n_ctx = 4096
 
 [batching]
 kv_page_size = 32

--- a/driver/portable/dev_ministral3.toml
+++ b/driver/portable/dev_ministral3.toml
@@ -8,8 +8,6 @@ spin_us = 0
 
 [model]
 hf_path = "/root/.cache/huggingface/hub/models--mistralai--Ministral-3-3B-Base-2512/snapshots/6f9c4b12a95b139af68670a6713616b757923735"
-n_gpu_layers = -1
-n_ctx = 8192
 
 [batching]
 kv_page_size = 32

--- a/driver/portable/dev_mixtral.toml
+++ b/driver/portable/dev_mixtral.toml
@@ -9,8 +9,6 @@ spin_us = 0
 
 [model]
 hf_path = "/root/.cache/huggingface/hub/models--mistralai--Mixtral-8x7B-v0.1/snapshots/fc7ac94680e38d7348cfa806e51218e6273104b0"
-n_gpu_layers = -1
-n_ctx = 4096
 
 [batching]
 kv_page_size = 32

--- a/driver/portable/dev_olmo3.toml
+++ b/driver/portable/dev_olmo3.toml
@@ -8,8 +8,6 @@ spin_us = 0
 
 [model]
 hf_path = "/root/.cache/huggingface/hub/models--allenai--Olmo-3-1025-7B/snapshots/a81bae42db3975be1671e27b9c9a56da1a9f980f"
-n_gpu_layers = -1
-n_ctx = 8192
 
 [batching]
 kv_page_size = 32

--- a/driver/portable/dev_qwen3_5.toml
+++ b/driver/portable/dev_qwen3_5.toml
@@ -11,8 +11,6 @@ spin_us = 0
 
 [model]
 hf_path = "/root/.cache/huggingface/hub/models--Qwen--Qwen3.5-0.8B/snapshots/2fc06364715b967f1860aea9cf38778875588b17"
-n_gpu_layers = -1
-n_ctx = 4096
 
 [batching]
 kv_page_size = 32

--- a/driver/portable/dev_qwen3_5_35b.toml
+++ b/driver/portable/dev_qwen3_5_35b.toml
@@ -11,8 +11,6 @@ spin_us = 0
 
 [model]
 hf_path = "/root/.cache/huggingface/hub/models--Qwen--Qwen3.5-35B-A3B/snapshots/59d61f3ce65a6d9863b86d2e96597125219dc754"
-n_gpu_layers = -1
-n_ctx = 4096
 
 [batching]
 kv_page_size = 32

--- a/driver/portable/dev_qwen3_5_4b.toml
+++ b/driver/portable/dev_qwen3_5_4b.toml
@@ -10,8 +10,6 @@ spin_us = 0
 
 [model]
 hf_path = "/root/.cache/huggingface/hub/models--Qwen--Qwen3.5-4B/snapshots/851bf6e806efd8d0a36b00ddf55e13ccb7b8cd0a"
-n_gpu_layers = -1
-n_ctx = 4096
 
 [batching]
 kv_page_size = 32

--- a/driver/portable/dev_qwen3_moe.toml
+++ b/driver/portable/dev_qwen3_moe.toml
@@ -8,8 +8,6 @@ spin_us = 0
 
 [model]
 hf_path = "/root/.cache/huggingface/hub/models--Qwen--Qwen3-30B-A3B/snapshots/ad44e777bcd18fa416d9da3bd8f70d33ebb85d39"
-n_gpu_layers = -1
-n_ctx = 8192
 
 [batching]
 kv_page_size = 32

--- a/driver/portable/dev_qwen3_q4km.toml
+++ b/driver/portable/dev_qwen3_q4km.toml
@@ -8,8 +8,6 @@ spin_us = 0
 
 [model]
 hf_path = "/root/.cache/huggingface/hub/models--unsloth--Qwen3-0.6B-GGUF/snapshots/50968a4468ef4233ed78cd7c3de230dd1d61a56b/Qwen3-0.6B-Q4_K_M.gguf"
-n_gpu_layers = -1
-n_ctx = 4096
 
 [batching]
 kv_page_size = 32

--- a/driver/portable/src/config.hpp
+++ b/driver/portable/src/config.hpp
@@ -24,19 +24,16 @@ struct AuxIpcConfig {
     std::string socket_path;
 };
 
+struct RuntimeConfig {
+    bool verbose = false;
+};
+
 struct ModelConfig {
     // Path to a HuggingFace snapshot directory containing config.json and
     // model.safetensors (optionally model.safetensors.index.json for sharded
     // checkpoints). Resolved by the Python wrapper from `hf_repo`, or set
     // directly for local dev. Required.
     std::string hf_path;
-    // 0 = CPU only, -1 = offload all layers to GPU, N = first N on GPU.
-    // Backend is CPU-only in v1; this knob lands when CUDA/Metal backends
-    // are wired up in M11.
-    std::int32_t n_gpu_layers = 0;
-    // Upper bound on max_position_embeddings the runtime may dispatch.
-    // Informational — does not size the KV cache (total_pages does).
-    std::uint32_t n_ctx = 4096;
 };
 
 struct BatchingConfig {
@@ -54,6 +51,7 @@ struct Config {
     ModelConfig    model;
     BatchingConfig batching;
     AuxIpcConfig   aux_ipc;
+    RuntimeConfig  runtime;
 };
 
 inline Config load_config(const std::filesystem::path& path) {
@@ -73,8 +71,6 @@ inline Config load_config(const std::filesystem::path& path) {
     }
     if (auto m = tbl["model"].as_table()) {
         c.model.hf_path      = (*m)["hf_path"].value_or(std::string{});
-        c.model.n_gpu_layers = (*m)["n_gpu_layers"].value_or<int64_t>(c.model.n_gpu_layers);
-        c.model.n_ctx        = (*m)["n_ctx"].value_or<int64_t>(c.model.n_ctx);
     }
     if (auto b = tbl["batching"].as_table()) {
         c.batching.kv_page_size     = (*b)["kv_page_size"].value_or<int64_t>(c.batching.kv_page_size);
@@ -85,6 +81,9 @@ inline Config load_config(const std::filesystem::path& path) {
     }
     if (auto a = tbl["aux_ipc"].as_table()) {
         c.aux_ipc.socket_path = (*a)["socket_path"].value_or(std::string{});
+    }
+    if (auto r = tbl["runtime"].as_table()) {
+        c.runtime.verbose = (*r)["verbose"].value_or(c.runtime.verbose);
     }
 
     if (c.model.hf_path.empty()) {

--- a/driver/portable/src/entry.cpp
+++ b/driver/portable/src/entry.cpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include <CLI/CLI.hpp>
+#include <ggml.h>
 #include <ggml-backend.h>
 #include <nlohmann/json.hpp>
 
@@ -111,6 +112,11 @@ std::vector<std::uint64_t> seq_ctx_ids(std::size_t count) {
     std::vector<std::uint64_t> v(count);
     for (std::size_t i = 0; i < count; ++i) v[i] = i + 1;
     return v;
+}
+
+void quiet_ggml_log(enum ggml_log_level level, const char* text, void*) {
+    (void)level;
+    (void)text;
 }
 
 enum class OfflineTestMode {
@@ -236,15 +242,18 @@ int run_impl(int argc,
     CLI11_PARSE(app, argc, argv);
 
     const auto cfg = pie_portable_driver::load_config(config_path);
+    if (!cfg.runtime.verbose) {
+        ggml_log_set(quiet_ggml_log, nullptr);
+    }
 
     // Informational logs go to stderr — stdout is reserved for the READY
     // handshake line consumed by the Python wrapper.
-    std::cerr << "[pie-driver-portable] config loaded\n"
-              << "  shmem.name        = " << cfg.shmem.name << "\n"
-              << "  shmem.num_slots   = " << cfg.shmem.num_slots << "\n"
-              << "  model.hf_path     = " << cfg.model.hf_path << "\n"
-              << "  model.n_gpu_layers= " << cfg.model.n_gpu_layers << "\n"
-              << "  model.n_ctx       = " << cfg.model.n_ctx << "\n";
+    if (cfg.runtime.verbose) {
+        std::cerr << "[pie-driver-portable] config loaded\n"
+                  << "  shmem.name        = " << cfg.shmem.name << "\n"
+                  << "  shmem.num_slots   = " << cfg.shmem.num_slots << "\n"
+                  << "  model.hf_path     = " << cfg.model.hf_path << "\n";
+    }
 
     // ---- Backend discovery. Registers all backends compiled into ggml
     // (CPU + CUDA / Metal / Vulkan when those `GGML_*=ON` flags were set
@@ -253,20 +262,23 @@ int run_impl(int argc,
     ggml_backend_load_all();
 
     // ---- Load the model. -----------------------------------------------------
-    const bool prefer_gpu = (cfg.model.n_gpu_layers != 0);
-    std::cerr << "[pie-driver-portable] loading model from " << cfg.model.hf_path
-              << " (prefer_gpu=" << (prefer_gpu ? "yes" : "no") << ")\n";
-    pie_portable_driver::Model model(cfg.model.hf_path, prefer_gpu);
+    if (cfg.runtime.verbose) {
+        std::cerr << "[pie-driver-portable] loading model from " << cfg.model.hf_path
+                  << " (backend=best-available)\n";
+    }
+    pie_portable_driver::Model model(cfg.model.hf_path, cfg.runtime.verbose);
     const auto& h = model.hparams();
-    std::cerr << "[pie-driver-portable] loaded "
-              << model.arch_name_pie() << " ("
-              << h.num_hidden_layers << " layers, hidden=" << h.hidden_size
-              << ", heads=" << h.num_attention_heads << "/"
-              << h.num_key_value_heads << " kv, head_dim=" << h.head_dim
-              << ", vocab=" << h.vocab_size
-              << ", dtype=" << model.activation_dtype_str()
-              << ", buf=" << (model.buffer_size() / (1024.0 * 1024.0)) << " MiB"
-              << ", backend=" << model.backend_name() << ")\n";
+    if (cfg.runtime.verbose) {
+        std::cerr << "[pie-driver-portable] loaded "
+                  << model.arch_name_pie() << " ("
+                  << h.num_hidden_layers << " layers, hidden=" << h.hidden_size
+                  << ", heads=" << h.num_attention_heads << "/"
+                  << h.num_key_value_heads << " kv, head_dim=" << h.head_dim
+                  << ", vocab=" << h.vocab_size
+                  << ", dtype=" << model.activation_dtype_str()
+                  << ", buf=" << (model.buffer_size() / (1024.0 * 1024.0)) << " MiB"
+                  << ", backend=" << model.backend_name() << ")\n";
+    }
 
     // ---- Allocate forward engine + paged KV pool. ---------------------------
     // The runtime owns page allocation; we report total_pages and page_size
@@ -277,10 +289,12 @@ int run_impl(int argc,
     const std::int32_t page_size =
         static_cast<std::int32_t>(cfg.batching.kv_page_size);
     pie_portable_driver::ForwardEngine engine(model, total_pages, page_size);
-    std::cerr << "[pie-driver-portable] forward engine ready (total_pages="
-              << total_pages << ", page_size=" << page_size
-              << ", kv_buf=" << (engine.kv_buffer_size() / (1024.0 * 1024.0))
-              << " MiB)\n";
+    if (cfg.runtime.verbose) {
+        std::cerr << "[pie-driver-portable] forward engine ready (total_pages="
+                  << total_pages << ", page_size=" << page_size
+                  << ", kv_buf=" << (engine.kv_buffer_size() / (1024.0 * 1024.0))
+                  << " MiB)\n";
+    }
 
     // ---- Optional host swap pool + aux IPC (M7). ----------------------------
     std::unique_ptr<pie_portable_driver::HostSwapPool> swap_pool;
@@ -298,13 +312,15 @@ int run_impl(int argc,
             cpu_pages,
             page_size,
             ggml_type_size(GGML_TYPE_F16));
-        std::cerr << "[pie-driver-portable] host swap pool: "
-                  << cpu_pages << " pages × "
-                  << (swap_pool->page_bytes() / 1024.0) << " KiB/layer × "
-                  << hp.num_hidden_layers << " layers × 2 (K+V) = "
-                  << (cpu_pages * swap_pool->page_bytes() *
-                      hp.num_hidden_layers * 2 / (1024.0 * 1024.0))
-                  << " MiB\n";
+        if (cfg.runtime.verbose) {
+            std::cerr << "[pie-driver-portable] host swap pool: "
+                      << cpu_pages << " pages × "
+                      << (swap_pool->page_bytes() / 1024.0) << " KiB/layer × "
+                      << hp.num_hidden_layers << " layers × 2 (K+V) = "
+                      << (cpu_pages * swap_pool->page_bytes() *
+                          hp.num_hidden_layers * 2 / (1024.0 * 1024.0))
+                      << " MiB\n";
+        }
     }
     if (!cfg.aux_ipc.socket_path.empty()) {
         aux_server = std::make_unique<pie_portable_driver::AuxServer>(
@@ -314,8 +330,10 @@ int run_impl(int argc,
             adapters.get(),
             model.backend(),
             &model.hparams());
-        std::cerr << "[pie-driver-portable] aux IPC listening on "
-                  << cfg.aux_ipc.socket_path << "\n";
+        if (cfg.runtime.verbose) {
+            std::cerr << "[pie-driver-portable] aux IPC listening on "
+                      << cfg.aux_ipc.socket_path << "\n";
+        }
     }
 
     // ---- Offline self-test paths. ------------------------------------------
@@ -357,13 +375,15 @@ int run_impl(int argc,
     }
 
     // ---- Capability handshake. ----------------------------------------------
-    // Pie's runtime reads this JSON line and constructs a `DriverCapabilities`
-    // (see `pie/src/pie/capabilities.py`). KV pages and swap pool size stay
-    // 0 in M1.2 — the KV manager (M2) computes real values.
+    // Advertise the largest single context the KV pool can hold. Model
+    // metadata such as max_position_embeddings may describe the training
+    // window, but it should not impose a runtime admission cap.
     const std::uint32_t max_model_len =
-        static_cast<std::uint32_t>(std::min<std::int32_t>(
-            h.max_position_embeddings,
-            static_cast<std::int32_t>(cfg.model.n_ctx)));
+        static_cast<std::uint32_t>(
+            std::max<std::int64_t>(
+                0,
+                static_cast<std::int64_t>(total_pages) *
+                    static_cast<std::int64_t>(page_size)));
     nlohmann::json caps = {
         {"total_pages",      total_pages},
         {"kv_page_size",     page_size},
@@ -383,10 +403,12 @@ int run_impl(int argc,
     const std::string caps_json = caps.dump();
     ready_cb(caps_json.c_str(), ready_ctx);
 
-    std::cerr << "[pie-driver-portable] serving on shmem " << server.name()
-              << " (" << server.num_slots() << " slots, "
-              << "req_buf=" << server.req_buf_size() << ", "
-              << "resp_buf=" << server.resp_buf_size() << ")\n";
+    if (cfg.runtime.verbose) {
+        std::cerr << "[pie-driver-portable] serving on shmem " << server.name()
+                  << " (" << server.num_slots() << " slots, "
+                  << "req_buf=" << server.req_buf_size() << ", "
+                  << "resp_buf=" << server.resp_buf_size() << ")\n";
+    }
 
     std::uint64_t handled = 0;
 
@@ -408,7 +430,7 @@ int run_impl(int argc,
             return 0;
         }
 
-        if (handled <= 4 || handled % 100 == 0) {
+        if (cfg.runtime.verbose && (handled <= 4 || handled % 100 == 0)) {
             const auto tokens =
                 decoded.as<std::uint32_t>(pie_portable_driver::schema::A_TOKEN_IDS);
             const auto context_ids =
@@ -426,8 +448,10 @@ int run_impl(int argc,
             const auto compute_ms =
                 std::chrono::duration_cast<std::chrono::milliseconds>(
                     std::chrono::steady_clock::now() - t_compute_start).count();
-            std::cerr << "[pie-driver-portable] req_id=" << req.req_id
-                      << " engine.run done in " << compute_ms << " ms\n";
+            if (cfg.runtime.verbose) {
+                std::cerr << "[pie-driver-portable] req_id=" << req.req_id
+                          << " engine.run done in " << compute_ms << " ms\n";
+            }
             return rc;
         } catch (const std::exception& e) {
             std::cerr << "[pie-driver-portable] forward failed for req_id="
@@ -437,8 +461,10 @@ int run_impl(int argc,
     });
 
     unregister_server(&server);
-    std::cerr << "[pie-driver-portable] shutting down (handled " << handled
-              << " requests)\n";
+    if (cfg.runtime.verbose) {
+        std::cerr << "[pie-driver-portable] shutting down (handled " << handled
+                  << " requests)\n";
+    }
     // Print per-stage timings on demand (e.g. e2e benchmarks). Default
     // off so production logs stay quiet.
     if (std::getenv("PIE_PORTABLE_LOG_TIMINGS")) {

--- a/driver/portable/src/model.cpp
+++ b/driver/portable/src/model.cpp
@@ -169,7 +169,7 @@ ggml_tensor* new_tensor_from_st(ggml_context* ctx,
 
 }  // namespace
 
-Model::Model(const std::filesystem::path& snapshot_dir, bool prefer_gpu)
+Model::Model(const std::filesystem::path& snapshot_dir, bool verbose)
     : snapshot_dir_(snapshot_dir) {
     // The "snapshot" can be either:
     //   * an HF snapshot directory (config.json + *.safetensors)
@@ -198,12 +198,10 @@ Model::Model(const std::filesystem::path& snapshot_dir, bool prefer_gpu)
     // time, `ggml_backend_load_all()` registers them as device providers and
     // `ggml_backend_init_best()` picks GPU > CPU. Falls back to CPU if no
     // GPU backend was compiled in or no device is available.
-    if (prefer_gpu) {
-        backend_ = ggml_backend_init_best();
-        if (!backend_) {
-            std::cerr << "[model] ggml_backend_init_best() returned null; "
-                         "falling back to CPU\n";
-        }
+    backend_ = ggml_backend_init_best();
+    if (!backend_) {
+        std::cerr << "[model] ggml_backend_init_best() returned null; "
+                     "falling back to CPU\n";
     }
     if (!backend_) {
         backend_ = ggml_backend_cpu_init();
@@ -225,8 +223,10 @@ Model::Model(const std::filesystem::path& snapshot_dir, bool prefer_gpu)
     };
     if (ggml_backend_is_cpu(backend_)) {
         const unsigned n = pin_cpu_threads(backend_);
-        std::cerr << "[model] ggml CPU backend pinned to "
-                  << n << " thread(s)\n";
+        if (verbose) {
+            std::cerr << "[model] ggml CPU backend pinned to "
+                      << n << " thread(s)\n";
+        }
     } else {
         // Primary is a GPU backend. Set up a CPU companion so the
         // ForwardEngine's `ggml_backend_sched` has somewhere to route
@@ -239,9 +239,11 @@ Model::Model(const std::filesystem::path& snapshot_dir, bool prefer_gpu)
         cpu_fallback_ = ggml_backend_cpu_init();
         if (cpu_fallback_) {
             const unsigned n = pin_cpu_threads(cpu_fallback_);
-            std::cerr << "[model] CPU fallback backend pinned to "
-                      << n << " thread(s) (sched safety net for "
-                      << ggml_backend_name(backend_) << ")\n";
+            if (verbose) {
+                std::cerr << "[model] CPU fallback backend pinned to "
+                          << n << " thread(s) (sched safety net for "
+                          << ggml_backend_name(backend_) << ")\n";
+            }
         } else {
             // Continue without fallback: graphs that would have used
             // it will hard-abort instead of falling back. Better than
@@ -270,10 +272,12 @@ Model::Model(const std::filesystem::path& snapshot_dir, bool prefer_gpu)
                 ggml_argsort(probe_ctx, probs, GGML_SORT_ORDER_DESC);
             supports_in_graph_topk_ =
                 ggml_backend_supports_op(backend_, sorted);
-            std::cerr << "[model] in-graph top-k support on "
-                      << ggml_backend_name(backend_) << ": "
-                      << (supports_in_graph_topk_ ? "yes" : "no — using slow_only sampling path")
-                      << "\n";
+            if (verbose) {
+                std::cerr << "[model] in-graph top-k support on "
+                          << ggml_backend_name(backend_) << ": "
+                          << (supports_in_graph_topk_ ? "yes" : "no — using slow_only sampling path")
+                          << "\n";
+            }
 
             // ggml_paged_attn_ext probe. Use the model's real attention
             // geometry: FlashInfer supports only specific head_dim/GQA
@@ -308,12 +312,14 @@ Model::Model(const std::filesystem::path& snapshot_dir, bool prefer_gpu)
                 /*scale=*/ 1.0f / 8.0f, /*softcap=*/ 0.0f);
             supports_paged_attn_ext_ =
                 ggml_backend_supports_op(backend_, probe_pa);
-            std::cerr << "[model] paged_attn_ext support on "
-                      << ggml_backend_name(backend_) << ": "
-                      << (supports_paged_attn_ext_
-                          ? "yes"
-                          : "no — using materialize+flash_attn_ext fallback")
-                      << "\n";
+            if (verbose) {
+                std::cerr << "[model] paged_attn_ext support on "
+                          << ggml_backend_name(backend_) << ": "
+                          << (supports_paged_attn_ext_
+                              ? "yes"
+                              : "no — using materialize+flash_attn_ext fallback")
+                          << "\n";
+            }
 
             ggml_free(probe_ctx);
         }

--- a/driver/portable/src/model.hpp
+++ b/driver/portable/src/model.hpp
@@ -8,9 +8,9 @@
 // — no GGUF involved. Multimodal-wrapper checkpoints (Ministral 3, Gemma 4)
 // substitute the canonical "model." prefix via Model::tname_().
 //
-// Backend selection follows ggml's registered devices: prefer_gpu picks
-// CUDA / Metal / Vulkan via ggml_backend_init_best() and falls back to
-// CPU when no GPU device is available.
+// Backend selection follows ggml's registered devices: pick the best compiled
+// backend via ggml_backend_init_best() and fall back to CPU when no GPU device
+// is available.
 
 #include <cstdint>
 #include <filesystem>
@@ -215,11 +215,10 @@ public:
     //   <snapshot_dir>/config.json
     //   <snapshot_dir>/model.safetensors  OR  <...>/model.safetensors.index.json
     //
-    // `prefer_gpu`: if true, picks the best registered GPU backend
-    // (CUDA / Metal / Vulkan, depending on what was compiled into ggml).
-    // Falls back to CPU if no GPU backend is available.
-    explicit Model(const std::filesystem::path& snapshot_dir,
-                   bool prefer_gpu = false);
+    // Picks the best registered backend (CUDA / Metal / Vulkan, depending on
+    // what was compiled into ggml). Falls back to CPU if no GPU backend is
+    // available.
+    explicit Model(const std::filesystem::path& snapshot_dir, bool verbose = false);
     ~Model();
 
     Model(const Model&) = delete;

--- a/inferlets/text-completion/Pie.toml
+++ b/inferlets/text-completion/Pie.toml
@@ -1,6 +1,6 @@
 [package]
 name = "text-completion"
-version = "0.2.14"
+version = "0.2.15"
 description = "Simple text completion inferlet"
 authors = ["In Gim <in.gim@icloud.com>"]
 repository = "https://github.com/pie-project/pie"

--- a/inferlets/text-completion/README.md
+++ b/inferlets/text-completion/README.md
@@ -1,12 +1,12 @@
-# Text Completion Inferlet
+# text-completion
 
-A simple inferlet for text completion tasks.
+A small chat-style text generation inferlet.
 
 ## Usage
 
-This inferlet accepts a prompt and optional parameters to generate text completions.
+Accepts a prompt and optional sampling parameters.
 
-### Inputs
+## Inputs
 
 - `prompt`: The user message to complete.
 - `system` (optional): System prompt.
@@ -14,6 +14,6 @@ This inferlet accepts a prompt and optional parameters to generate text completi
 - `temperature` (optional): Sampling temperature.
 - `top_p` (optional): Nucleus sampling threshold.
 
-### Outputs
+## Output
 
-- `completion`: The generated text.
+A string containing the generated text. Thinking tags are left in the text when the model emits them.

--- a/inferlets/text-completion/src/lib.rs
+++ b/inferlets/text-completion/src/lib.rs
@@ -1,19 +1,10 @@
 //! Simple text completion inferlet.
 //!
 //! Demonstrates chat-style generation with the explicit per-step Generator
-//! loop, fanning each token batch through both `chat::Decoder` (for the
-//! visible response) and `reasoning::Decoder` (for the thinking trace).
-//! This composes the two decoders by hand rather than leaning on a
-//! framework-provided unified event stream.
+//! loop and `chat::Decoder`.
 
-use inferlet::{
-    Context, Result,
-    chat, reasoning,
-    model::Model,
-    runtime,
-    sample::Sampler,
-};
-use serde::{Deserialize, Serialize};
+use inferlet::{Context, Result, chat, model::Model, runtime, sample::Sampler};
+use serde::Deserialize;
 
 #[derive(Deserialize)]
 struct Input {
@@ -37,21 +28,21 @@ struct Input {
     top_p: f32,
 }
 
-fn default_max_tokens() -> usize { 256 }
-fn default_system() -> String { "You are a helpful, respectful and honest assistant.".into() }
-fn default_temperature() -> f32 { 0.6 }
-fn default_top_p() -> f32 { 0.95 }
-
-#[derive(Serialize)]
-struct Output {
-    /// The thinking/reasoning trace.
-    thinking: String,
-    /// The generated text.
-    text: String,
+fn default_max_tokens() -> usize {
+    256
+}
+fn default_system() -> String {
+    "You are a helpful, respectful and honest assistant.".into()
+}
+fn default_temperature() -> f32 {
+    0.6
+}
+fn default_top_p() -> f32 {
+    0.95
 }
 
 #[inferlet::main]
-async fn main(input: Input) -> Result<Output> {
+async fn main(input: Input) -> Result<String> {
     let models = runtime::models();
     let model_name = models.first().ok_or("No models available")?;
     let model = Model::load(model_name)?;
@@ -59,11 +50,8 @@ async fn main(input: Input) -> Result<Output> {
     let mut ctx = Context::new(&model)?;
     ctx.system(&input.system).user(&input.prompt).cue();
 
-    let mut think = reasoning::Decoder::new(&model);
     let mut chat = chat::Decoder::new(&model);
-    let mut thinking = String::new();
     let mut text = String::new();
-    let mut in_reasoning = false;
 
     let mut g = ctx
         .generate(Sampler::TopP {
@@ -79,27 +67,8 @@ async fn main(input: Input) -> Result<Output> {
             continue;
         }
 
-        // Reasoning side: Start / Delta / End. Idle is the no-op signal
-        // (tokens outside any reasoning block, or empty visible chunks).
-        match think.feed(&out.tokens)? {
-            reasoning::Event::Start => in_reasoning = true,
-            reasoning::Event::Delta(s) => {
-                eprint!("{}", s);
-                thinking.push_str(&s);
-            }
-            reasoning::Event::End(_) => {
-                eprintln!();
-                in_reasoning = false;
-            }
-            reasoning::Event::Idle => {}
-        }
-
-        // Chat side: Delta is visible text. The `in_reasoning` guard is
-        // a defensive filter — the host should already exclude reasoning
-        // tokens from chat::Delta, but we keep it until the contract is
-        // confirmed.
         match chat.feed(&out.tokens)? {
-            chat::Event::Delta(s) if !in_reasoning => {
+            chat::Event::Delta(s) => {
                 print!("{}", s);
                 text.push_str(&s);
             }
@@ -111,5 +80,5 @@ async fn main(input: Input) -> Result<Output> {
         }
     }
 
-    Ok(Output { thinking, text })
+    Ok(text)
 }

--- a/runtime/src/bootstrap.rs
+++ b/runtime/src/bootstrap.rs
@@ -1,7 +1,8 @@
-use anyhow::{bail, ensure, Context, Result};
+use anyhow::{Context, Result, bail, ensure};
 
 use std::fs;
 use std::path::PathBuf;
+use tokio::net::TcpListener;
 
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -58,7 +59,6 @@ pub struct RuntimeConfig {
     // component_instances, memories, tables) — pie uses one of each per
     // inferlet, so we expose them as a single `wasm_max_instances` knob
     // and bump them in lockstep.
-
     /// Concurrent-inferlet cap (sets all four wasmtime `total_*` caps).
     pub wasm_max_instances: u32,
     /// Per-inferlet linear-memory cap, in MiB.
@@ -69,7 +69,6 @@ pub struct RuntimeConfig {
     pub wasm_warm_slots: u32,
 
     // ── filesystem ───────────────────────────────────────────────────
-
     /// Mount per-process scratch dir at `/scratch` with full read+write.
     pub allow_fs: bool,
     /// Base dir under which per-process scratch dirs are created.
@@ -77,7 +76,6 @@ pub struct RuntimeConfig {
     pub fs_scratch_dir: PathBuf,
 
     // ── network ──────────────────────────────────────────────────────
-
     /// Expose the host network to inferlets (both `wasi:sockets` and
     /// `wasi:http`). When false, sockets are denied and the `wasi:http`
     /// linker binding is dropped entirely.
@@ -89,7 +87,6 @@ pub struct RuntimeConfig {
     pub network_allowed_hosts: Vec<String>,
 
     // ── upload cap ───────────────────────────────────────────────────
-
     /// Per-upload cap on cumulative bytes (program installs +
     /// `session.send_file` blobs), in MiB.
     pub max_upload_mb: usize,
@@ -153,7 +150,24 @@ pub struct AuthConfig {
     pub authorized_users_dir: PathBuf,
 }
 
-pub async fn bootstrap(config: Config) -> Result<String> {
+#[derive(Debug, Clone)]
+pub struct BootstrapHandle {
+    pub token: String,
+    pub port: u16,
+}
+
+pub async fn bootstrap(config: Config) -> Result<BootstrapHandle> {
+    bootstrap_inner(config, None).await
+}
+
+pub async fn bootstrap_with_listener(
+    config: Config,
+    listener: TcpListener,
+) -> Result<BootstrapHandle> {
+    bootstrap_inner(config, Some(listener)).await
+}
+
+async fn bootstrap_inner(config: Config, listener: Option<TcpListener>) -> Result<BootstrapHandle> {
     verify_config(&config)?;
 
     if !config.skip_tracing {
@@ -166,10 +180,7 @@ pub async fn bootstrap(config: Config) -> Result<String> {
     // runtime state rather than loading their own copies.
     crate::program::python::runtime::init(&wasm_engine, config.python_snapshot);
 
-    auth::spawn(
-        config.auth.enabled,
-        &config.auth.authorized_users_dir,
-    );
+    auth::spawn(config.auth.enabled, &config.auth.authorized_users_dir);
 
     program::spawn(
         &wasm_engine,
@@ -191,7 +202,10 @@ pub async fn bootstrap(config: Config) -> Result<String> {
 
     linker::spawn(&wasm_engine, fs_policy, network_policy);
     let max_upload_bytes = config.runtime.max_upload_mb.saturating_mul(1024 * 1024);
-    server::spawn(&config.host, config.port, max_upload_bytes);
+    let bound_port = match listener {
+        Some(listener) => server::spawn_listener(listener, max_upload_bytes)?,
+        None => server::spawn(&config.host, config.port, max_upload_bytes).await?,
+    };
     messaging::spawn();
     process::init_admission(config.max_concurrent_processes);
 
@@ -203,9 +217,18 @@ pub async fn bootstrap(config: Config) -> Result<String> {
             cfg.tokenizer_path.clone(),
         )?;
 
-        let devices: Vec<usize> = cfg.devices.iter().map(|d| {
-            device::spawn(&d.hostname, d.total_pages, d.max_batch_size, d.max_batch_tokens)
-        }).collect();
+        let devices: Vec<usize> = cfg
+            .devices
+            .iter()
+            .map(|d| {
+                device::spawn(
+                    &d.hostname,
+                    d.total_pages,
+                    d.max_batch_size,
+                    d.max_batch_tokens,
+                )
+            })
+            .collect();
 
         let num_gpu_pages: Vec<usize> = cfg.devices.iter().map(|d| d.total_pages).collect();
         let num_cpu_pages: Vec<usize> = cfg.devices.iter().map(|d| d.cpu_pages).collect();
@@ -224,11 +247,15 @@ pub async fn bootstrap(config: Config) -> Result<String> {
             cfg.kv_page_size as u32,
             cfg.scheduler.request_timeout_secs,
             cfg.scheduler.batch_policy.clone(),
-        ).await;
+        )
+        .await;
         adapter::spawn(&devices);
     }
 
-    Ok(auth::get_internal_auth_token().await?)
+    Ok(BootstrapHandle {
+        token: auth::get_internal_auth_token().await?,
+        port: bound_port,
+    })
 }
 
 /// Boot-time checks for the values pie's Python layer cannot validate
@@ -242,28 +269,42 @@ fn verify_config(config: &Config) -> Result<()> {
         .with_context(|| format!("Could not create cache dir: {:?}", config.cache_dir))?;
 
     if config.auth.enabled {
-        fs::create_dir_all(&config.auth.authorized_users_dir)
-            .with_context(|| format!("Could not create auth users dir: {:?}", config.auth.authorized_users_dir))?;
+        fs::create_dir_all(&config.auth.authorized_users_dir).with_context(|| {
+            format!(
+                "Could not create auth users dir: {:?}",
+                config.auth.authorized_users_dir
+            )
+        })?;
     }
 
     for model in &config.models {
         ensure!(
             model.tokenizer_path.exists(),
-            "Model {:?}: tokenizer not found at {:?}", model.name, model.tokenizer_path
+            "Model {:?}: tokenizer not found at {:?}",
+            model.name,
+            model.tokenizer_path
         );
         for (i, dev) in model.devices.iter().enumerate() {
-            ensure!(dev.total_pages > 0,
-                "Model {:?} device {i}: total_pages must be > 0", model.name);
-            ensure!(dev.max_batch_size > 0,
-                "Model {:?} device {i}: max_batch_size must be > 0", model.name);
-            ensure!(dev.max_batch_tokens > 0,
-                "Model {:?} device {i}: max_batch_tokens must be > 0", model.name);
+            ensure!(
+                dev.total_pages > 0,
+                "Model {:?} device {i}: total_pages must be > 0",
+                model.name
+            );
+            ensure!(
+                dev.max_batch_size > 0,
+                "Model {:?} device {i}: max_batch_size must be > 0",
+                model.name
+            );
+            ensure!(
+                dev.max_batch_tokens > 0,
+                "Model {:?} device {i}: max_batch_tokens must be > 0",
+                model.name
+            );
         }
     }
 
     Ok(())
 }
-
 
 fn init_wasmtime(runtime: &RuntimeConfig) -> wasmtime::Engine {
     let mut wasm_config = wasmtime::Config::default();
@@ -282,13 +323,13 @@ fn init_wasmtime(runtime: &RuntimeConfig) -> wasmtime::Engine {
     pooling_config.total_tables(runtime.wasm_max_instances);
     pooling_config.total_stacks(runtime.wasm_max_instances);
     pooling_config.max_memory_size(runtime.wasm_max_memory_mb.saturating_mul(1024 * 1024));
-    pooling_config.linear_memory_keep_resident(
-        runtime.wasm_warm_memory_mb.saturating_mul(1024 * 1024),
-    );
+    pooling_config
+        .linear_memory_keep_resident(runtime.wasm_warm_memory_mb.saturating_mul(1024 * 1024));
     pooling_config.max_unused_warm_slots(runtime.wasm_warm_slots);
 
-    wasm_config
-        .allocation_strategy(wasmtime::InstanceAllocationStrategy::Pooling(pooling_config));
+    wasm_config.allocation_strategy(wasmtime::InstanceAllocationStrategy::Pooling(
+        pooling_config,
+    ));
 
     wasmtime::Engine::new(&wasm_config).unwrap()
 }
@@ -299,12 +340,12 @@ fn init_tracing(
     verbose: bool,
     telemetry_config: &TelemetryConfig,
 ) -> Result<()> {
-    use tracing_subscriber::fmt;
     use tracing_subscriber::EnvFilter;
+    use tracing_subscriber::fmt;
 
     let default_level = if verbose { "debug" } else { "info" };
-    let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new(default_level));
+    let filter =
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(default_level));
 
     // Optional file writer layer
     let file_layer = if let Some(dir) = log_dir {

--- a/runtime/src/program.rs
+++ b/runtime/src/program.rs
@@ -17,7 +17,7 @@ use crate::service::{Service, ServiceHandler};
 mod manifest;
 pub(crate) mod python;
 mod repository;
-pub use manifest::Manifest;
+pub use manifest::{Manifest, ParameterType};
 pub use repository::Repository;
 
 use python::runtime as py_runtime;
@@ -31,25 +31,18 @@ static SERVICE: LazyLock<Service<Message>> = LazyLock::new(Service::new);
 
 /// Spawns the program manager service.
 pub fn spawn(wasm_engine: &WasmEngine, registry_url: String, cache_dir: PathBuf) {
-    let mut repository = Repository::new(
-        registry_url,
-        cache_dir,
-    );
+    let mut repository = Repository::new(registry_url, cache_dir);
 
     // Scan disk on startup: load existing programs into index
     repository.load_program_cache();
 
-    SERVICE.spawn(|| {
-        ProgramService::new(&wasm_engine, repository)
-    }).expect("Program manager already spawned");
+    SERVICE
+        .spawn(|| ProgramService::new(&wasm_engine, repository))
+        .expect("Program manager already spawned");
 }
 
 /// Add a program with WASM binary and manifest. Stores in repository + disk (does NOT install).
-pub async fn add(
-    wasm_binary: Vec<u8>,
-    manifest: Manifest,
-    force_overwrite: bool,
-) -> Result<()> {
+pub async fn add(wasm_binary: Vec<u8>, manifest: Manifest, force_overwrite: bool) -> Result<()> {
     let (tx, rx) = oneshot::channel();
     SERVICE.send(Message::Add {
         wasm_binary,
@@ -74,20 +67,24 @@ pub async fn add_from_registry(name: &ProgramName, force_overwrite: bool) -> Res
 /// Check if a program is registered in repository.
 pub async fn is_registered(name: &ProgramName) -> bool {
     let (tx, rx) = oneshot::channel();
-    SERVICE.send(Message::Exists {
-        name: name.clone(),
-        response: tx,
-    }).ok();
+    SERVICE
+        .send(Message::Exists {
+            name: name.clone(),
+            response: tx,
+        })
+        .ok();
     rx.await.unwrap_or(false)
 }
 
 /// Check if a program is installed (JIT compiled and ready to run).
 pub async fn is_installed(name: &ProgramName) -> bool {
     let (tx, rx) = oneshot::channel();
-    SERVICE.send(Message::IsInstalled {
-        name: name.clone(),
-        response: tx,
-    }).ok();
+    SERVICE
+        .send(Message::IsInstalled {
+            name: name.clone(),
+            response: tx,
+        })
+        .ok();
     rx.await.unwrap_or(false)
 }
 
@@ -104,20 +101,24 @@ pub async fn install(name: &ProgramName) -> Result<()> {
 /// Uninstall a program: remove from installed programs (does NOT remove from cache).
 pub async fn uninstall(name: &ProgramName) -> bool {
     let (tx, rx) = oneshot::channel();
-    SERVICE.send(Message::Uninstall {
-        name: name.clone(),
-        response: tx,
-    }).ok();
+    SERVICE
+        .send(Message::Uninstall {
+            name: name.clone(),
+            response: tx,
+        })
+        .ok();
     rx.await.unwrap_or(false)
 }
 
 /// Get program metadata by name.
 pub async fn fetch_manifest(name: &ProgramName) -> Option<Manifest> {
     let (tx, rx) = oneshot::channel();
-    SERVICE.send(Message::GetMetadata {
-        name: name.clone(),
-        response: tx,
-    }).ok();
+    SERVICE
+        .send(Message::GetMetadata {
+            name: name.clone(),
+            response: tx,
+        })
+        .ok();
     rx.await.ok().flatten()
 }
 
@@ -126,10 +127,12 @@ pub async fn fetch_manifest(name: &ProgramName) -> Option<Manifest> {
 /// python-runtime version).
 pub async fn get_wasm_component(name: &ProgramName) -> Option<InstalledComponent> {
     let (tx, rx) = oneshot::channel();
-    SERVICE.send(Message::GetWasmComponent {
-        name: name.clone(),
-        response: tx,
-    }).ok();
+    SERVICE
+        .send(Message::GetWasmComponent {
+            name: name.clone(),
+            response: tx,
+        })
+        .ok();
     rx.await.ok().flatten()
 }
 
@@ -154,10 +157,12 @@ impl ProgramName {
             fancy_regex::Regex::new(r"^([a-zA-Z0-9][a-zA-Z0-9_-]*)@(\d+\.\d+\.\d+)$").unwrap()
         });
 
-        let caps = RE.captures(s)?
-            .ok_or_else(|| anyhow!(
-                "Invalid program identifier '{}': expected 'name@major.minor.patch'", s
-            ))?;
+        let caps = RE.captures(s)?.ok_or_else(|| {
+            anyhow!(
+                "Invalid program identifier '{}': expected 'name@major.minor.patch'",
+                s
+            )
+        })?;
 
         Ok(Self {
             name: caps.get(1).unwrap().as_str().to_string(),
@@ -263,7 +268,6 @@ impl ProgramService {
         true
     }
 
-
     /// Add a program with WASM binary and manifest: store in repository + disk (does NOT install).
     async fn add(
         &mut self,
@@ -271,12 +275,16 @@ impl ProgramService {
         manifest: Manifest,
         force_overwrite: bool,
     ) -> Result<()> {
-        self.repository.add(wasm_binary, manifest, force_overwrite).await
+        self.repository
+            .add(wasm_binary, manifest, force_overwrite)
+            .await
     }
 
     /// Add a program from registry by name: download and store in repository + disk (does NOT install).
     async fn add_from_registry(&mut self, name: &ProgramName, force_overwrite: bool) -> Result<()> {
-        self.repository.add_from_registry(name, force_overwrite).await
+        self.repository
+            .add_from_registry(name, force_overwrite)
+            .await
     }
 
     /// Install a program: JIT compile + link, resolves transitive dependencies.
@@ -347,12 +355,8 @@ impl ProgramService {
                 .filter_map(|n| self.installed.get(&n).map(|p| p.component.clone()))
                 .collect();
 
-            match snapshot::snapshot_from_bytes(
-                &self.wasm_engine,
-                &wasm_binary,
-                dep_components,
-            )
-            .await
+            match snapshot::snapshot_from_bytes(&self.wasm_engine, &wasm_binary, dep_components)
+                .await
             {
                 Ok(snap_bytes) => match compile_wasm_component(&self.wasm_engine, snap_bytes).await
                 {
@@ -362,7 +366,10 @@ impl ProgramService {
                             "Compile of snapshotted component failed for {}, falling back to non-snapshotted: {e:#}",
                             name,
                         );
-                        (compile_wasm_component(&self.wasm_engine, wasm_binary).await?, false)
+                        (
+                            compile_wasm_component(&self.wasm_engine, wasm_binary).await?,
+                            false,
+                        )
                     }
                 },
                 Err(e) => {
@@ -370,11 +377,17 @@ impl ProgramService {
                         "Snapshot pipeline failed for {}, falling back to non-snapshotted: {e:#}",
                         name,
                     );
-                    (compile_wasm_component(&self.wasm_engine, wasm_binary).await?, false)
+                    (
+                        compile_wasm_component(&self.wasm_engine, wasm_binary).await?,
+                        false,
+                    )
                 }
             }
         } else {
-            (compile_wasm_component(&self.wasm_engine, wasm_binary).await?, false)
+            (
+                compile_wasm_component(&self.wasm_engine, wasm_binary).await?,
+                false,
+            )
         };
 
         // Step 5: Track as installed and mark as explicitly installed
@@ -420,7 +433,9 @@ impl ProgramService {
             }
 
             // Get manifest to find direct dependencies
-            let manifest = self.repository.fetch_manifest(&current)
+            let manifest = self
+                .repository
+                .fetch_manifest(&current)
                 .ok_or_else(|| anyhow!("Manifest not found for program: {}", current))?;
 
             // Push current back with children_processed=true (for post-order)
@@ -525,7 +540,6 @@ enum Message {
     },
 }
 
-
 impl ServiceHandler for ProgramService {
     type Message = Message;
 
@@ -534,10 +548,19 @@ impl ServiceHandler for ProgramService {
             Message::GetMetadata { name, response } => {
                 let _ = response.send(self.get_manifest(&name));
             }
-            Message::Add { wasm_binary, manifest, force_overwrite, response } => {
+            Message::Add {
+                wasm_binary,
+                manifest,
+                force_overwrite,
+                response,
+            } => {
                 let _ = response.send(self.add(wasm_binary, manifest, force_overwrite).await);
             }
-            Message::AddFromRegistry { name, force_overwrite, response } => {
+            Message::AddFromRegistry {
+                name,
+                force_overwrite,
+                response,
+            } => {
                 let _ = response.send(self.add_from_registry(&name, force_overwrite).await);
             }
             Message::Exists { name, response } => {
@@ -564,7 +587,10 @@ impl ServiceHandler for ProgramService {
 // =============================================================================
 
 /// Compiles WASM bytes to a Component in a blocking thread.
-pub async fn compile_wasm_component(engine: &WasmEngine, wasm_binary: Vec<u8>) -> Result<Component> {
+pub async fn compile_wasm_component(
+    engine: &WasmEngine,
+    wasm_binary: Vec<u8>,
+) -> Result<Component> {
     let engine = engine.clone();
     match tokio::task::spawn_blocking(move || Component::from_binary(&engine, &wasm_binary)).await {
         Ok(Ok(component)) => Ok(component),
@@ -581,20 +607,29 @@ mod tests {
     fn program_name_parse_validation() {
         // ── Valid inputs ──────────────────────────────────────────────
         let valid = [
-            ("text-completion@0.1.0",  "text-completion", "0.1.0"),
-            ("my_inferlet@1.2.3",      "my_inferlet",     "1.2.3"),
-            ("a@0.0.0",               "a",               "0.0.0"),
-            ("X@99.99.99",            "X",               "99.99.99"),
-            ("foo-bar_baz@10.20.30",  "foo-bar_baz",     "10.20.30"),
-            ("A1-b2_C3@0.0.1",       "A1-b2_C3",        "0.0.1"),
+            ("text-completion@0.1.0", "text-completion", "0.1.0"),
+            ("my_inferlet@1.2.3", "my_inferlet", "1.2.3"),
+            ("a@0.0.0", "a", "0.0.0"),
+            ("X@99.99.99", "X", "99.99.99"),
+            ("foo-bar_baz@10.20.30", "foo-bar_baz", "10.20.30"),
+            ("A1-b2_C3@0.0.1", "A1-b2_C3", "0.0.1"),
         ];
         for (input, expected_name, expected_version) in valid {
             let p = ProgramName::parse(input)
                 .unwrap_or_else(|e| panic!("Expected '{}' to be valid, got: {}", input, e));
             assert_eq!(p.name, expected_name, "name mismatch for '{}'", input);
-            assert_eq!(p.version, expected_version, "version mismatch for '{}'", input);
+            assert_eq!(
+                p.version, expected_version,
+                "version mismatch for '{}'",
+                input
+            );
             // Display roundtrip
-            assert_eq!(p.to_string(), input, "Display roundtrip failed for '{}'", input);
+            assert_eq!(
+                p.to_string(),
+                input,
+                "Display roundtrip failed for '{}'",
+                input
+            );
         }
 
         // ── Invalid inputs ───────────────────────────────────────────
@@ -636,7 +671,8 @@ mod tests {
         for input in invalid {
             assert!(
                 ProgramName::parse(input).is_err(),
-                "Expected '{}' to be rejected, but it was accepted", input
+                "Expected '{}' to be rejected, but it was accepted",
+                input
             );
         }
     }

--- a/runtime/src/server.rs
+++ b/runtime/src/server.rs
@@ -14,8 +14,8 @@
 //! Process ↔ Client mappings are managed by the Process actor itself.
 //! Session state uses lock-free global DashMaps for zero-overhead lookups.
 
-mod handler;
 mod data_transfer;
+mod handler;
 
 pub use data_transfer::InFlightUpload;
 
@@ -23,7 +23,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, LazyLock};
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use base64::Engine as Base64Engine;
 use bytes::Bytes;
 use dashmap::DashMap;
@@ -35,10 +35,9 @@ use tokio::task::{self, JoinHandle};
 use tokio_tungstenite::accept_async;
 use tungstenite::Message as WsMessage;
 
-
 use crate::auth;
+use crate::process::{self, ProcessEvent, ProcessId};
 use crate::service::{Service, ServiceHandler, ServiceMap};
-use crate::process::{self, ProcessId, ProcessEvent};
 use crate::workflow::{self, WorkflowId};
 
 /// Unique identifier for a connected client.
@@ -50,30 +49,55 @@ pub type ClientId = u32;
 
 static SERVICE: LazyLock<Service<ServerMessage>> = LazyLock::new(Service::new);
 
-/// Starts the server on the given address. `max_upload_bytes` caps
-/// per-upload buffer growth (program installs + blob transfers).
-pub fn spawn(host: &str, port: u16, max_upload_bytes: usize) {
+/// Binds the websocket listener. Callers that have expensive startup work can
+/// bind first, then pass the listener to [`spawn_listener`] after startup.
+pub async fn bind(host: &str, port: u16) -> Result<TcpListener> {
     let addr = format!("{}:{}", host, port);
+    TcpListener::bind(&addr)
+        .await
+        .with_context(|| format!("bind websocket listener on {addr}"))
+}
+
+/// Starts the server on a pre-bound listener. `max_upload_bytes` caps
+/// per-upload buffer growth (program installs + blob transfers).
+///
+/// Returns the actual bound port. This matters when the listener was bound to
+/// port `0`, where the OS picks an available ephemeral port.
+pub fn spawn_listener(listener: TcpListener, max_upload_bytes: usize) -> Result<u16> {
+    let bound_port = listener
+        .local_addr()
+        .context("read websocket listener local_addr")?
+        .port();
     SERVICE
-        .spawn::<Server, _>(move || Server::new(addr, max_upload_bytes))
-        .expect("Server already spawned");
+        .spawn::<Server, _>(move || Server::new(listener, max_upload_bytes))
+        .context("spawn websocket server actor")?;
+    Ok(bound_port)
+}
+
+/// Starts the server on the given address.
+pub async fn spawn(host: &str, port: u16, max_upload_bytes: usize) -> Result<u16> {
+    let listener = bind(host, port).await?;
+    spawn_listener(listener, max_upload_bytes)
 }
 
 // =============================================================================
 // Client Session Public API
 // =============================================================================
 
-static CLIENT_SERVICES: LazyLock<ServiceMap<ClientId, SessionMessage>> = LazyLock::new(ServiceMap::new);
+static CLIENT_SERVICES: LazyLock<ServiceMap<ClientId, SessionMessage>> =
+    LazyLock::new(ServiceMap::new);
 
 /// Sends a typed process event to a client.
 pub fn send_event(client_id: ClientId, process_id: ProcessId, event: &ProcessEvent) -> Result<()> {
-    CLIENT_SERVICES.send(&client_id, SessionMessage::Event {
-        process_id,
-        event: event.name().to_string(),
-        value: event.value().to_string(),
-    })
+    CLIENT_SERVICES.send(
+        &client_id,
+        SessionMessage::Event {
+            process_id,
+            event: event.name().to_string(),
+            value: event.value().to_string(),
+        },
+    )
 }
-
 
 /// Sends a binary file to a client for a specific process.
 pub fn send_file(client_id: ClientId, process_id: ProcessId, data: Bytes) -> Result<()> {
@@ -83,7 +107,13 @@ pub fn send_file(client_id: ClientId, process_id: ProcessId, data: Bytes) -> Res
 /// Registers a file waiter for a process. Returns the file bytes when the client delivers them.
 pub async fn receive_file(client_id: ClientId, process_id: ProcessId) -> Result<Bytes> {
     let (tx, rx) = tokio::sync::oneshot::channel();
-    CLIENT_SERVICES.send(&client_id, SessionMessage::ReceiveFile { process_id, sender: tx })?;
+    CLIENT_SERVICES.send(
+        &client_id,
+        SessionMessage::ReceiveFile {
+            process_id,
+            sender: tx,
+        },
+    )?;
     Ok(rx.await?)
 }
 
@@ -114,23 +144,22 @@ pub async fn send_mcp_request(
     params: String,
 ) -> Result<std::result::Result<String, String>> {
     let (tx, rx) = tokio::sync::oneshot::channel();
-    CLIENT_SERVICES.send(&client_id, SessionMessage::McpRelay {
-        process_id,
-        server_name,
-        method,
-        params,
-        response: tx,
-    })?;
+    CLIENT_SERVICES.send(
+        &client_id,
+        SessionMessage::McpRelay {
+            process_id,
+            server_name,
+            method,
+            params,
+            response: tx,
+        },
+    )?;
     let (ok, result) = rx.await?;
     Ok(if ok { Ok(result) } else { Err(result) })
 }
 
 /// Spawns a new session actor for the given TCP connection.
-async fn spawn_session(
-    id: ClientId,
-    tcp_stream: TcpStream,
-    state: Arc<ServerState>,
-) -> Result<()> {
+async fn spawn_session(id: ClientId, tcp_stream: TcpStream, state: Arc<ServerState>) -> Result<()> {
     let session = Session::new(id, tcp_stream, state).await?;
     CLIENT_SERVICES.spawn(id, || session)?;
     Ok(())
@@ -160,21 +189,20 @@ struct Server {
 }
 
 impl Server {
-    fn new(addr: String, max_upload_bytes: usize) -> Self {
+    fn new(listener: TcpListener, max_upload_bytes: usize) -> Self {
         let state = Arc::new(ServerState {
             next_client_id: AtomicU32::new(1),
             clients: DashMap::new(),
             max_upload_bytes,
         });
 
-        task::spawn(Self::listener_loop(addr, state.clone()));
+        task::spawn(Self::listener_loop(listener, state.clone()));
 
         Server { state }
     }
 
     /// Accepts incoming connections and spawns session actors.
-    async fn listener_loop(addr: String, state: Arc<ServerState>) {
-        let listener = TcpListener::bind(addr).await.unwrap();
+    async fn listener_loop(listener: TcpListener, state: Arc<ServerState>) {
         while let Ok((stream, _addr)) = listener.accept().await {
             // Disable Nagle's algorithm so small RPC messages don't sit waiting
             // for delayed-ACKs — without this, concurrent client requests see
@@ -243,13 +271,20 @@ static MCP_REGISTRATIONS: LazyLock<DashMap<ClientId, Vec<McpServerEntry>>> =
 #[derive(Debug)]
 enum SessionMessage {
     /// Text event to push to the client (stdout, stderr, message, return, error).
-    Event { process_id: ProcessId, event: String, value: String },
+    Event {
+        process_id: ProcessId,
+        event: String,
+        value: String,
+    },
     /// Binary file to push to the client.
     File { process_id: ProcessId, data: Bytes },
     /// WebSocket message received from client.
     ClientRequest(ClientMessage),
     /// Register a file waiter for a process (client → process delivery).
-    ReceiveFile { process_id: ProcessId, sender: tokio::sync::oneshot::Sender<Bytes> },
+    ReceiveFile {
+        process_id: ProcessId,
+        sender: tokio::sync::oneshot::Sender<Bytes>,
+    },
     /// MCP relay: inferlet wants to call an MCP server through this client.
     McpRelay {
         process_id: ProcessId,
@@ -293,11 +328,7 @@ struct Session {
 
 impl Session {
     /// Creates a new Session, accepting the TCP connection and spawning WS pumps.
-    async fn new(
-        id: ClientId,
-        tcp_stream: TcpStream,
-        state: Arc<ServerState>,
-    ) -> Result<Self> {
+    async fn new(id: ClientId, tcp_stream: TcpStream, state: Arc<ServerState>) -> Result<Self> {
         let (ws_msg_tx, mut ws_msg_rx) = mpsc::channel(1000);
 
         let ws_stream = accept_async(tcp_stream).await?;
@@ -334,7 +365,10 @@ impl Session {
                     };
 
                     // Send directly to session actor
-                    if CLIENT_SERVICES.send(&client_id, SessionMessage::ClientRequest(client_msg)).is_err() {
+                    if CLIENT_SERVICES
+                        .send(&client_id, SessionMessage::ClientRequest(client_msg))
+                        .is_err()
+                    {
                         break;
                     }
                 }
@@ -360,7 +394,6 @@ impl Session {
             mcp_corr_id: 1,
         })
     }
-
 
     /// Cleanup when session is terminated.
     fn cleanup(&mut self) {
@@ -406,7 +439,11 @@ impl ServiceHandler for Session {
                     self.handle_client_message(client_msg).await;
                 }
             }
-            SessionMessage::Event { process_id, event, value } => {
+            SessionMessage::Event {
+                process_id,
+                event,
+                value,
+            } => {
                 self.send_process_event(process_id, &event, value).await;
             }
             SessionMessage::File { process_id, data } => {
@@ -415,11 +452,18 @@ impl ServiceHandler for Session {
             SessionMessage::ReceiveFile { process_id, sender } => {
                 self.file_waiters.insert(process_id, sender);
             }
-            SessionMessage::McpRelay { process_id, server_name, method, params, response } => {
+            SessionMessage::McpRelay {
+                process_id,
+                server_name,
+                method,
+                params,
+                response,
+            } => {
                 let corr_id = self.mcp_corr_id;
                 self.mcp_corr_id += 1;
                 self.pending_mcp.insert(corr_id, response);
-                self.send_mcp_request_ws(corr_id, process_id, server_name, method, params).await;
+                self.send_mcp_request_ws(corr_id, process_id, server_name, method, params)
+                    .await;
             }
         }
     }
@@ -453,12 +497,22 @@ impl Session {
     async fn handle_auth_request(&mut self, corr_id: u32, username: String) -> Result<bool> {
         if !auth::is_auth_enabled().await? {
             self.username = username;
-            self.send_response(corr_id, true, "Authenticated (Engine disabled authentication)".to_string()).await;
+            self.send_response(
+                corr_id,
+                true,
+                "Authenticated (Engine disabled authentication)".to_string(),
+            )
+            .await;
             return Ok(true);
         }
 
         if !auth::user_exists(username.clone()).await? {
-            self.send_response(corr_id, false, format!("User '{}' is not authorized", username)).await;
+            self.send_response(
+                corr_id,
+                false,
+                format!("User '{}' is not authorized", username),
+            )
+            .await;
             bail!("User '{}' is not authorized", username)
         }
 
@@ -466,7 +520,10 @@ impl Session {
         let challenge_b64 = base64::engine::general_purpose::STANDARD.encode(&challenge);
         self.send_response(corr_id, true, challenge_b64).await;
 
-        self.pending_auth = Some(PendingAuth { username, challenge });
+        self.pending_auth = Some(PendingAuth {
+            username,
+            challenge,
+        });
         Ok(false)
     }
 
@@ -475,27 +532,38 @@ impl Session {
         let pending = match self.pending_auth.take() {
             Some(p) => p,
             None => {
-                self.send_response(corr_id, false, "No pending authentication".to_string()).await;
+                self.send_response(corr_id, false, "No pending authentication".to_string())
+                    .await;
                 bail!("Signature received without pending authentication")
             }
         };
 
-        let signature_bytes = match base64::engine::general_purpose::STANDARD.decode(signature_b64.as_bytes()) {
+        let signature_bytes = match base64::engine::general_purpose::STANDARD
+            .decode(signature_b64.as_bytes())
+        {
             Ok(bytes) => bytes,
             Err(e) => {
-                self.send_response(corr_id, false, format!("Invalid signature encoding: {}", e)).await;
+                self.send_response(corr_id, false, format!("Invalid signature encoding: {}", e))
+                    .await;
                 bail!("Failed to decode signature: {}", e)
             }
         };
 
-        let verified = auth::verify_signature(pending.username.clone(), pending.challenge, signature_bytes).await?;
+        let verified =
+            auth::verify_signature(pending.username.clone(), pending.challenge, signature_bytes)
+                .await?;
 
         if !verified {
-            self.send_response(corr_id, false, "Signature verification failed".to_string()).await;
-            bail!("Signature verification failed for user '{}'", pending.username)
+            self.send_response(corr_id, false, "Signature verification failed".to_string())
+                .await;
+            bail!(
+                "Signature verification failed for user '{}'",
+                pending.username
+            )
         }
 
-        self.send_response(corr_id, true, "Authenticated".to_string()).await;
+        self.send_response(corr_id, true, "Authenticated".to_string())
+            .await;
         self.username = pending.username;
         Ok(true)
     }
@@ -545,7 +613,12 @@ impl Session {
         .await;
     }
 
-    pub(super) async fn send_process_event(&self, process_id: ProcessId, event: &str, value: String) {
+    pub(super) async fn send_process_event(
+        &self,
+        process_id: ProcessId,
+        event: &str,
+        value: String,
+    ) {
         let uuid_str = process_id.to_string();
         self.send(WireServerMessage::ProcessEvent {
             process_id: uuid_str,
@@ -591,7 +664,7 @@ impl Session {
                 self.send_response(corr_id, false, "Already authenticated".to_string())
                     .await;
             }
-            
+
             ClientMessage::AuthByToken { corr_id, token: _ } => {
                 self.send_response(corr_id, true, "Already authenticated".to_string())
                     .await;
@@ -702,12 +775,19 @@ impl Session {
                 args,
                 url,
             } => {
-                let entry = McpServerEntry { name, transport, command, args, url };
+                let entry = McpServerEntry {
+                    name,
+                    transport,
+                    command,
+                    args,
+                    url,
+                };
                 MCP_REGISTRATIONS
                     .entry(self.id)
                     .or_insert_with(Vec::new)
                     .push(entry);
-                self.send_response(corr_id, true, "MCP server registered".to_string()).await;
+                self.send_response(corr_id, true, "MCP server registered".to_string())
+                    .await;
             }
 
             ClientMessage::McpResponse {

--- a/sdk/python-server/python/pie/server.py
+++ b/sdk/python-server/python/pie/server.py
@@ -9,11 +9,11 @@ test fixtures (`tests/inferlets/conftest.py::_run`, `benches/*`,
         ...
 
 Lifecycle:
-  * `__aenter__`: optionally auto-pick a free port (`ServerConfig.port == 0`),
-    serialize the `Config` to TOML, hand it to the pyo3 `bootstrap`. The
-    pyo3 layer blocks until drivers + WS listener are up, then returns
-    a handle. We run that on a thread (`asyncio.to_thread`) so the
-    asyncio loop isn't blocked.
+  * `__aenter__`: serialize the `Config` to TOML and hand it to the pyo3
+    `bootstrap`. If `ServerConfig.port == 0`, Rust asks the OS for an
+    ephemeral port and returns the bound URL. The pyo3 layer blocks until
+    drivers + WS listener are up, then returns a handle. We run that on a
+    thread (`asyncio.to_thread`) so the asyncio loop isn't blocked.
   * `connect()`: build a `pie_client.PieClient` against the bound URL +
     auth-token-handshake using the engine's internal token. Each call
     returns a fresh client; the user is responsible for closing them.
@@ -28,20 +28,12 @@ from __future__ import annotations
 
 import asyncio
 import copy
-import socket
 from typing import TYPE_CHECKING, Any
 
 from pie.config import Config
 
 if TYPE_CHECKING:
     from pie_client import PieClient
-
-
-def _find_free_port() -> int:
-    """Bind a fresh socket to port 0 to discover a free local port."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("", 0))
-        return s.getsockname()[1]
 
 
 class Server:
@@ -74,11 +66,6 @@ class Server:
     def __init__(self, config: Config):
         # Copy so the user's object isn't mutated by the auto-port lookup.
         self._config = copy.deepcopy(config)
-
-        # Auto-assign a free port if the user requested one (matches the
-        # legacy `pie-server.Server.__init__` behavior).
-        if self._config.server.port == 0:
-            self._config.server.port = _find_free_port()
 
         self._handle: Any = None
         self._clients: list[Any] = []

--- a/sdk/tools/bakery/pyproject.toml
+++ b/sdk/tools/bakery/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "httpx>=0.27.0",
     "esprima>=4.0.0",
     "rich>=13.0.0",
-    "factored-componentize-py>=0.20.4",
+    "factored-componentize-py>=0.20.7",
 ]
 
 [project.scripts]

--- a/sdk/tools/bakery/uv.lock
+++ b/sdk/tools/bakery/uv.lock
@@ -75,11 +75,11 @@ wheels = [
 
 [[package]]
 name = "factored-componentize-py"
-version = "0.20.5"
+version = "0.20.7"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/31/c8ef21f22f04cf8f6bfd22a4e9269ff47726e1ed488a360928d1a48a0310/factored_componentize_py-0.20.5.tar.gz", hash = "sha256:77600692d427ca14ad8254606629a2041bf0c7431646a0e9b2465d17b4fb8e48", size = 182543, upload-time = "2026-03-27T06:37:12.308Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a6/37/80ab2efca55295181aa469766a98801f9c3ddd9899a54a793afd3c20fe33/factored_componentize_py-0.20.5-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:f801f6ff7cfed9fdecdfdfb6d154f52f91db7f8ea71deb5d94b51bd07c5a6a71", size = 24068355, upload-time = "2026-03-27T06:37:09.872Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/4b/ecccc61797c9f64f6445b3d670bca134c1cd98ea0b4a321a99da0efd206f/factored_componentize_py-0.20.7-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:df3244974750a37ddba92a033ed06512f20b09a528e5f6caca0babf91ff7f02f", size = 22657359, upload-time = "2026-05-04T05:15:18.712Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/57/aa505be1ce222253bc4240a6ee2a3f897d9e3dd2e35b7852db5aa3fcee16/factored_componentize_py-0.20.7-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cb2eccd49182a35d258d93e6dde20bf92f03acff646493ac406e85abb59caf84", size = 24040334, upload-time = "2026-05-04T05:21:59.278Z" },
 ]
 
 [[package]]
@@ -188,7 +188,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "esprima", specifier = ">=4.0.0" },
-    { name = "factored-componentize-py", specifier = ">=0.20.4" },
+    { name = "factored-componentize-py", specifier = ">=0.20.7" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "rich", specifier = ">=13.0.0" },

--- a/server/build.rs
+++ b/server/build.rs
@@ -111,7 +111,8 @@ fn build_portable() {
         // ggml-metal links against Apple's MetalKit / Foundation. The
         // C++ side handles those via xcrun; we just need to flip the
         // ggml flag and add the framework links below.
-        cfg.define("GGML_STATIC", "ON");
+        cfg.define("GGML_STATIC", "ON")
+            .define("GGML_METAL_EMBED_LIBRARY", "ON");
     }
     // Disable ggml-cpu's OpenMP unconditionally. macOS's Apple clang
     // doesn't ship libomp; on Linux, `-Wl,--as-needed -lgomp` is

--- a/server/src/cli.rs
+++ b/server/src/cli.rs
@@ -28,6 +28,7 @@ mod config_cmd;
 mod diag_cmd;
 mod doctor_cmd;
 mod driver_cmd;
+mod inferlet_cmd;
 mod model_cmd;
 mod monitor;
 mod run_cmd;
@@ -70,6 +71,12 @@ pub enum Command {
     Model {
         #[command(subcommand)]
         cmd: model_cmd::ModelCmd,
+    },
+
+    /// Inspect inferlets from the registry.
+    Inferlet {
+        #[command(subcommand)]
+        cmd: inferlet_cmd::InferletCmd,
     },
 
     /// Manage per-driver venvs + diagnostics
@@ -122,6 +129,7 @@ pub fn dispatch() -> Result<()> {
         Command::Config { cmd } => config_cmd::run(cmd),
         Command::Auth { cmd } => auth_cmd::run(cmd),
         Command::Model { cmd } => model_cmd::run(cmd),
+        Command::Inferlet { cmd } => inferlet_cmd::run(cmd),
         Command::Driver { cmd } => driver_cmd::run(cmd),
         Command::New(args) => bakery_cmd::run_new(args),
         Command::Build(args) => bakery_cmd::run_build(args),

--- a/server/src/cli/config_cmd/template.rs
+++ b/server/src/cli/config_cmd/template.rs
@@ -76,11 +76,9 @@ restore_pause_at_utilization = 0.85
 const PORTABLE_DRIVER_BLOCK: &str = r#"
 [model.driver]
 type = "portable"
-device = ["cpu"]
+device = ["auto"]
 
 [model.driver.options]
-n_ctx = 4096
-n_gpu_layers = 0
 max_batch_tokens = 10240
 max_batch_size = 512
 "#;

--- a/server/src/cli/inferlet_cmd.rs
+++ b/server/src/cli/inferlet_cmd.rs
@@ -1,0 +1,228 @@
+//! `pie inferlet info` — inspect registry inferlet metadata.
+
+use std::io::IsTerminal;
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, anyhow, bail};
+use clap::{Args, Subcommand};
+use serde::Deserialize;
+
+use pie::program::{Manifest, ProgramName};
+
+use crate::{config, paths};
+
+#[derive(Subcommand, Debug)]
+pub enum InferletCmd {
+    /// Show manifest metadata and accepted input parameters.
+    Info(InfoArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct InfoArgs {
+    /// Inferlet name, with optional version (e.g. `text-completion`
+    /// or `text-completion@0.2.14`).
+    pub inferlet: String,
+
+    /// Config TOML to use for the registry URL. Defaults to
+    /// `~/.pie/config.toml`.
+    #[arg(short = 'c', long)]
+    pub config: Option<PathBuf>,
+}
+
+pub fn run(cmd: InferletCmd) -> Result<()> {
+    match cmd {
+        InferletCmd::Info(args) => info(args),
+    }
+}
+
+fn info(args: InfoArgs) -> Result<()> {
+    let cfg_path = args.config.unwrap_or_else(paths::default_config_path);
+    let cfg = config::Config::from_toml_file(&cfg_path)
+        .with_context(|| format!("loading TOML config from {cfg_path:?}"))?;
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let (program, manifest) = runtime.block_on(async {
+        let program = resolve_inferlet_id(&args.inferlet, &cfg.server.registry).await?;
+        let manifest = Manifest::from_url(&cfg.server.registry, &program).await?;
+        Result::<_>::Ok((program, manifest))
+    })?;
+
+    print_manifest(&program, &manifest);
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct RegistryInferlet {
+    versions: Vec<RegistryVersion>,
+}
+
+#[derive(Deserialize)]
+struct RegistryVersion {
+    num: String,
+}
+
+async fn resolve_inferlet_id(inferlet: &str, registry_url: &str) -> Result<ProgramName> {
+    match inferlet.split_once('@') {
+        Some((name, "latest")) => {
+            validate_bare_inferlet_name(name)?;
+            let version = latest_version(name, registry_url).await?;
+            Ok(ProgramName {
+                name: name.to_string(),
+                version,
+            })
+        }
+        Some(_) => ProgramName::parse(inferlet),
+        None => {
+            validate_bare_inferlet_name(inferlet)?;
+            let version = latest_version(inferlet, registry_url).await?;
+            Ok(ProgramName {
+                name: inferlet.to_string(),
+                version,
+            })
+        }
+    }
+}
+
+async fn latest_version(name: &str, registry_url: &str) -> Result<String> {
+    let url = format!(
+        "{}/api/v1/inferlets/{}",
+        registry_url.trim_end_matches('/'),
+        name
+    );
+    let resp = reqwest::get(&url)
+        .await
+        .with_context(|| format!("resolve latest inferlet version from {url}"))?;
+    if !resp.status().is_success() {
+        bail!(
+            "resolve latest inferlet version: {url} returned {}",
+            resp.status()
+        );
+    }
+    let body = resp
+        .text()
+        .await
+        .with_context(|| format!("read latest inferlet metadata from {url}"))?;
+    latest_version_from_registry_json(&body)
+        .with_context(|| format!("resolve latest version for {name:?}"))
+}
+
+fn latest_version_from_registry_json(body: &str) -> Result<String> {
+    let info: RegistryInferlet =
+        serde_json::from_str(body).context("parse registry inferlet metadata")?;
+    info.versions
+        .into_iter()
+        .find(|v| !v.num.is_empty())
+        .map(|v| v.num)
+        .ok_or_else(|| anyhow!("registry returned no versions"))
+}
+
+fn validate_bare_inferlet_name(name: &str) -> Result<()> {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        bail!("inferlet name is empty");
+    };
+    if !first.is_ascii_alphanumeric() {
+        bail!("invalid inferlet name {name:?}: must start with an ASCII letter or digit");
+    }
+    if chars.any(|c| !(c.is_ascii_alphanumeric() || c == '-' || c == '_')) {
+        bail!("invalid inferlet name {name:?}: use only ASCII letters, digits, '-' and '_'");
+    }
+    Ok(())
+}
+
+fn print_manifest(program: &ProgramName, manifest: &Manifest) {
+    let colorize = std::io::stdout().is_terminal();
+    let (bold, dim, cyan, green, reset) = if colorize {
+        ("\x1b[1m", "\x1b[2m", "\x1b[36m", "\x1b[32m", "\x1b[0m")
+    } else {
+        ("", "", "", "", "")
+    };
+
+    println!("{bold}{program}{reset}");
+    if let Some(description) = &manifest.package.description {
+        println!("{description}");
+    }
+    if let Some(repository) = &manifest.package.repository {
+        println!("{dim}{repository}{reset}");
+    }
+
+    if manifest.parameters.is_empty() {
+        println!("\n{dim}(no parameters){reset}");
+        return;
+    }
+
+    println!("\n{bold}Parameters{reset}");
+    let name_width = manifest
+        .parameters
+        .keys()
+        .map(|name| name.chars().count())
+        .max()
+        .unwrap_or(4)
+        .max("name".len());
+    let type_width = manifest
+        .parameters
+        .values()
+        .map(|param| parameter_type_name(&param.param_type).len())
+        .max()
+        .unwrap_or(4)
+        .max("type".len());
+
+    println!(
+        "{dim}{:<name_width$}  {:<type_width$}  required  description{reset}",
+        "name", "type"
+    );
+    for (name, param) in &manifest.parameters {
+        let required = if param.optional {
+            format!("{dim}optional{reset}")
+        } else {
+            format!("{green}yes{reset}")
+        };
+        let description = param.description.as_deref().unwrap_or("");
+        println!(
+            "{cyan}{:<name_width$}{reset}  {:<type_width$}  {:<8}  {}",
+            name,
+            parameter_type_name(&param.param_type),
+            required,
+            description
+        );
+    }
+}
+
+fn parameter_type_name(param_type: &pie::program::ParameterType) -> &'static str {
+    match param_type {
+        pie::program::ParameterType::String => "string",
+        pie::program::ParameterType::Int => "int",
+        pie::program::ParameterType::Float => "float",
+        pie::program::ParameterType::Bool => "bool",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn latest_version_from_registry_json_uses_first_version() {
+        let body = r#"{
+            "versions": [
+                {"num": "0.2.14"},
+                {"num": "0.2.13"}
+            ]
+        }"#;
+
+        assert_eq!(latest_version_from_registry_json(body).unwrap(), "0.2.14");
+    }
+
+    #[test]
+    fn bare_inferlet_name_validation_matches_program_names() {
+        validate_bare_inferlet_name("text-completion").unwrap();
+        validate_bare_inferlet_name("foo_bar-1").unwrap();
+
+        assert!(validate_bare_inferlet_name("").is_err());
+        assert!(validate_bare_inferlet_name("-bad").is_err());
+        assert!(validate_bare_inferlet_name("bad/name").is_err());
+        assert!(validate_bare_inferlet_name("bad.name").is_err());
+    }
+}

--- a/server/src/cli/run_cmd.rs
+++ b/server/src/cli/run_cmd.rs
@@ -4,13 +4,18 @@
 //! one-shot engine, connects via `pie-client`, launches the inferlet,
 //! relays process events, and tears the engine down on completion.
 
-use std::io::Write;
+use std::io::{self, IsTerminal, Write};
 use std::path::PathBuf;
-use std::sync::mpsc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+    mpsc,
+};
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
 use clap::Args;
+use serde::Deserialize;
 
 use pie_client::client::{Client, ProcessEvent};
 
@@ -45,10 +50,14 @@ pub struct RunArgs {
     #[arg(long, default_value = "{}")]
     pub input: String,
 
-    /// Include inferlet stdout as it is produced. Without this flag,
-    /// only the final return value is printed.
+    /// Include inferlet stdout/stderr as it is produced. Without this
+    /// flag, only the final return value is printed.
     #[arg(long = "stdout")]
     pub relay_stdout: bool,
+
+    /// Show engine, driver, server, and inferlet diagnostics.
+    #[arg(long)]
+    pub debug: bool,
 
     /// Suppress `pie run` progress chatter on stderr.
     #[arg(short = 'q', long)]
@@ -83,20 +92,38 @@ pub fn run(mut args: RunArgs) -> Result<()> {
         .unwrap_or_else(paths::default_config_path);
     let mut cfg = config::Config::from_toml_file(&cfg_path)
         .with_context(|| format!("loading TOML config from {cfg_path:?}"))?;
-    if let Some(p) = args.port {
-        cfg.server.port = p;
-    }
-    // Heavy testing phase: always show startup details, even for old
-    // temp configs that explicitly set `verbose = false`.
-    cfg.server.verbose = true;
+    cfg.server.port = args.port.unwrap_or(0);
+    cfg.server.verbose = args.debug;
 
     crate::py_runtime::ensure_installed_best_effort();
     let runtime = serve::build_runtime(&cfg)?;
 
     runtime.block_on(async move {
-        let engine = serve::start_engine(cfg)
+        if args.path.is_none() {
+            if let Some(inferlet) = args.inferlet.take() {
+                args.inferlet = Some(resolve_inferlet_id(&inferlet, &cfg.server.registry).await?);
+            }
+        }
+
+        let model_label = cfg
+            .models
+            .first()
+            .map(|m| m.hf_repo.clone())
+            .unwrap_or_else(|| "default".to_string());
+        let status = RunStatus::start(args.quiet || args.debug, model_label);
+        let engine = match serve::start_engine(cfg)
             .await
-            .context("starting one-shot engine")?;
+            .context("starting one-shot engine")
+        {
+            Ok(engine) => {
+                status.finish();
+                engine
+            }
+            Err(e) => {
+                status.fail("Engine failed");
+                return Err(e);
+            }
+        };
         let url = engine.url.clone();
         let token = engine.token.clone();
         let result = drive_inferlet(&url, &token, &args).await;
@@ -107,7 +134,7 @@ pub fn run(mut args: RunArgs) -> Result<()> {
             eprintln!("pie run: {e:#}");
         }
 
-        shutdown_engine_bounded(engine, args.quiet);
+        shutdown_engine_bounded(engine, args.quiet || !args.debug);
 
         result
     })
@@ -143,7 +170,7 @@ async fn drive_inferlet(url: &str, token: &str, args: &RunArgs) -> Result<()> {
             .expect("argument-validation guaranteed inferlet is Some")
     };
 
-    let mut process = client
+    let mut process = match client
         .launch_process(
             inferlet_id.clone(),
             args.input.clone(),
@@ -151,11 +178,22 @@ async fn drive_inferlet(url: &str, token: &str, args: &RunArgs) -> Result<()> {
             /*token_budget=*/ None,
         )
         .await
-        .with_context(|| format!("launch_process {inferlet_id}"))?;
+        .with_context(|| format!("launch_process {inferlet_id}"))
+    {
+        Ok(process) => process,
+        Err(e) => {
+            return Err(e);
+        }
+    };
 
-    if !args.quiet {
+    if args.debug {
         eprintln!("(launched {inferlet_id} as {})", process.id());
     }
+
+    let mut status = RunStatus::spawn(
+        args.quiet || args.debug || args.relay_stdout,
+        inferlet_id.clone(),
+    );
 
     let mut stdout = std::io::stdout();
     let mut stderr = std::io::stderr();
@@ -168,20 +206,28 @@ async fn drive_inferlet(url: &str, token: &str, args: &RunArgs) -> Result<()> {
                 }
             }
             ProcessEvent::Stderr(s) => {
-                let _ = stderr.write_all(s.as_bytes());
-                let _ = stderr.flush();
+                if args.relay_stdout || args.debug {
+                    let _ = stderr.write_all(s.as_bytes());
+                    let _ = stderr.flush();
+                }
             }
             ProcessEvent::Message(m) => {
-                eprintln!("[message] {m}");
+                if args.debug {
+                    eprintln!("[message] {m}");
+                }
             }
             ProcessEvent::File(bytes) => {
-                eprintln!("[received file: {} bytes]", bytes.len());
+                if args.debug {
+                    eprintln!("[received file: {} bytes]", bytes.len());
+                }
             }
             ProcessEvent::Return(v) => {
-                println!("{v}");
+                status.stop();
+                print_return_value(&v, args.debug || args.relay_stdout)?;
                 break;
             }
             ProcessEvent::Error(e) => {
+                status.fail("Inferlet failed");
                 eprintln!("✗ {e}");
                 bail!("inferlet errored: {e}");
             }
@@ -190,6 +236,75 @@ async fn drive_inferlet(url: &str, token: &str, args: &RunArgs) -> Result<()> {
     // `run` is a one-shot CLI: once the process returned, teardown is
     // handled by the caller immediately after this function returns.
     let _ = tokio::time::timeout(Duration::from_secs(2), client.close()).await;
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct RegistryInferlet {
+    versions: Vec<RegistryVersion>,
+}
+
+#[derive(Deserialize)]
+struct RegistryVersion {
+    num: String,
+}
+
+async fn resolve_inferlet_id(inferlet: &str, registry_url: &str) -> Result<String> {
+    let (name, should_resolve) = match inferlet.split_once('@') {
+        None => (inferlet, true),
+        Some((name, "latest")) => (name, true),
+        Some(_) => return Ok(inferlet.to_string()),
+    };
+
+    validate_bare_inferlet_name(name)?;
+    if !should_resolve {
+        return Ok(inferlet.to_string());
+    }
+
+    let url = format!(
+        "{}/api/v1/inferlets/{}",
+        registry_url.trim_end_matches('/'),
+        name
+    );
+    let resp = reqwest::get(&url)
+        .await
+        .with_context(|| format!("resolve latest inferlet version from {url}"))?;
+    if !resp.status().is_success() {
+        bail!(
+            "resolve latest inferlet version: {url} returned {}",
+            resp.status()
+        );
+    }
+    let body = resp
+        .text()
+        .await
+        .with_context(|| format!("read latest inferlet metadata from {url}"))?;
+    let latest = latest_version_from_registry_json(&body)
+        .with_context(|| format!("resolve latest version for {name:?}"))?;
+    Ok(format!("{name}@{latest}"))
+}
+
+fn latest_version_from_registry_json(body: &str) -> Result<String> {
+    let info: RegistryInferlet =
+        serde_json::from_str(body).context("parse registry inferlet metadata")?;
+    info.versions
+        .into_iter()
+        .find(|v| !v.num.is_empty())
+        .map(|v| v.num)
+        .ok_or_else(|| anyhow!("registry returned no versions"))
+}
+
+fn validate_bare_inferlet_name(name: &str) -> Result<()> {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        bail!("inferlet name is empty");
+    };
+    if !first.is_ascii_alphanumeric() {
+        bail!("invalid inferlet name {name:?}: must start with an ASCII letter or digit");
+    }
+    if chars.any(|c| !(c.is_ascii_alphanumeric() || c == '-' || c == '_')) {
+        bail!("invalid inferlet name {name:?}: use only ASCII letters, digits, '-' and '_'");
+    }
     Ok(())
 }
 
@@ -280,5 +395,197 @@ fn shutdown_engine_bounded(engine: serve::EngineHandle, quiet: bool) {
     }
     if rx.recv_timeout(SHUTDOWN_GRACE).is_err() {
         eprintln!("engine shutdown did not finish within {SHUTDOWN_GRACE:?}; exiting");
+    }
+}
+
+struct RunStatus {
+    done: Arc<AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+    enabled: bool,
+}
+
+impl RunStatus {
+    fn start(disabled: bool, model_label: String) -> Self {
+        Self::spawn(disabled, format!("loading model ({model_label})"))
+    }
+
+    fn spawn(disabled: bool, label: String) -> Self {
+        let enabled = !disabled && io::stderr().is_terminal();
+        if !enabled {
+            return Self {
+                done: Arc::new(AtomicBool::new(true)),
+                handle: None,
+                enabled,
+            };
+        }
+
+        let done = Arc::new(AtomicBool::new(false));
+        let thread_done = Arc::clone(&done);
+        let handle = std::thread::spawn(move || {
+            const FRAMES: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+            let mut idx = 0usize;
+            while !thread_done.load(Ordering::Relaxed) {
+                eprint!("\r\x1b[K{} {}", FRAMES[idx % FRAMES.len()], label);
+                let _ = io::stderr().flush();
+                idx = idx.wrapping_add(1);
+                std::thread::sleep(Duration::from_millis(90));
+            }
+        });
+        Self {
+            done,
+            handle: Some(handle),
+            enabled,
+        }
+    }
+
+    fn finish(mut self) {
+        self.stop();
+    }
+
+    fn fail(mut self, message: &str) {
+        self.stop();
+        if self.enabled {
+            eprintln!("\x1b[31m✗\x1b[0m {message}");
+        }
+    }
+
+    fn stop(&mut self) {
+        self.done.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+        if self.enabled {
+            eprint!("\r\x1b[K");
+            let _ = io::stderr().flush();
+        }
+    }
+}
+
+impl Drop for RunStatus {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn print_return_value(value: &str, rich: bool) -> Result<()> {
+    if !rich || !io::stdout().is_terminal() {
+        println!("{value}");
+        return Ok(());
+    }
+
+    let display = serde_json::from_str::<serde_json::Value>(value)
+        .ok()
+        .and_then(|json| serde_json::to_string_pretty(&json).ok())
+        .unwrap_or_else(|| value.to_string());
+    for line in display.lines() {
+        println!("{}", highlight_json_line(line));
+    }
+    Ok(())
+}
+
+fn highlight_json_line(line: &str) -> String {
+    const RESET: &str = "\x1b[0m";
+    const KEY: &str = "\x1b[1;36m";
+    const STRING: &str = "\x1b[32m";
+    const NUMBER: &str = "\x1b[33m";
+    const KEYWORD: &str = "\x1b[35m";
+    const PUNCT: &str = "\x1b[90m";
+
+    let mut out = String::with_capacity(line.len() + 32);
+    let mut i = 0usize;
+    let bytes = line.as_bytes();
+    while i < bytes.len() {
+        let c = bytes[i] as char;
+        match c {
+            '"' => {
+                let start = i;
+                i += 1;
+                let mut escaped = false;
+                while i < bytes.len() {
+                    let ch = bytes[i] as char;
+                    if escaped {
+                        escaped = false;
+                    } else if ch == '\\' {
+                        escaped = true;
+                    } else if ch == '"' {
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+                let token = &line[start..i.min(line.len())];
+                let rest = &line[i.min(line.len())..];
+                let is_key = rest.trim_start().starts_with(':');
+                out.push_str(if is_key { KEY } else { STRING });
+                out.push_str(token);
+                out.push_str(RESET);
+            }
+            '-' | '0'..='9' => {
+                let start = i;
+                i += 1;
+                while i < bytes.len()
+                    && matches!(bytes[i] as char, '0'..='9' | '.' | 'e' | 'E' | '+' | '-')
+                {
+                    i += 1;
+                }
+                out.push_str(NUMBER);
+                out.push_str(&line[start..i]);
+                out.push_str(RESET);
+            }
+            't' | 'f' | 'n' => {
+                let rest = &line[i..];
+                let keyword = ["true", "false", "null"]
+                    .iter()
+                    .find(|kw| rest.starts_with(**kw));
+                if let Some(keyword) = keyword {
+                    i += keyword.len();
+                    out.push_str(KEYWORD);
+                    out.push_str(keyword);
+                    out.push_str(RESET);
+                } else {
+                    out.push(c);
+                    i += 1;
+                }
+            }
+            '{' | '}' | '[' | ']' | ':' | ',' => {
+                out.push_str(PUNCT);
+                out.push(c);
+                out.push_str(RESET);
+                i += 1;
+            }
+            _ => {
+                out.push(c);
+                i += 1;
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn latest_version_from_registry_json_uses_first_version() {
+        let body = r#"{
+            "versions": [
+                {"num": "0.2.14"},
+                {"num": "0.2.13"}
+            ]
+        }"#;
+
+        assert_eq!(latest_version_from_registry_json(body).unwrap(), "0.2.14");
+    }
+
+    #[test]
+    fn bare_inferlet_name_validation_matches_program_names() {
+        validate_bare_inferlet_name("text-completion").unwrap();
+        validate_bare_inferlet_name("foo_bar-1").unwrap();
+
+        assert!(validate_bare_inferlet_name("").is_err());
+        assert!(validate_bare_inferlet_name("-bad").is_err());
+        assert!(validate_bare_inferlet_name("bad/name").is_err());
+        assert!(validate_bare_inferlet_name("bad.name").is_err());
     }
 }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -565,8 +565,8 @@ pub struct PortableDriverOptions {
     pub max_batch_tokens: u32,
     pub max_batch_size: u32,
     pub cpu_pages: u32,
-    pub n_ctx: u32,
-    pub n_gpu_layers: i32,
+    #[serde(skip)]
+    pub verbose: bool,
     pub ready_timeout_s: f64,
     pub shutdown_timeout_s: f64,
     /// Ignored in standalone (binary is statically linked); accepted
@@ -582,8 +582,7 @@ impl Default for PortableDriverOptions {
             max_batch_tokens: 10240,
             max_batch_size: 512,
             cpu_pages: 0,
-            n_ctx: 4096,
-            n_gpu_layers: 0,
+            verbose: false,
             ready_timeout_s: 120.0,
             shutdown_timeout_s: 5.0,
             binary_path: String::new(),

--- a/server/src/embedded_driver.rs
+++ b/server/src/embedded_driver.rs
@@ -220,6 +220,10 @@ fn insert_str(table: &mut toml::Table, key: &str, value: impl Into<String>) {
     table.insert(key.into(), toml::Value::String(value.into()));
 }
 
+fn insert_bool(table: &mut toml::Table, key: &str, value: bool) {
+    table.insert(key.into(), toml::Value::Boolean(value));
+}
+
 fn insert_table(doc: &mut toml::Table, key: &str, table: toml::Table) {
     doc.insert(key.into(), toml::Value::Table(table));
 }
@@ -325,8 +329,6 @@ pub fn write_startup_toml(
 
     let mut model = toml::Table::new();
     insert_str(&mut model, "hf_path", path_string(snapshot_dir));
-    insert_int(&mut model, "n_gpu_layers", options.n_gpu_layers);
-    insert_int(&mut model, "n_ctx", options.n_ctx);
     insert_table(&mut doc, "model", model);
 
     let mut batching = toml::Table::new();
@@ -340,6 +342,10 @@ pub fn write_startup_toml(
     let mut aux_ipc = toml::Table::new();
     insert_str(&mut aux_ipc, "socket_path", path_string(aux_socket_path));
     insert_table(&mut doc, "aux_ipc", aux_ipc);
+
+    let mut runtime = toml::Table::new();
+    insert_bool(&mut runtime, "verbose", options.verbose);
+    insert_table(&mut doc, "runtime", runtime);
 
     write_toml_table(out_path, doc)
 }

--- a/server/src/serve.rs
+++ b/server/src/serve.rs
@@ -183,6 +183,7 @@ pub fn build_runtime(user_cfg: &config::Config) -> Result<tokio::runtime::Runtim
 /// the caller can drive (wait-and-shutdown for plain serve, or hand
 /// off to a TUI for the monitor path).
 pub async fn start_engine(user_cfg: config::Config) -> Result<EngineHandle> {
+    let listener = pie::server::bind(&user_cfg.server.host, user_cfg.server.port).await?;
     let mut handshakes: Vec<ModelHandshake> = Vec::with_capacity(user_cfg.models.len());
     let mut drivers: Vec<DriverHandle> = Vec::new();
     let mut rpc_servers: Vec<Arc<pie::device::RpcServer>> = Vec::new();
@@ -236,10 +237,11 @@ pub async fn start_engine(user_cfg: config::Config) -> Result<EngineHandle> {
 
         // Embedded options are typed; subprocess uses raw passthrough,
         // so it's only built when we know we're on the embedded path.
-        let embedded_base_opts = match resolved {
+        let mut embedded_base_opts = match resolved {
             ResolvedFlavor::Embedded(f) => Some(topology::build_embedded_options(m, f)?),
             ResolvedFlavor::Subprocess(_) => None,
         };
+        apply_portable_verbose(&mut embedded_base_opts, user_cfg.server.verbose);
 
         // Resolve snapshot once per model — every group serves the same
         // weights against the same on-disk path.
@@ -314,20 +316,22 @@ pub async fn start_engine(user_cfg: config::Config) -> Result<EngineHandle> {
     let boot_cfg = bootstrap_translate::build(&user_cfg, &handshakes)
         .context("translating to bootstrap::Config")?;
 
-    let token = pie::bootstrap::bootstrap(boot_cfg)
+    let boot = pie::bootstrap::bootstrap_with_listener(boot_cfg, listener)
         .await
         .map_err(|e| anyhow!("pie::bootstrap::bootstrap: {e}"))?;
+    let bound_port = boot.port;
+    let token = boot.token;
 
-    eprintln!(
-        "pie-server serving on {}:{} ({} model(s))",
-        user_cfg.server.host,
-        user_cfg.server.port,
-        user_cfg.models.len(),
-    );
     if user_cfg.server.verbose {
+        eprintln!(
+            "pie-server serving on {}:{} ({} model(s))",
+            user_cfg.server.host,
+            bound_port,
+            user_cfg.models.len(),
+        );
         eprintln!("internal token: {token}");
+        eprintln!("press Ctrl-C to shut down");
     }
-    eprintln!("press Ctrl-C to shut down");
 
     let shmem_names: Vec<String> = drivers.iter().map(|d| d.shmem_name().to_string()).collect();
 
@@ -337,7 +341,7 @@ pub async fn start_engine(user_cfg: config::Config) -> Result<EngineHandle> {
         rpc_threads,
         shmem_names,
         token,
-        url: format!("ws://{}:{}", user_cfg.server.host, user_cfg.server.port),
+        url: format!("ws://{}:{}", user_cfg.server.host, bound_port),
     })
 }
 
@@ -482,6 +486,16 @@ fn embedded_opts_for_device(base_opts: &DriverOptions, device: String) -> Driver
         },
         other => other.clone(),
     }
+}
+
+fn apply_portable_verbose(options: &mut Option<DriverOptions>, verbose: bool) {
+    #[cfg(feature = "driver-portable")]
+    if let Some(DriverOptions::Portable(p)) = options.as_mut() {
+        p.verbose = verbose;
+    }
+
+    #[cfg(not(feature = "driver-portable"))]
+    let _ = (options, verbose);
 }
 
 #[cfg(feature = "driver-cuda")]

--- a/website/docs/guide/examples/chat.mdx
+++ b/website/docs/guide/examples/chat.mdx
@@ -11,7 +11,7 @@ The starting point. Each of these is a small inferlet that loads a model, builds
 | Inferlet | What it shows |
 |---|---|
 | [`helloworld`](https://github.com/pie-project/pie/tree/main/inferlets/helloworld) | Minimal `#[inferlet::main]` with typed JSON input/output. |
-| [`text-completion`](https://github.com/pie-project/pie/tree/main/inferlets/text-completion) | Chat-style generation via `Context::system / user / cue`, the per-step `Generator`, and independent `chat::Decoder` and `reasoning::Decoder`. |
+| [`text-completion`](https://github.com/pie-project/pie/tree/main/inferlets/text-completion) | Chat-style generation via `Context::system / user / cue`, the per-step `Generator`, and `chat::Decoder`. |
 | [`text-completion-spec`](https://github.com/pie-project/pie/tree/main/inferlets/text-completion-spec) | Same shape, but exercises the speculative-decoding path (`Speculation::Default` → backend NGRAM). |
 | [`python-example`](https://github.com/pie-project/pie/tree/main/inferlets/python-example) | Text completion in Python. |
 | [`js-example`](https://github.com/pie-project/pie/tree/main/inferlets/js-example) | Text completion in JavaScript. |

--- a/website/docs/reference/drivers/portable.mdx
+++ b/website/docs/reference/drivers/portable.mdx
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 # Portable
 
-`type = "portable"`. An embedded ggml-backed driver built from `driver/portable/` on top of vendored llama.cpp/ggml. Loads HuggingFace safetensors directly, no GGUF conversion. CPU is the default backend; CUDA, Vulkan, Metal, HIP, and SYCL backends are selected at C++ build time via `GGML_*=ON` CMake flags.
+`type = "portable"`. An embedded ggml-backed driver built from `driver/portable/` on top of vendored llama.cpp/ggml. Loads HuggingFace safetensors directly, no GGUF conversion. By default it picks the best backend compiled into the binary and falls back to CPU. CUDA, Vulkan, Metal, HIP, and SYCL backends are selected at C++ build time via `GGML_*=ON` CMake flags.
 
 Pick `portable` for CPU-only inference, non-NVIDIA GPUs (Vulkan / Metal / HIP / SYCL), or any host where you want a self-contained binary without a Python runtime.
 
@@ -31,7 +31,7 @@ From source, `cargo install --path server` builds `pie` with `driver-portable` e
 ```toml
 [model.driver]
 type = "portable"
-device = ["cpu"]                  # or ["cuda:0"] / ["metal"] / ["vulkan"] depending on the build
+device = ["auto"]                 # logical local replica name
 activation_dtype = "bfloat16"
 
 [model.driver.options]
@@ -40,8 +40,6 @@ max_num_kv_pages     = 1024
 max_batch_tokens     = 10240
 max_batch_size       = 512
 cpu_pages            = 0
-n_ctx                = 4096
-n_gpu_layers         = 0
 ready_timeout_s      = 120.0
 shutdown_timeout_s   = 5.0
 ```
@@ -54,8 +52,6 @@ shutdown_timeout_s   = 5.0
 | `max_batch_tokens` | `10240` | Cap on tokens per fire_batch. |
 | `max_batch_size` | `512` | Cap on sequences per fire_batch. |
 | `cpu_pages` | `0` | Host-side swap pool capacity. `0` = no swap. |
-| `n_ctx` | `4096` | Informational max position the binary will accept. Real KV capacity is `max_num_kv_pages * kv_page_size` slots flexibly shared across contexts. |
-| `n_gpu_layers` | `0` | `0` = CPU only, `-1` = offload all layers to a GPU backend, `N` = first `N` layers. Takes effect only when GPU backends are linked into the binary. |
 | `ready_timeout_s` | `120.0` | Seconds to wait for `READY` on stdout. |
 | `shutdown_timeout_s` | `5.0` | Seconds to wait for graceful shutdown after SIGTERM. |
 


### PR DESCRIPTION
## Summary
- clean up portable driver config and default backend behavior
- improve pie run output/spinner handling and add inferlet info
- publish text-completion as plaintext output and update docs/bakery lock

## Verification
- cargo check -p pie-server --bin pie
- cargo check -p pie-server --bin pie --no-default-features
- git diff --check

## CI trigger audit
- release/build publishing workflows are manual-only via workflow_dispatch
- PR CI does not upload release assets or publish packages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `pie inferlet info` command to query inferlet metadata from registry.
  * Added `--debug` flag to `pie run` for enhanced logging and formatted JSON output.

* **Bug Fixes**
  * Fixed server port binding to return actual bound port instead of configured port.

* **Changes**
  * Portable driver now automatically selects the best available compiled backend with CPU fallback.
  * Simplified text-completion inferlet output—now returns only generated text without thinking tags.
  * Removed `n_ctx` and `n_gpu_layers` configuration options from portable driver settings.
  * Text-completion package updated to version 0.2.15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->