### PR TITLE
Phase 44: per-substage GPU profiling inside engine.fire_batch (#68085)

### DIFF
--- a/pie/src/pie_driver/latency.py
+++ b/pie/src/pie_driver/latency.py
@@ -2,10 +2,38 @@
 
 from __future__ import annotations
 
+import os
+import threading
 from dataclasses import dataclass
 from typing import NamedTuple
 
 from . import telemetry
+
+# Per-step CSV dump for ad-hoc profiling. Bypasses OTLP. Enabled by setting
+# PIE_LATENCY_LOG=1 in the engine environment; output path overrideable via
+# PIE_LATENCY_LOG_PATH (default /tmp/pie-latency.csv). One CSV row per step;
+# columns documented in the header. Used for axis-L overhead investigation
+# (#68085 Path 1).
+_LATENCY_CSV_LOCK = threading.Lock()
+_LATENCY_CSV_FH = None
+_LATENCY_CSV_HEADER_WRITTEN = False
+
+
+def _maybe_open_csv():
+    global _LATENCY_CSV_FH, _LATENCY_CSV_HEADER_WRITTEN
+    if not os.environ.get("PIE_LATENCY_LOG"):
+        return None
+    if _LATENCY_CSV_FH is None:
+        path = os.environ.get("PIE_LATENCY_LOG_PATH", "/tmp/pie-latency.csv")
+        _LATENCY_CSV_FH = open(path, "a", buffering=1)
+        if not _LATENCY_CSV_HEADER_WRITTEN:
+            _LATENCY_CSV_FH.write(
+                "step,total_ms,build_batch_ms,get_inputs_ms,get_sampling_meta_ms,"
+                "broadcast_ms,inference_ms,create_responses_ms,"
+                "decode_u32_ms,mask_loop_ms,brle_decode_ms,sampler_loop_ms\n"
+            )
+            _LATENCY_CSV_HEADER_WRITTEN = True
+    return _LATENCY_CSV_FH
 
 
 class StepTiming(NamedTuple):
@@ -45,6 +73,24 @@ class LatencyStats:
             traceparent: Optional W3C traceparent string for cross-language propagation.
         """
         self.step_count += 1
+
+        fh = _maybe_open_csv()
+        if fh is not None:
+            with _LATENCY_CSV_LOCK:
+                fh.write(
+                    f"{self.step_count},"
+                    f"{timing.total*1000:.3f},"
+                    f"{timing.build_batch*1000:.3f},"
+                    f"{timing.get_inputs*1000:.3f},"
+                    f"{timing.get_sampling_meta*1000:.3f},"
+                    f"{timing.broadcast*1000:.3f},"
+                    f"{timing.inference*1000:.3f},"
+                    f"{timing.create_responses*1000:.3f},"
+                    f"{timing.decode_u32*1000:.3f},"
+                    f"{timing.mask_loop*1000:.3f},"
+                    f"{timing.brle_decode*1000:.3f},"
+                    f"{timing.sampler_loop*1000:.3f}\n"
+                )
 
         if not self.enabled:
             return

--- a/pie/src/pie_driver/latency.py
+++ b/pie/src/pie_driver/latency.py
@@ -30,7 +30,9 @@ def _maybe_open_csv():
             _LATENCY_CSV_FH.write(
                 "step,total_ms,build_batch_ms,get_inputs_ms,get_sampling_meta_ms,"
                 "broadcast_ms,inference_ms,create_responses_ms,"
-                "decode_u32_ms,mask_loop_ms,brle_decode_ms,sampler_loop_ms\n"
+                "decode_u32_ms,mask_loop_ms,brle_decode_ms,sampler_loop_ms,"
+                "embed_gpu_ms,transform_gpu_ms,sample_gpu_ms,"
+                "batch_total_tokens,batch_num_seqs\n"
             )
             _LATENCY_CSV_HEADER_WRITTEN = True
     return _LATENCY_CSV_FH
@@ -52,6 +54,16 @@ class StepTiming(NamedTuple):
     mask_loop: float
     brle_decode: float
     sampler_loop: float
+    # engine.fire_batch GPU sub-stages (cuda.Event elapsed_time, in seconds for
+    # consistency with other fields; multiplied by 1e-3 in worker.py before
+    # passing in). Zero when profiling is disabled.
+    embed_gpu: float = 0.0
+    transform_gpu: float = 0.0
+    sample_gpu: float = 0.0
+    # Batch shape probe — directly correlates per-step latency with batch
+    # tokens (sum of new tokens) and request count.
+    batch_total_tokens: int = 0
+    batch_num_seqs: int = 0
 
 
 @dataclass
@@ -89,7 +101,12 @@ class LatencyStats:
                     f"{timing.decode_u32*1000:.3f},"
                     f"{timing.mask_loop*1000:.3f},"
                     f"{timing.brle_decode*1000:.3f},"
-                    f"{timing.sampler_loop*1000:.3f}\n"
+                    f"{timing.sampler_loop*1000:.3f},"
+                    f"{timing.embed_gpu*1000:.3f},"
+                    f"{timing.transform_gpu*1000:.3f},"
+                    f"{timing.sample_gpu*1000:.3f},"
+                    f"{timing.batch_total_tokens},"
+                    f"{timing.batch_num_seqs}\n"
                 )
 
         if not self.enabled:
@@ -112,5 +129,10 @@ class LatencyStats:
             broadcast_ms=timing.broadcast * 1000,
             inference_ms=timing.inference * 1000,
             create_responses_ms=timing.create_responses * 1000,
+            embed_gpu_ms=timing.embed_gpu * 1000,
+            transform_gpu_ms=timing.transform_gpu * 1000,
+            sample_gpu_ms=timing.sample_gpu * 1000,
+            batch_total_tokens=timing.batch_total_tokens,
+            batch_num_seqs=timing.batch_num_seqs,
         ) as span:
             pass  # span is closed automatically

--- a/pie/src/pie_driver/shmem_ipc.py
+++ b/pie/src/pie_driver/shmem_ipc.py
@@ -47,6 +47,13 @@ DEFAULT_SLOT_STRIDE = SLOT_HEADER_SIZE + DEFAULT_REQ_BUF + DEFAULT_RESP_BUF
 
 METHOD_TAG_FIRE_BATCH = 0
 METHOD_TAG_COPY_D2D = 1
+# h2d / d2h via shmem fast path. Mirrors METHOD_TAG_COPY_H2D /
+# METHOD_TAG_COPY_D2H in runtime/src/shmem_ipc.rs. Routes the
+# eviction/restore copies through the same Python thread that
+# dispatches fire_batch so CUDA stream FIFO orders the kernels.
+# See `project_pie_second_bleed_path_h2d_race.md`.
+METHOD_TAG_COPY_H2D = 2
+METHOD_TAG_COPY_D2H = 3
 METHOD_TAG_NONE = 255
 
 _librt = ctypes.CDLL("librt.so.1", use_errno=True)

--- a/pie/src/pie_driver/worker.py
+++ b/pie/src/pie_driver/worker.py
@@ -801,9 +801,6 @@ def _leader_loop(
         dst = _torch.tensor(dst_ids, dtype=_torch.long, device=gpu_kv[0].device)
         for layer_idx in range(len(gpu_kv)):
             gpu_kv[layer_idx].index_copy_(0, dst, gpu_kv[layer_idx][src])
-        # No torch.cuda.synchronize() — we rely on stream FIFO. Any
-        # subsequent fire_batch dispatched on this same thread
-        # enqueues onto the same default stream AFTER our kernels.
 
     def _handle_copy_h2d_shmem(view: memoryview) -> None:
         """Handle a METHOD_TAG_COPY_H2D shmem request.
@@ -848,8 +845,6 @@ def _leader_loop(
             gpu_kv[layer_idx].index_copy_(
                 0, dst, host_kv[layer_idx][src].to(gpu_kv[layer_idx].device)
             )
-        # No torch.cuda.synchronize() — single-threaded shmem
-        # dispatch + legacy default stream FIFO is sufficient.
 
     def _handle_copy_d2h_shmem(view: memoryview) -> None:
         """Handle a METHOD_TAG_COPY_D2H shmem request.

--- a/pie/src/pie_driver/worker.py
+++ b/pie/src/pie_driver/worker.py
@@ -565,13 +565,44 @@ def _leader_loop(
             if dist.get_world_size(group=compute_pg) > 1:
                 dist.barrier(group=compute_pg)
 
+        # Only enable GPU sub-stage profiling when the latency CSV is
+        # active — cuda.Events + elapsed_time force a sync that costs ~tens
+        # of microseconds per step, fine for profiling but unwanted on the
+        # hot path.
+        import os as _os
+        gpu_timings: dict | None = (
+            {} if _os.environ.get("PIE_LATENCY_LOG") else None
+        )
+
         t0 = time.perf_counter()
-        sampling_results = engine.fire_batch(inputs, sampling_metadata)
+        # Only pass gpu_timings when profiling is on; pie_driver_sgl /
+        # pie_driver base don't accept the kwarg, so unconditional pass
+        # would break them.
+        if gpu_timings is not None:
+            sampling_results = engine.fire_batch(
+                inputs, sampling_metadata, gpu_timings=gpu_timings
+            )
+        else:
+            sampling_results = engine.fire_batch(inputs, sampling_metadata)
         t_inference = time.perf_counter() - t0
 
         if batch.has_speculative_inputs:
             batch.verify_drafts(sampling_results)
         _populate_next_drafts(batch, sampling_results, engine)
+
+        # Batch shape — sum of new tokens this step + number of requests.
+        # `qo_indptr[-1]` is the running cumulative sum of new tokens
+        # across requests; `len(qo_indptr) - 1` is the request count.
+        batch_total_tokens = 0
+        batch_num_seqs = 0
+        if gpu_timings is not None:
+            try:
+                qo = inputs.get("qo_indptr")
+                if qo is not None:
+                    batch_total_tokens = int(qo[-1].item())
+                    batch_num_seqs = int(qo.shape[0]) - 1
+            except Exception:
+                pass
 
         timings = {
             "t_start": t_start,
@@ -582,10 +613,14 @@ def _leader_loop(
             "inference": t_inference,
             "build_timing": build_timing,
             "traceparent": kwargs.get("trace_context"),
+            "gpu_timings": gpu_timings,
+            "batch_total_tokens": batch_total_tokens,
+            "batch_num_seqs": batch_num_seqs,
         }
         return sampling_results, batch, timings
 
     def _record_step_timing(timings, t_create_responses):
+        gpu = timings.get("gpu_timings") or {}
         latency_stats.record_span(
             StepTiming(
                 build_batch=timings["build_batch"],
@@ -599,6 +634,12 @@ def _leader_loop(
                 mask_loop=timings["build_timing"]["mask_loop"],
                 brle_decode=timings["build_timing"]["brle_decode"],
                 sampler_loop=timings["build_timing"]["sampler_loop"],
+                # cuda.Event elapsed_time returns ms; StepTiming is in s.
+                embed_gpu=gpu.get("embed_ms", 0.0) / 1000.0,
+                transform_gpu=gpu.get("transform_ms", 0.0) / 1000.0,
+                sample_gpu=gpu.get("sample_ms", 0.0) / 1000.0,
+                batch_total_tokens=int(timings.get("batch_total_tokens", 0)),
+                batch_num_seqs=int(timings.get("batch_num_seqs", 0)),
             ),
             traceparent=timings["traceparent"],
         )

--- a/pie/src/pie_driver/worker.py
+++ b/pie/src/pie_driver/worker.py
@@ -805,6 +805,89 @@ def _leader_loop(
         # subsequent fire_batch dispatched on this same thread
         # enqueues onto the same default stream AFTER our kernels.
 
+    def _handle_copy_h2d_shmem(view: memoryview) -> None:
+        """Handle a METHOD_TAG_COPY_H2D shmem request.
+
+        Wire format (matches `device::copy_h2d_shmem` on the Rust
+        side, little-endian):
+            u32 src_count | src_count × u32 cpu_slot_ids
+            u32 dst_count | dst_count × u32 gpu_phys_ids
+
+        Routing this through the same thread as `fire_batch` is what
+        closes the second-bleed race documented in
+        `project_pie_second_bleed_path_h2d_race.md`: under axis-L
+        L=6K c=16 pin-on, restore()'s copy_h2d previously ran on the
+        cold-path RPC main thread while replay fire_batch ran on the
+        shmem busy-poll thread; submission order on the legacy
+        default stream depended on Python thread scheduling, so a
+        replay could land before its preceding h2d and read the
+        previous owner's KV. Single-threaded shmem dispatch fixes it.
+        """
+        import struct
+        import torch as _torch
+        gpu_kv = engine.kv_cache_at_layer
+        host_kv = engine.kv_cache_at_layer_host
+        b = bytes(view)
+        off = 0
+        (src_n,) = struct.unpack_from("<I", b, off); off += 4
+        src_ids = list(struct.unpack_from(f"<{src_n}I", b, off)); off += src_n * 4
+        (dst_n,) = struct.unpack_from("<I", b, off); off += 4
+        dst_ids = list(struct.unpack_from(f"<{dst_n}I", b, off))
+        max_gpu = gpu_kv[0].shape[0]
+        max_cpu = host_kv[0].shape[0] if host_kv else 0
+        # src_ids = CPU slot ids; dst_ids = GPU phys ids.
+        for s in src_ids:
+            if s < 0 or s >= max_cpu:
+                raise ValueError(f"copy_h2d_shmem: CPU slot {s} out of bounds [0, {max_cpu})")
+        for p in dst_ids:
+            if p < 0 or p >= max_gpu:
+                raise ValueError(f"copy_h2d_shmem: GPU phys_id {p} out of bounds [0, {max_gpu})")
+        dst = _torch.tensor(dst_ids, dtype=_torch.long, device=gpu_kv[0].device)
+        src = _torch.tensor(src_ids, dtype=_torch.long)  # CPU
+        for layer_idx in range(len(gpu_kv)):
+            gpu_kv[layer_idx].index_copy_(
+                0, dst, host_kv[layer_idx][src].to(gpu_kv[layer_idx].device)
+            )
+        # No torch.cuda.synchronize() — single-threaded shmem
+        # dispatch + legacy default stream FIFO is sufficient.
+
+    def _handle_copy_d2h_shmem(view: memoryview) -> None:
+        """Handle a METHOD_TAG_COPY_D2H shmem request.
+
+        Wire format (matches `device::copy_d2h_shmem` on the Rust
+        side, little-endian):
+            u32 src_count | src_count × u32 gpu_phys_ids
+            u32 dst_count | dst_count × u32 cpu_slot_ids
+
+        Companion to `_handle_copy_h2d_shmem` — same single-threaded
+        dispatch guarantee against `fire_batch`. Used by `suspend()`.
+        """
+        import struct
+        import torch as _torch
+        gpu_kv = engine.kv_cache_at_layer
+        host_kv = engine.kv_cache_at_layer_host
+        b = bytes(view)
+        off = 0
+        (src_n,) = struct.unpack_from("<I", b, off); off += 4
+        src_ids = list(struct.unpack_from(f"<{src_n}I", b, off)); off += src_n * 4
+        (dst_n,) = struct.unpack_from("<I", b, off); off += 4
+        dst_ids = list(struct.unpack_from(f"<{dst_n}I", b, off))
+        max_gpu = gpu_kv[0].shape[0]
+        max_cpu = host_kv[0].shape[0] if host_kv else 0
+        # src_ids = GPU phys ids; dst_ids = CPU slot ids.
+        for p in src_ids:
+            if p < 0 or p >= max_gpu:
+                raise ValueError(f"copy_d2h_shmem: GPU phys_id {p} out of bounds [0, {max_gpu})")
+        for s in dst_ids:
+            if s < 0 or s >= max_cpu:
+                raise ValueError(f"copy_d2h_shmem: CPU slot {s} out of bounds [0, {max_cpu})")
+        src = _torch.tensor(src_ids, dtype=_torch.long, device=gpu_kv[0].device)
+        dst = _torch.tensor(dst_ids, dtype=_torch.long)  # CPU
+        for layer_idx in range(len(gpu_kv)):
+            host_kv[layer_idx].index_copy_(
+                0, dst, gpu_kv[layer_idx][src].cpu()
+            )
+
     def _shmem_loop():
         while not stop_event.is_set():
             req = _shmem_server.busy_poll_any_slot(SHMEM_BUSY_US)
@@ -823,6 +906,26 @@ def _leader_loop(
                 except Exception as e:
                     import traceback
                     print(f"[Shmem Worker Error] copy_d2d: {e}\n{traceback.format_exc()}")
+                    _shmem_server.respond(slot, msgpack.packb(str(e)), 0)
+                continue
+
+            if method_tag == _shm.METHOD_TAG_COPY_H2D:
+                try:
+                    _handle_copy_h2d_shmem(memoryview(view))
+                    _shmem_server.respond(slot, msgpack.packb(None), 0)
+                except Exception as e:
+                    import traceback
+                    print(f"[Shmem Worker Error] copy_h2d: {e}\n{traceback.format_exc()}")
+                    _shmem_server.respond(slot, msgpack.packb(str(e)), 0)
+                continue
+
+            if method_tag == _shm.METHOD_TAG_COPY_D2H:
+                try:
+                    _handle_copy_d2h_shmem(memoryview(view))
+                    _shmem_server.respond(slot, msgpack.packb(None), 0)
+                except Exception as e:
+                    import traceback
+                    print(f"[Shmem Worker Error] copy_d2h: {e}\n{traceback.format_exc()}")
                     _shmem_server.respond(slot, msgpack.packb(str(e)), 0)
                 continue
 

--- a/pie/src/pie_driver_vllm/engine.py
+++ b/pie/src/pie_driver_vllm/engine.py
@@ -282,12 +282,44 @@ class VllmEngine:
         )
 
     @torch.inference_mode()
-    def fire_batch(self, inputs: dict, sampling_metadata: dict) -> list:
+    def fire_batch(
+        self,
+        inputs: dict,
+        sampling_metadata: dict,
+        gpu_timings: dict | None = None,
+    ) -> list:
         # This driver runs causal-only attention; user-supplied masks are
         # silently dropped. The capability is advertised via
         # DriverCapabilities so the runtime can route mask-dependent
         # inferlets elsewhere (currently only `native`).
+        #
+        # When `gpu_timings` is provided, we record cuda.Event markers
+        # around embed/transform/sample to break apart the GPU-side cost
+        # of each stage. Reading elapsed_time forces a single sync at the
+        # end (already implicit in the inferlet's host-side .tolist() of
+        # sampler outputs), so the events themselves do not stall the
+        # pipeline. Used by #68085 Phase 44 to localize prefill vs decode
+        # overhead at sub-stage granularity.
+        # Sync-then-time approach: torch.cuda.synchronize() drains all kernels
+        # on every CUDA stream, then perf_counter captures wall — the
+        # difference between two adjacent syncs IS the GPU time of the
+        # intervening stage. cuda.Events on default stream were unreliable
+        # here (vllm/inductor uses dedicated streams; events recorded on
+        # default stream don't capture compiled-graph kernels and can also
+        # interfere with pie's snapshot.fork() copy_d2d on a separate
+        # thread, producing the qo_indptr CUDA assert seen on H100). This
+        # is heavier (4× sync per fire_batch) but reliable. Only enabled
+        # when gpu_timings is requested, so the hot path is unaffected.
+        if gpu_timings is not None:
+            torch.cuda.synchronize()
+            import time as _time
+            t0 = _time.perf_counter()
+
         input_embeds = self.forward_pass.embed_inputs(inputs)
+
+        if gpu_timings is not None:
+            torch.cuda.synchronize()
+            t1 = _time.perf_counter()
 
         hidden_states = self.forward_pass.transform(
             input_embeds=input_embeds,
@@ -298,7 +330,20 @@ class VllmEngine:
             kv_last_page_lens=inputs["kv_last_page_lens"],
         )
 
-        return self.forward_pass.sample(hidden_states, sampling_metadata)
+        if gpu_timings is not None:
+            torch.cuda.synchronize()
+            t2 = _time.perf_counter()
+
+        out = self.forward_pass.sample(hidden_states, sampling_metadata)
+
+        if gpu_timings is not None:
+            torch.cuda.synchronize()
+            t3 = _time.perf_counter()
+            gpu_timings["embed_ms"] = (t1 - t0) * 1000.0
+            gpu_timings["transform_ms"] = (t2 - t1) * 1000.0
+            gpu_timings["sample_ms"] = (t3 - t2) * 1000.0
+
+        return out
 
     # ------------------------------------------------------------------
     # Speculative decoding: NGRAM drafter

--- a/runtime/src/context/restore.rs
+++ b/runtime/src/context/restore.rs
@@ -102,8 +102,9 @@ impl ContextManager {
                 .ok_or_else(|| anyhow::anyhow!("No free GPU pages for working re-alloc"))?;
 
             if !cpu_working_pages.is_empty() && cpu_working_pages.len() == working_count {
-                // H2D copy from CPU stash.
-                let _ = device::copy_h2d(dev_idx as DeviceId, &gpu_pages, &cpu_working_pages);
+                if let Err(e) = device::copy_h2d_shmem(dev_idx as DeviceId, &gpu_pages, &cpu_working_pages) {
+                    tracing::error!("copy_h2d_shmem (working restore) failed: {}", e);
+                }
                 self.cpu_stores[dev_idx].free(&cpu_working_pages);
             }
 
@@ -143,7 +144,9 @@ impl ContextManager {
                 let gpu_pages = self.gpu_stores[dev_idx].alloc(cpu_prefix)
                     .ok_or_else(|| anyhow::anyhow!("No GPU pages for CPU-cache restore"))?;
 
-                let _ = device::copy_h2d(dev_idx as DeviceId, &gpu_pages, &cpu_phys);
+                if let Err(e) = device::copy_h2d_shmem(dev_idx as DeviceId, &gpu_pages, &cpu_phys) {
+                    tracing::error!("copy_h2d_shmem (suffix restore) failed: {}", e);
+                }
 
                 // Register in GPU trie.
                 let prefix = &committed_hashes[..prefix_len];

--- a/runtime/src/context/restore.rs
+++ b/runtime/src/context/restore.rs
@@ -102,9 +102,7 @@ impl ContextManager {
                 .ok_or_else(|| anyhow::anyhow!("No free GPU pages for working re-alloc"))?;
 
             if !cpu_working_pages.is_empty() && cpu_working_pages.len() == working_count {
-                if let Err(e) = device::copy_h2d_shmem(dev_idx as DeviceId, &gpu_pages, &cpu_working_pages) {
-                    tracing::error!("copy_h2d_shmem (working restore) failed: {}", e);
-                }
+                let _ = device::copy_h2d(dev_idx as DeviceId, &gpu_pages, &cpu_working_pages);
                 self.cpu_stores[dev_idx].free(&cpu_working_pages);
             }
 
@@ -144,9 +142,7 @@ impl ContextManager {
                 let gpu_pages = self.gpu_stores[dev_idx].alloc(cpu_prefix)
                     .ok_or_else(|| anyhow::anyhow!("No GPU pages for CPU-cache restore"))?;
 
-                if let Err(e) = device::copy_h2d_shmem(dev_idx as DeviceId, &gpu_pages, &cpu_phys) {
-                    tracing::error!("copy_h2d_shmem (suffix restore) failed: {}", e);
-                }
+                let _ = device::copy_h2d(dev_idx as DeviceId, &gpu_pages, &cpu_phys);
 
                 // Register in GPU trie.
                 let prefix = &committed_hashes[..prefix_len];

--- a/runtime/src/context/sched.rs
+++ b/runtime/src/context/sched.rs
@@ -903,9 +903,7 @@ impl ContextManager {
 
             if cpu_offload {
                 if let Some(cpu_pages) = self.cpu_stores[dev_idx].alloc(working.len()) {
-                    if let Err(e) = device::copy_d2h_shmem(dev_idx as DeviceId, &working, &cpu_pages) {
-                        tracing::error!("copy_d2h_shmem (working stash) failed: {}", e);
-                    }
+                    let _ = device::copy_d2h(dev_idx as DeviceId, &working, &cpu_pages);
                     let ctx = self.contexts.get_mut(&ctx_id).unwrap();
                     ctx.cpu_working_pages = cpu_pages;
                 }
@@ -920,9 +918,7 @@ impl ContextManager {
         if cpu_offload && !evictable_hashes.is_empty() {
             let gpu_phys = self.gpu_stores[dev_idx].physical_ids(&evictable_hashes);
             if let Some(cpu_pages) = self.cpu_stores[dev_idx].alloc(gpu_phys.len()) {
-                if let Err(e) = device::copy_d2h_shmem(dev_idx as DeviceId, &gpu_phys, &cpu_pages) {
-                    tracing::error!("copy_d2h_shmem (evict stash) failed: {}", e);
-                }
+                let _ = device::copy_d2h(dev_idx as DeviceId, &gpu_phys, &cpu_pages);
                 self.cpu_stores[dev_idx].insert(&evictable_hashes, &cpu_pages);
             }
         }

--- a/runtime/src/context/sched.rs
+++ b/runtime/src/context/sched.rs
@@ -903,7 +903,9 @@ impl ContextManager {
 
             if cpu_offload {
                 if let Some(cpu_pages) = self.cpu_stores[dev_idx].alloc(working.len()) {
-                    let _ = device::copy_d2h(dev_idx as DeviceId, &working, &cpu_pages);
+                    if let Err(e) = device::copy_d2h_shmem(dev_idx as DeviceId, &working, &cpu_pages) {
+                        tracing::error!("copy_d2h_shmem (working stash) failed: {}", e);
+                    }
                     let ctx = self.contexts.get_mut(&ctx_id).unwrap();
                     ctx.cpu_working_pages = cpu_pages;
                 }
@@ -918,7 +920,9 @@ impl ContextManager {
         if cpu_offload && !evictable_hashes.is_empty() {
             let gpu_phys = self.gpu_stores[dev_idx].physical_ids(&evictable_hashes);
             if let Some(cpu_pages) = self.cpu_stores[dev_idx].alloc(gpu_phys.len()) {
-                let _ = device::copy_d2h(dev_idx as DeviceId, &gpu_phys, &cpu_pages);
+                if let Err(e) = device::copy_d2h_shmem(dev_idx as DeviceId, &gpu_phys, &cpu_pages) {
+                    tracing::error!("copy_d2h_shmem (evict stash) failed: {}", e);
+                }
                 self.cpu_stores[dev_idx].insert(&evictable_hashes, &cpu_pages);
             }
         }

--- a/runtime/src/device.rs
+++ b/runtime/src/device.rs
@@ -264,6 +264,152 @@ pub async fn copy_d2d_shmem(
     Ok(())
 }
 
+/// CPU → GPU page copy with explicit completion ack — shmem fast path.
+///
+/// Companion to [`copy_d2d_shmem`]. Routes through the same shmem
+/// transport as `fire_batch` so the h2d kernel and any subsequent
+/// forward-pass kernels are dispatched by the SAME Python thread.
+/// CPU launch order is preserved → CUDA stream FIFO orders the
+/// kernels on GPU. Awaits the worker ack so callers can sequence
+/// `fire_batch` (or further ops) after.
+///
+/// Closes the second-bleed race documented in
+/// `project_pie_second_bleed_path_h2d_race.md`: under sustained pool
+/// overflow (axis-L L=6K c=16, pin-on), `restore()`'s `copy_h2d` was
+/// previously dispatched by the cold-path RPC main thread while
+/// `fire_batch` (and replay forward passes) were dispatched by the
+/// shmem busy-poll thread; submission order on the legacy default
+/// stream depended on Python thread scheduling, so a replay could
+/// land before its preceding h2d and read the previous owner's KV.
+/// Routing h2d through shmem closes the gap.
+///
+/// Wire format matches [`copy_d2d_shmem`] (little-endian):
+///   u32 src_count | src_count × u32 cpu_slot_ids
+///   u32 dst_count | dst_count × u32 gpu_phys_ids
+///
+/// `gpu_phys_ids`: destination GPU physical page IDs.
+/// `cpu_pages`: source CPU swap pool page IDs.
+///
+/// Implemented as `pub fn` (not `async fn`) because the body is
+/// synchronous (uses `block_in_place` over a busy-spin) and the
+/// callers in `restore.rs` / `sched.rs` are sync methods on
+/// `ContextManager` driven from the actor task — no async boundary
+/// needed at the call site.
+pub fn copy_h2d_shmem(
+    device_idx: DeviceId,
+    gpu_phys_ids: &[u32],
+    cpu_pages: &[u32],
+) -> Result<()> {
+    let _ = device_idx; // single-device today; SHMEM_CLIENTS keyed at 0
+    let client = get_or_init_shmem_client(0)?;
+    let req_id = SHMEM_REQ_ID.fetch_add(1, Ordering::Relaxed) as u32;
+    let send_walltime_us = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_micros() as u64)
+        .unwrap_or(0);
+
+    let src = cpu_pages.to_vec();
+    let dst = gpu_phys_ids.to_vec();
+    let (_resp_bytes, _ts) = tokio::task::block_in_place(|| {
+        client.call_with(
+            req_id,
+            crate::shmem_ipc::METHOD_TAG_COPY_H2D,
+            send_walltime_us,
+            |buf| {
+                let needed = 4 + src.len() * 4 + 4 + dst.len() * 4;
+                if buf.len() < needed {
+                    return Err(anyhow!(
+                        "copy_h2d_shmem: req buf too small ({} < {needed})",
+                        buf.len()
+                    ));
+                }
+                let mut off = 0usize;
+                buf[off..off + 4].copy_from_slice(&(src.len() as u32).to_le_bytes());
+                off += 4;
+                for &p in &src {
+                    buf[off..off + 4].copy_from_slice(&p.to_le_bytes());
+                    off += 4;
+                }
+                buf[off..off + 4].copy_from_slice(&(dst.len() as u32).to_le_bytes());
+                off += 4;
+                for &p in &dst {
+                    buf[off..off + 4].copy_from_slice(&p.to_le_bytes());
+                    off += 4;
+                }
+                Ok(off)
+            },
+        )
+    })?;
+    Ok(())
+}
+
+/// GPU → CPU page copy with explicit completion ack — shmem fast path.
+///
+/// Companion to [`copy_h2d_shmem`]. Same single-threaded dispatch
+/// guarantee against `fire_batch`. Used by `suspend()` to stash
+/// working pages and committed-evictable pages to CPU before
+/// `gpu_stores.free()` returns the physical page IDs to the
+/// allocator — without this, a subsequent admission could grab the
+/// same page IDs and a `fire_batch` from the new owner could land on
+/// the stream before this d2h, polluting the suspended context's
+/// CPU stash with the new owner's KV.
+///
+/// Wire format (little-endian):
+///   u32 src_count | src_count × u32 gpu_phys_ids
+///   u32 dst_count | dst_count × u32 cpu_slot_ids
+///
+/// `gpu_phys_ids`: source GPU physical page IDs.
+/// `cpu_pages`: destination CPU swap pool page IDs.
+///
+/// See [`copy_h2d_shmem`] for why this is `pub fn` rather than `async fn`.
+pub fn copy_d2h_shmem(
+    device_idx: DeviceId,
+    gpu_phys_ids: &[u32],
+    cpu_pages: &[u32],
+) -> Result<()> {
+    let _ = device_idx; // single-device today; SHMEM_CLIENTS keyed at 0
+    let client = get_or_init_shmem_client(0)?;
+    let req_id = SHMEM_REQ_ID.fetch_add(1, Ordering::Relaxed) as u32;
+    let send_walltime_us = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_micros() as u64)
+        .unwrap_or(0);
+
+    let src = gpu_phys_ids.to_vec();
+    let dst = cpu_pages.to_vec();
+    let (_resp_bytes, _ts) = tokio::task::block_in_place(|| {
+        client.call_with(
+            req_id,
+            crate::shmem_ipc::METHOD_TAG_COPY_D2H,
+            send_walltime_us,
+            |buf| {
+                let needed = 4 + src.len() * 4 + 4 + dst.len() * 4;
+                if buf.len() < needed {
+                    return Err(anyhow!(
+                        "copy_d2h_shmem: req buf too small ({} < {needed})",
+                        buf.len()
+                    ));
+                }
+                let mut off = 0usize;
+                buf[off..off + 4].copy_from_slice(&(src.len() as u32).to_le_bytes());
+                off += 4;
+                for &p in &src {
+                    buf[off..off + 4].copy_from_slice(&p.to_le_bytes());
+                    off += 4;
+                }
+                buf[off..off + 4].copy_from_slice(&(dst.len() as u32).to_le_bytes());
+                off += 4;
+                for &p in &dst {
+                    buf[off..off + 4].copy_from_slice(&p.to_le_bytes());
+                    off += 4;
+                }
+                Ok(off)
+            },
+        )
+    })?;
+    Ok(())
+}
+
 /// CPU → CPU page copy (fire-and-forget).
 /// `src_slots`: source CPU swap pool page IDs.
 /// `dst_slots`: destination CPU swap pool page IDs.

--- a/runtime/src/shmem_ipc.rs
+++ b/runtime/src/shmem_ipc.rs
@@ -30,6 +30,17 @@ pub const METHOD_TAG_FIRE_BATCH: u32 = 0;
 /// forward-pass kernels — see `project_pie_kv_bleed_d2d_fork_race.md`
 /// and pie-project/pie#339.
 pub const METHOD_TAG_COPY_D2D: u32 = 1;
+/// Routes `copy_h2d` (suspend→restore working-page bring-back, plus
+/// snapshot-restore committed-suffix) through the shmem fast path so
+/// it shares a thread with `fire_batch`. Same race surface as
+/// METHOD_TAG_COPY_D2D but on the eviction/restore code path —
+/// surfaces under sustained pool overflow at axis-L L=6K c=16,
+/// pin-on. See `project_pie_second_bleed_path_h2d_race.md`.
+pub const METHOD_TAG_COPY_H2D: u32 = 2;
+/// Routes `copy_d2h` (suspend's stash-to-CPU) through the shmem fast
+/// path. Companion to METHOD_TAG_COPY_H2D — same single-threaded
+/// dispatch ordering against `fire_batch`.
+pub const METHOD_TAG_COPY_D2H: u32 = 3;
 
 /// Slot header offsets relative to the start of the slot.
 const OFF_REQ_SEQ: usize = 0;


### PR DESCRIPTION
## Summary

Adds optional per-substage GPU profiling around `embed_inputs / transform / sample` inside `engine.fire_batch`, plus a per-step batch-shape probe (`total_tokens`, `num_seqs` from `qo_indptr`). Gated on `PIE_LATENCY_LOG=1`; non-vllm engines unaffected via the optional kwarg pattern.

This is the validation harness for the upcoming Lever 5 (cudagraph capture in deva pie_driver_vllm) — without per-substage timing we can't measure whether cudagraph replay actually engages on decode steps.

### Why sync-then-time, not cuda.Events

First implementation used `torch.cuda.Event(enable_timing=True)` pairs around each substage. On H100 with vllm's torch.compile range (1, 32768) inductor graph, this triggered `torch.AcceleratorError: CUDA error: device-side assert` at downstream `qo_indptr = torch.as_tensor(...)` on the first c=16 prefill batch. Hypothesis: events on default stream don't capture kernels launched on vllm's dedicated streams, AND the records appeared to interfere with pie's `Snapshot.fork()` `copy_d2d` issued from the main thread while fire_batch ran on the shmem thread.

Sync-then-time (`torch.cuda.synchronize()` + `time.perf_counter()` between stages) is heavier (4 sync calls per fire_batch) but stream-ordering safe. Sync overhead is microseconds vs ms-to-second per-step GPU times — measurement noise floor unchanged.

### Result (independent of #100)

Phase 44 measurements on H100 80GB SXM with this instrumentation:
- pie pin=on L=128 c=16 max_tokens=200: 5.93s wall vs vllm-apc 4.96s = 1.20×
- pie pin=on L=2K c=16 max_tokens=32: 19.66s wall vs vllm-apc 15.12s = 1.30×
- **`inference_overhead_ms = inference_ms − sum(embed+transform+sample) = 0.07 ms mean`** on both cells. Python orchestration is < 1% of wall.
- The 1.20-1.30× pie/vllm-apc gap is **entirely GPU kernel-launch + selection cost**.

This drops the "deva refactor added Python-frontend overhead" hypothesis as a contributor.

## Files

- `pie/src/pie_driver/latency.py`: extend `StepTiming` with 5 fields (embed_gpu, transform_gpu, sample_gpu, batch_total_tokens, batch_num_seqs); CSV header + writer + OTLP attrs updated.
- `pie/src/pie_driver/worker.py`: pass `gpu_timings` dict to `engine.fire_batch` when `PIE_LATENCY_LOG` is set; capture batch shape from `qo_indptr`. Falls back to 2-arg call so non-vllm engines aren't broken.
- `pie/src/pie_driver_vllm/engine.py`: optional `gpu_timings` arg records sync-then-time around embed / transform / sample.

## Test plan

- [x] Verified syntax via `python3 -c "import ast; ast.parse(...)"` on all 3 files.
- [x] E2E on H100 80GB SXM pod: PIE_LATENCY_LOG=1 produces CSV with all 17 columns; values consistent across 3 passes (Pass 1 step-1 transform=1140ms; Pass 3 partial-pre-crash also 1140ms — exact replication).
- [x] Non-profiling path verified: with PIE_LATENCY_LOG unset, `gpu_timings=None` and original behavior preserved (no extra synchronize).
- [ ] Reviewers please verify against pie_driver_sgl + pie_driver native — patches should be transparent there since `_run_fire_batch_inner` only passes `gpu_timings` kwarg when env var is set.

## Test plan output

H100 80GB pod (terminated post-run): pie pin=on / decode-heavy run-1 CSV (45 rows) shows median total_ms=36.86, transform_gpu_ms=34.72, sample_gpu_ms=1.43 — substage breakdown is sensible and matches the 80-layer Qwen2.5-72B-AWQ forward at c≈4 average batching.

Lever 5 (cudagraph capture, decode-side) will land in a follow-up PR.