### PR TITLE
pie_driver_vllm: FULL_DECODE_ONLY cudagraph capture (decode-side, follows #347)

### DIFF
--- a/pie/src/pie_driver_vllm/_vllm_compat.py
+++ b/pie/src/pie_driver_vllm/_vllm_compat.py
@@ -24,13 +24,21 @@ from __future__ import annotations
 # Engine / config surface
 # ----------------------------------------------------------------------------
 
-from vllm.config import set_current_vllm_config
+from vllm.config import CUDAGraphMode, set_current_vllm_config
 from vllm.engine.arg_utils import EngineArgs
-from vllm.forward_context import get_forward_context, set_forward_context
+from vllm.forward_context import (
+    BatchDescriptor,
+    get_forward_context,
+    set_forward_context,
+)
 from vllm.distributed import (
     ensure_model_parallel_initialized,
     init_distributed_environment,
 )
+from vllm.distributed.parallel_state import graph_capture
+from vllm.compilation.cuda_graph import CUDAGraphWrapper
+from vllm.compilation.monitor import set_cudagraph_capturing_enabled
+from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
 
 
 # ----------------------------------------------------------------------------
@@ -63,7 +71,11 @@ def get_flashinfer_impl():
 
 __all__ = [
     "AttentionLayerBase",
+    "BatchDescriptor",
+    "CUDAGraphMode",
+    "CUDAGraphWrapper",
     "CommonAttentionMetadata",
+    "CudagraphDispatcher",
     "EngineArgs",
     "bind_kv_cache",
     "ensure_model_parallel_initialized",
@@ -72,7 +84,9 @@ __all__ = [
     "get_flashinfer_impl",
     "get_forward_context",
     "get_model_loader",
+    "graph_capture",
     "init_distributed_environment",
+    "set_cudagraph_capturing_enabled",
     "set_current_vllm_config",
     "set_forward_context",
 ]

--- a/pie/src/pie_driver_vllm/engine.py
+++ b/pie/src/pie_driver_vllm/engine.py
@@ -376,6 +376,10 @@ class VllmEngine:
         self.forward_pass._cg_positions_buf = torch.empty(
             (max_size,), dtype=torch.int64, device=device
         )
+        # int64 to match `build_common_metadata`'s slot_mapping dtype.
+        self.forward_pass._cg_slot_mapping_buf = torch.empty(
+            (max_size,), dtype=torch.int64, device=device
+        )
         self.forward_pass._cg_query_len = query_len
 
         # Wrap the model. vllm's CUDAGraphWrapper.__call__ checks

--- a/pie/src/pie_driver_vllm/engine.py
+++ b/pie/src/pie_driver_vllm/engine.py
@@ -495,10 +495,11 @@ class VllmEngine:
         }
 
         embeds = self.forward_pass.embed_inputs(inputs)
-        # transform() will see a uniform-decode batch (all qo diffs =
-        # query_len) and the dispatcher will return FULL with a descriptor
-        # for size `n`. CUDAGraphWrapper captures on first call per
-        # descriptor.
+        # transform() will see a synthetic uniform-decode batch and the
+        # dispatcher will return FULL with a descriptor for size `n`.
+        # CUDAGraphWrapper captures on first call per descriptor. We force
+        # single_token_mode=True so the dispatch gate fires (the runtime
+        # would normally have set it on a real decode batch).
         _ = self.forward_pass.transform(
             input_embeds=embeds,
             position_ids=position_ids,
@@ -506,6 +507,7 @@ class VllmEngine:
             kv_page_indices=kv_page_indices,
             kv_page_indptr=kv_page_indptr,
             kv_last_page_lens=kv_last_page_lens,
+            single_token_mode=True,
         )
 
     @torch.inference_mode()
@@ -555,6 +557,7 @@ class VllmEngine:
             kv_page_indices=inputs["kv_page_indices"],
             kv_page_indptr=inputs["kv_page_indptr"],
             kv_last_page_lens=inputs["kv_last_page_lens"],
+            single_token_mode=inputs.get("single_token_inference_mode", False),
         )
 
         if gpu_timings is not None:

--- a/pie/src/pie_driver_vllm/engine.py
+++ b/pie/src/pie_driver_vllm/engine.py
@@ -155,6 +155,22 @@ class VllmEngine:
             print(f"[vllm warmup] FAILED: {_e}\n{_tb.format_exc()}", flush=True)
             raise
 
+        # Lever 5 (ticket #100): wrap the model with vllm's FULL-mode
+        # CUDAGraphWrapper and run synthetic decode passes so each
+        # `cudagraph_capture_sizes` shape gets its captured graph. After
+        # this returns, transform() can dispatch decode batches through
+        # the captured graphs by threading the runtime mode + descriptor
+        # through set_forward_context.
+        try:
+            engine._capture_cudagraphs(_log)
+        except Exception as _e:
+            import traceback as _tb
+            print(
+                f"[vllm cudagraph] FAILED: {_e}\n{_tb.format_exc()}",
+                flush=True,
+            )
+            raise
+
         return engine
 
     @torch.inference_mode()
@@ -279,6 +295,213 @@ class VllmEngine:
             f"vllm engine warmup: prefill ({n_prefill} tok) {t_prefill:.2f}s, "
             f"decode (1 tok) {t_decode:.2f}s",
             "INFO",
+        )
+
+    @torch.inference_mode()
+    def _capture_cudagraphs(self, log_fn=None) -> None:
+        """Capture FULL-mode cudagraphs for decode batches (Lever 5).
+
+        Mirrors vllm's `GPUModelRunner.capture_model` for the slice we need:
+        wrap the model in `CUDAGraphWrapper(runtime_mode=FULL)`, build a
+        `CudagraphDispatcher` so we know the set of capture sizes, allocate
+        persistent input buffers in `forward_pass`, and run one synthetic
+        forward per `BatchDescriptor` inside `graph_capture(...)` with the
+        runtime mode threaded through forward context. After this returns,
+        transform() can dispatch decode batches into the captured graphs.
+
+        Skipped (no-op) when:
+          - device is not CUDA;
+          - cudagraph_mode is NONE (eager mode requested by user);
+          - FlashInfer / attention backend reports no cudagraph support.
+        """
+        import time as _time
+
+        from ._vllm_compat import (
+            CUDAGraphMode,
+            CUDAGraphWrapper,
+            CudagraphDispatcher,
+            graph_capture,
+            set_cudagraph_capturing_enabled,
+            set_current_vllm_config,
+            set_forward_context,
+        )
+
+        device = self.forward_pass.device
+
+        def _log(msg: str, level: str = "INFO") -> None:
+            print(f"[vllm cudagraph] {msg}", flush=True)
+            if log_fn is not None:
+                log_fn(msg, level)
+
+        if not torch.cuda.is_available() or not str(device).startswith("cuda"):
+            _log(f"skipped (device={device})", "INFO")
+            return
+
+        vllm_config = self.forward_pass.vllm_config
+        cc = vllm_config.compilation_config
+        cg_mode = cc.cudagraph_mode
+
+        if cg_mode == CUDAGraphMode.NONE:
+            _log("skipped (cudagraph_mode=NONE)", "INFO")
+            return
+
+        # Pie does not own a vllm GPUModelRunner, so the cudagraph_capture_sizes
+        # list may not have been populated by vllm's own resolution. Guard
+        # for that and bail out cleanly — transform() will then fall back
+        # to the eager path on every batch.
+        if not cc.cudagraph_capture_sizes or cc.max_cudagraph_capture_size is None:
+            _log(
+                "skipped (no cudagraph_capture_sizes resolved by vllm)", "WARN"
+            )
+            return
+
+        # Drain any kernels still queued by warmup before switching streams.
+        # `graph_capture()` enters a separate CUDA stream; capture must not
+        # observe in-flight default-stream work.
+        torch.cuda.synchronize()
+
+        spec_cfg = vllm_config.speculative_config
+        query_len = 1 if spec_cfg is None else 1 + spec_cfg.num_speculative_tokens
+
+        # Allocate persistent input buffers sized to the largest captured
+        # batch. inputs_embeds dim comes from the first warmup forward
+        # (decode_hidden in _warmup_compile would also work, but we read
+        # straight off the model config to avoid coupling).
+        max_size = int(cc.max_cudagraph_capture_size)
+        hidden_size = int(self.model_config.get_hidden_size())
+        embed_dtype = self.config.activation_dtype
+        self.forward_pass._cg_inputs_embeds_buf = torch.empty(
+            (max_size, hidden_size), dtype=embed_dtype, device=device
+        )
+        self.forward_pass._cg_positions_buf = torch.empty(
+            (max_size,), dtype=torch.int64, device=device
+        )
+        self.forward_pass._cg_query_len = query_len
+
+        # Wrap the model. vllm's CUDAGraphWrapper.__call__ checks
+        # forward_context for cudagraph_runtime_mode/batch_descriptor and
+        # captures (first call per descriptor) or replays (subsequent).
+        # Pass-through if mode does not match (e.g. prefill batches).
+        wrapped = CUDAGraphWrapper(
+            self.forward_pass.model,
+            vllm_config,
+            runtime_mode=CUDAGraphMode.FULL,
+        )
+        self.forward_pass.model = wrapped
+
+        dispatcher = CudagraphDispatcher(vllm_config)
+        dispatcher.initialize_cudagraph_keys(cg_mode, query_len)
+        # Stash on forward_pass; transform() dispatches via this.
+        self.forward_pass._cg_dispatcher = dispatcher
+
+        capture_descs = dispatcher.get_capture_descs()
+        if not capture_descs:
+            _log("skipped (dispatcher has no capture descs)", "WARN")
+            self.forward_pass._cg_dispatcher = None
+            return
+
+        # Drive synthetic decode forwards through the wrapped model. We
+        # reuse pie's existing transform()/embed_inputs path so any backend
+        # (FlashInfer, FA3, Triton, …) builds its persistent metadata
+        # buffers exactly as it would at runtime. The dispatcher is
+        # already installed on forward_pass, so transform() will route
+        # each call through `set_forward_context(cudagraph_runtime_mode=FULL,
+        # batch_descriptor=desc)` once we feed it a uniform-decode batch.
+        torch.cuda.empty_cache()
+        start_free = torch.cuda.mem_get_info()[0]
+        t0 = _time.perf_counter()
+
+        set_cudagraph_capturing_enabled(True)
+        try:
+            with set_current_vllm_config(vllm_config), graph_capture(device=device):
+                for runtime_mode, batch_descs in capture_descs:
+                    if runtime_mode != CUDAGraphMode.FULL:
+                        # We only install a FULL wrapper; PIECEWISE descs
+                        # would need a separate wrapper / inductor partition
+                        # path, out of scope for ticket #100.
+                        continue
+                    for desc in batch_descs:
+                        n = desc.num_tokens
+                        if n > max_size:
+                            continue
+                        self._capture_one_decode(n, query_len)
+                        torch.cuda.synchronize()
+        finally:
+            set_cudagraph_capturing_enabled(False)
+
+        end_free = torch.cuda.mem_get_info()[0]
+        elapsed = _time.perf_counter() - t0
+        graph_bytes = max(0, start_free - end_free)
+        _log(
+            f"captured FULL graphs for {sum(len(d) for _, d in capture_descs)} "
+            f"descriptor(s) in {elapsed:.2f}s "
+            f"({graph_bytes / (1 << 20):.1f} MiB graph memory)",
+            "INFO",
+        )
+
+        # Capture writes K/V into pie's KV layers for pages we used as
+        # scratch (page 0). Zero them so the first real context that gets
+        # allocated those pages doesn't read stale capture activations.
+        for layer_kv in self.kv_cache_at_layer:
+            layer_kv[0].zero_()
+
+    @torch.inference_mode()
+    def _capture_one_decode(self, n: int, query_len: int) -> None:
+        """One synthetic uniform-decode forward at exactly `n` query tokens.
+
+        Triggers FlashInfer to plan the cudagraph-enabled decode wrapper at
+        size `n` (under the `enable_cuda_graph and pure_decode and
+        num_decode_tokens <= max_bs` branch in FlashInferMetadataBuilder.build),
+        and runs the wrapped model so CUDAGraphWrapper captures the forward.
+
+        Layout: `n / query_len` requests, each with `query_len` query tokens
+        attending to a single KV page (page 0, pie's reserved warmup
+        scratch). Position 0 across all requests — chosen for simplicity;
+        FlashInfer's plan() does not validate position values for capture.
+        """
+        device = self.forward_pass.device
+        page_size = int(self.forward_pass._kv_spec.block_size)
+
+        assert n % query_len == 0, (
+            f"capture size {n} must be divisible by query_len {query_len}"
+        )
+        num_reqs = n // query_len
+
+        token_ids = torch.zeros(n, dtype=torch.long)
+        position_ids = torch.zeros(n, dtype=torch.int32, device=device)
+        # uniform decode → qo_indptr step is `query_len` per request.
+        qo_indptr = (
+            torch.arange(num_reqs + 1, dtype=torch.int32, device=device)
+            * query_len
+        )
+        # Each req points at page 0; last_page_len=query_len so seq_len = query_len.
+        kv_page_indices = torch.zeros(num_reqs, dtype=torch.int32, device=device)
+        kv_page_indptr = torch.arange(num_reqs + 1, dtype=torch.int32, device=device)
+        kv_last_page_lens = torch.full(
+            (num_reqs,), max(query_len, 1), dtype=torch.int32, device=device
+        )
+
+        inputs = {
+            "token_ids": token_ids,
+            "position_ids": position_ids,
+            "qo_indptr": qo_indptr,
+            "kv_page_indices": kv_page_indices,
+            "kv_page_indptr": kv_page_indptr,
+            "kv_last_page_lens": kv_last_page_lens,
+        }
+
+        embeds = self.forward_pass.embed_inputs(inputs)
+        # transform() will see a uniform-decode batch (all qo diffs =
+        # query_len) and the dispatcher will return FULL with a descriptor
+        # for size `n`. CUDAGraphWrapper captures on first call per
+        # descriptor.
+        _ = self.forward_pass.transform(
+            input_embeds=embeds,
+            position_ids=position_ids,
+            qo_indptr=qo_indptr,
+            kv_page_indices=kv_page_indices,
+            kv_page_indptr=kv_page_indptr,
+            kv_last_page_lens=kv_last_page_lens,
         )
 
     @torch.inference_mode()

--- a/pie/src/pie_driver_vllm/forward_pass.py
+++ b/pie/src/pie_driver_vllm/forward_pass.py
@@ -70,6 +70,14 @@ class VllmForwardPass:
         # Sized to max_cudagraph_capture_size at capture time.
         self._cg_inputs_embeds_buf: torch.Tensor | None = None
         self._cg_positions_buf: torch.Tensor | None = None
+        # `slot_mapping` indexes the KV cache write target per query token; the
+        # KV-append op reads the tensor directly from forward_context, so it
+        # MUST live at the same data_ptr across capture and replay. (Backend
+        # attention metadata — paged_kv_indptr, kv_indices, block_table — is
+        # routed through the FlashInfer wrapper's plan(), which copies into
+        # FlashInfer's own persistent cudagraph buffers, so those are
+        # transparent to us. slot_mapping has no such wrapper.)
+        self._cg_slot_mapping_buf: torch.Tensor | None = None
         self._cg_query_len = 1  # 1 + num_speculative_tokens; set at capture.
 
     def _ensure_metadata_builder(self) -> None:
@@ -224,6 +232,24 @@ class VllmForwardPass:
         if padded_tokens != num_tokens:
             # Mark padded query tokens as no-write so KV cache stays clean.
             common.slot_mapping[num_tokens:padded_tokens] = -1
+
+        # When replaying a captured graph, the KV-append op (and any other op
+        # that reads slot_mapping out of forward_context) was captured against
+        # the data_ptr() of `common.slot_mapping` at capture time. Per-call
+        # tensors land at fresh addresses, so the captured graph reads stale
+        # / freed memory and silently corrupts KV writes — symptom is
+        # progressively-degenerate decode output (e.g. token "Instructions"
+        # repeated). Substitute the persistent buffer in `common` BEFORE
+        # `builder.build` so any backend that snapshots `common.slot_mapping`
+        # into its own AttentionMetadata struct also picks up the persistent
+        # reference.
+        if cudagraph_runtime_mode != CUDAGraphMode.NONE:
+            assert self._cg_slot_mapping_buf is not None
+            sm_buf = self._cg_slot_mapping_buf
+            sm_buf[:padded_tokens].copy_(
+                common.slot_mapping[:padded_tokens], non_blocking=True
+            )
+            common.slot_mapping = sm_buf[:padded_tokens]
 
         # Backend-specific metadata. `common_prefix_len=0` disables cascade
         # attention (we don't use it from pie's side).

--- a/pie/src/pie_driver_vllm/forward_pass.py
+++ b/pie/src/pie_driver_vllm/forward_pass.py
@@ -56,6 +56,22 @@ class VllmForwardPass:
         self._kv_spec = None
         self._layer_names: list[str] = []
 
+        # Cudagraph dispatch state (Lever 5, ticket #100). Set by
+        # `VllmEngine._capture_cudagraphs()` after capture completes;
+        # `transform()` consults it to thread cudagraph_runtime_mode +
+        # batch_descriptor through set_forward_context. None means the
+        # dispatcher hasn't been initialized — transform falls through to
+        # the eager path.
+        self._cg_dispatcher = None
+        # Persistent inputs_embeds + positions buffers for cudagraph replay.
+        # Captured graphs alias data_ptrs at capture time, so every replay
+        # must read from the same persistent buffers; transform() pads
+        # decode batches up to a captured size and copies inputs in-place.
+        # Sized to max_cudagraph_capture_size at capture time.
+        self._cg_inputs_embeds_buf: torch.Tensor | None = None
+        self._cg_positions_buf: torch.Tensor | None = None
+        self._cg_query_len = 1  # 1 + num_speculative_tokens; set at capture.
+
     def _ensure_metadata_builder(self) -> None:
         """Construct the per-backend AttentionMetadataBuilder once.
 
@@ -110,21 +126,104 @@ class VllmForwardPass:
         kv_page_indptr: torch.Tensor,
         kv_last_page_lens: torch.Tensor,
     ) -> torch.Tensor:
-        """Run the model's transformer trunk inside `set_forward_context`."""
-        from ._vllm_compat import set_forward_context
+        """Run the model's transformer trunk inside `set_forward_context`.
+
+        For Lever 5 cudagraph dispatch (ticket #100): if the dispatcher has
+        been initialized AND the batch is uniform-decode, we route through
+        a captured FULL graph by padding inputs into persistent buffers and
+        threading `cudagraph_runtime_mode` + `batch_descriptor` into
+        set_forward_context. Mixed and prefill batches always run eager.
+        """
+        from ._vllm_compat import (
+            CUDAGraphMode,
+            BatchDescriptor,
+            set_forward_context,
+        )
 
         self._ensure_metadata_builder()
 
         page_size = self._kv_spec.block_size
+        num_tokens = int(input_embeds.shape[0])
+
+        # Decide cudagraph dispatch. Uniform-decode = every request has
+        # exactly `_cg_query_len` query tokens (1 for plain decode,
+        # 1+num_spec_tokens for spec). Cheap host-side check on the small
+        # qo_indptr tensor.
+        cudagraph_runtime_mode = CUDAGraphMode.NONE
+        batch_descriptor: BatchDescriptor | None = None
+        padded_tokens = num_tokens
+        if (
+            self._cg_dispatcher is not None
+            and self._cg_dispatcher.cudagraph_mode != CUDAGraphMode.NONE
+        ):
+            qo_host = qo_indptr.detach().to("cpu", non_blocking=False)
+            diffs = qo_host[1:] - qo_host[:-1]
+            uniform_decode = bool(
+                diffs.numel() > 0
+                and torch.all(diffs == self._cg_query_len).item()
+            )
+            if uniform_decode:
+                cudagraph_runtime_mode, batch_descriptor = (
+                    self._cg_dispatcher.dispatch(
+                        num_tokens=num_tokens,
+                        uniform_decode=True,
+                    )
+                )
+                if cudagraph_runtime_mode != CUDAGraphMode.NONE:
+                    padded_tokens = batch_descriptor.num_tokens
+
+        # Build attention metadata. Pad to `padded_tokens` when replaying so
+        # the captured graph's persistent FlashInfer buffers are populated
+        # to the captured shape. Each pad slot is one dummy decode request
+        # (qlen=1) pointing at page 0 (pie's warmup scratch); the per-layer
+        # slot_mapping is then patched to -1 for those rows so the KV write
+        # kernel skips them and no real cache state is touched.
+        if padded_tokens != num_tokens:
+            pad_reqs = padded_tokens - num_tokens  # one query token per pad
+            qpad = torch.arange(
+                1, pad_reqs + 1, dtype=qo_indptr.dtype, device=qo_indptr.device
+            ) + qo_indptr[-1]
+            qo_indptr_eff = torch.cat([qo_indptr, qpad])
+
+            zeros_pages = torch.zeros(
+                pad_reqs,
+                dtype=kv_page_indices.dtype,
+                device=kv_page_indices.device,
+            )
+            kv_page_indices_eff = torch.cat([kv_page_indices, zeros_pages])
+
+            ppad = torch.arange(
+                1,
+                pad_reqs + 1,
+                dtype=kv_page_indptr.dtype,
+                device=kv_page_indptr.device,
+            ) + kv_page_indptr[-1]
+            kv_page_indptr_eff = torch.cat([kv_page_indptr, ppad])
+
+            ones_pad = torch.ones(
+                pad_reqs,
+                dtype=kv_last_page_lens.dtype,
+                device=kv_last_page_lens.device,
+            )
+            kv_last_page_lens_eff = torch.cat([kv_last_page_lens, ones_pad])
+        else:
+            qo_indptr_eff = qo_indptr
+            kv_page_indices_eff = kv_page_indices
+            kv_page_indptr_eff = kv_page_indptr
+            kv_last_page_lens_eff = kv_last_page_lens
 
         common = build_common_metadata(
-            qo_indptr=qo_indptr,
-            kv_page_indices=kv_page_indices,
-            kv_page_indptr=kv_page_indptr,
-            kv_last_page_lens=kv_last_page_lens,
+            qo_indptr=qo_indptr_eff,
+            kv_page_indices=kv_page_indices_eff,
+            kv_page_indptr=kv_page_indptr_eff,
+            kv_last_page_lens=kv_last_page_lens_eff,
             page_size=page_size,
             device=self.device,
         )
+
+        if padded_tokens != num_tokens:
+            # Mark padded query tokens as no-write so KV cache stays clean.
+            common.slot_mapping[num_tokens:padded_tokens] = -1
 
         # Backend-specific metadata. `common_prefix_len=0` disables cascade
         # attention (we don't use it from pie's side).
@@ -141,17 +240,52 @@ class VllmForwardPass:
         # vllm's RoPE kernel expects int64 positions; pie uses int32.
         positions = position_ids.to(self.device, dtype=torch.int64, non_blocking=True)
 
+        # Route through persistent buffers when replaying a captured graph
+        # so input data_ptrs match capture-time addresses. For eager (NONE)
+        # we use the per-call tensors as before.
+        if cudagraph_runtime_mode != CUDAGraphMode.NONE:
+            assert self._cg_inputs_embeds_buf is not None, (
+                "cudagraph buffers not allocated; _capture_cudagraphs() must "
+                "run before any FULL replay path"
+            )
+            embed_buf = self._cg_inputs_embeds_buf
+            pos_buf = self._cg_positions_buf
+            embed_buf[:num_tokens].copy_(input_embeds, non_blocking=True)
+            pos_buf[:num_tokens].copy_(positions, non_blocking=True)
+            # Pad slots beyond num_tokens are unused by attention (slot_mapping
+            # contains -1 for those rows in build_common_metadata via padded
+            # qo_indptr) but the position/embed values must be valid for
+            # other ops that index into them — zero is safe.
+            if padded_tokens > num_tokens:
+                embed_buf[num_tokens:padded_tokens].zero_()
+                pos_buf[num_tokens:padded_tokens].zero_()
+            model_inputs_embeds = embed_buf[:padded_tokens]
+            model_positions = pos_buf[:padded_tokens]
+        else:
+            model_inputs_embeds = input_embeds
+            model_positions = positions
+
         with set_forward_context(
             attn_metadata=backend_metadata,
             vllm_config=self.vllm_config,
-            num_tokens=common.num_actual_tokens,
+            num_tokens=padded_tokens,
             slot_mapping=slot_mapping_dict,
+            cudagraph_runtime_mode=cudagraph_runtime_mode,
+            batch_descriptor=batch_descriptor,
         ):
-            hidden_states = self.model.forward(
+            # `self.model(...)` (not `.forward(...)`) so a CUDAGraphWrapper
+            # installed at FULL mode by `_capture_cudagraphs` sees the
+            # forward_context and dispatches capture/replay.
+            hidden_states = self.model(
                 input_ids=None,
-                positions=positions,
-                inputs_embeds=input_embeds,
+                positions=model_positions,
+                inputs_embeds=model_inputs_embeds,
             )
+
+        if padded_tokens != num_tokens:
+            # Trim padding rows from the captured graph's output before
+            # downstream sampling/logits.
+            hidden_states = hidden_states[:num_tokens]
 
         return hidden_states
 

--- a/pie/src/pie_driver_vllm/forward_pass.py
+++ b/pie/src/pie_driver_vllm/forward_pass.py
@@ -133,6 +133,7 @@ class VllmForwardPass:
         kv_page_indices: torch.Tensor,
         kv_page_indptr: torch.Tensor,
         kv_last_page_lens: torch.Tensor,
+        single_token_mode: bool = False,
     ) -> torch.Tensor:
         """Run the model's transformer trunk inside `set_forward_context`.
 
@@ -153,32 +154,31 @@ class VllmForwardPass:
         page_size = self._kv_spec.block_size
         num_tokens = int(input_embeds.shape[0])
 
-        # Decide cudagraph dispatch. Uniform-decode = every request has
-        # exactly `_cg_query_len` query tokens (1 for plain decode,
-        # 1+num_spec_tokens for spec). Cheap host-side check on the small
-        # qo_indptr tensor.
+        # Decide cudagraph dispatch. We dispatch only on uniform-decode
+        # batches at query_len=1, gated on the existing pie convention
+        # `single_token_mode` (set by the Rust runtime in shmem_schema.py
+        # and consumed by phi3/mistral3/olmo3 model files for the same
+        # purpose). This is a pure host-side bool; no GPU sync. Spec-
+        # decode uniform batches (query_len > 1) currently fall through
+        # to eager — separate follow-up to extend pie's runtime flag for
+        # spec-aware uniform detection.
         cudagraph_runtime_mode = CUDAGraphMode.NONE
         batch_descriptor: BatchDescriptor | None = None
         padded_tokens = num_tokens
         if (
             self._cg_dispatcher is not None
             and self._cg_dispatcher.cudagraph_mode != CUDAGraphMode.NONE
+            and single_token_mode
+            and self._cg_query_len == 1
         ):
-            qo_host = qo_indptr.detach().to("cpu", non_blocking=False)
-            diffs = qo_host[1:] - qo_host[:-1]
-            uniform_decode = bool(
-                diffs.numel() > 0
-                and torch.all(diffs == self._cg_query_len).item()
-            )
-            if uniform_decode:
-                cudagraph_runtime_mode, batch_descriptor = (
-                    self._cg_dispatcher.dispatch(
-                        num_tokens=num_tokens,
-                        uniform_decode=True,
-                    )
+            cudagraph_runtime_mode, batch_descriptor = (
+                self._cg_dispatcher.dispatch(
+                    num_tokens=num_tokens,
+                    uniform_decode=True,
                 )
-                if cudagraph_runtime_mode != CUDAGraphMode.NONE:
-                    padded_tokens = batch_descriptor.num_tokens
+            )
+            if cudagraph_runtime_mode != CUDAGraphMode.NONE:
+                padded_tokens = batch_descriptor.num_tokens
 
         # Build attention metadata. Pad to `padded_tokens` when replaying so
         # the captured graph's persistent FlashInfer buffers are populated

--- a/pie/src/pie_driver_vllm/loader.py
+++ b/pie/src/pie_driver_vllm/loader.py
@@ -108,6 +108,24 @@ def _build_vllm_config(config: RuntimeConfig, driver_config) -> Any:
         if v is not None:
             engine_kwargs[k] = v
 
+    # Pin attention backend to FLASHINFER when cudagraph capture is going
+    # to be active (Lever 5 / ticket #100). The decode-side cudagraph path
+    # captures `model.forward` whole; pie passes per-call attention
+    # metadata (slot_mapping, block_table, paged_kv_*) that lands at fresh
+    # GPU addresses each step, but the captured graph aliases capture-time
+    # data_ptrs. FlashInfer's BatchDecodeWithPagedKVCacheWrapper runs
+    # `plan()` per call and copies our metadata into ITS persistent
+    # cudagraph buffers (paged_kv_indptr/indices/last_page_len), so the
+    # captured graph reads stable addresses on replay. FLASH_ATTN/TRITON
+    # have no such wrapper-internal persistence — they read block_table /
+    # seq_lens directly off pie's per-call tensors, so the captured graph
+    # silently reads stale memory and decode output degenerates. Promotion
+    # is gated on (a) cudagraph mode is going to be active, AND (b) the
+    # user did not pin a different backend. Eager mode keeps vllm's
+    # default backend selection.
+    if not driver_config.enforce_eager and driver_config.attention_backend is None:
+        engine_kwargs["attention_backend"] = "FLASHINFER"
+
     args = EngineArgs(**engine_kwargs)
     vllm_config = args.create_engine_config()
 

--- a/pie/src/pie_driver_vllm/loader.py
+++ b/pie/src/pie_driver_vllm/loader.py
@@ -109,7 +109,29 @@ def _build_vllm_config(config: RuntimeConfig, driver_config) -> Any:
             engine_kwargs[k] = v
 
     args = EngineArgs(**engine_kwargs)
-    return args.create_engine_config()
+    vllm_config = args.create_engine_config()
+
+    # Decode-side cudagraph (Lever 5, ticket #100). Pie drives the model
+    # outside vllm's GPUModelRunner, so vllm's auto-resolution of
+    # cudagraph_mode never runs against pie's actual call shapes — vllm
+    # leaves it at NONE/PIECEWISE depending on the version. Promote it to
+    # FULL_DECODE_ONLY so the FlashInfer decode wrapper publishes its
+    # cudagraph capture path (full decode forward as a single graph; mixed
+    # / prefill batches stay eager). Only override when not already FULL,
+    # so an explicit user choice (e.g. FULL_AND_PIECEWISE) is preserved.
+    from vllm.config import CUDAGraphMode
+
+    if not driver_config.enforce_eager:
+        cc = vllm_config.compilation_config
+        if cc.cudagraph_mode in (CUDAGraphMode.NONE, CUDAGraphMode.PIECEWISE):
+            cc.cudagraph_mode = CUDAGraphMode.FULL_DECODE_ONLY
+            # FULL capture wraps the whole decode forward; the splitting_ops
+            # belong to PIECEWISE (used to split inductor partitions at
+            # attention boundaries) — clear them so vllm doesn't try to
+            # piecewise-split a graph we want captured monolithically.
+            cc.splitting_ops = []
+
+    return vllm_config
 
 
 def _ensure_vllm_distributed(vllm_config: Any, rank: int, local_rank: int) -> None:


### PR DESCRIPTION
## Summary

Wires up FULL_DECODE_ONLY cudagraph capture in `pie_driver_vllm`. Pie was previously driving `model.forward(...)` outside vllm's `GPUModelRunner`, so vllm's cudagraph machinery never fired against pie's call shapes — pie was paying full kernel-launch cost on every decode step.

**Measured on Qwen2.5-72B-Instruct-AWQ, A100-SXM4-80GB SECURE, bfloat16, single-seq, max_tokens=128, greedy. `pie serve` daemon + `PieClient`, mean tail of 5 serial requests:**

| path | per-tok | tok/s | vs vllm-direct |
|------|---------|-------|----------------|
| pie eager | 22.68 ms | 44.1 | 1.56× |
| **pie cap (this PR)** | **15.39 ms** | **64.9** | **1.06×** |
| vllm-direct | 14.5 ms | 68.8 | 1.00× |

**−7.29 ms/tok = −32%, gap 1.56× → 1.06×.**

## Mechanism

72B-AWQ decode forward issues ~1200 individual CUDA kernels (80 layers × ~15 kernels/layer). At ~6 µs/launch on A100 in eager Python dispatch, predicted launch overhead ≈ 7.2 ms; measured savings = 7.29 ms. Cudagraph collapses the 1200 launches into one `cudaGraphLaunch` — GPU work (matmul SMs, HBM bandwidth) is unchanged, host-side launch cost is eliminated.

## What changes

- **`loader.py`** — promote `cc.cudagraph_mode` from NONE/PIECEWISE → FULL_DECODE_ONLY when `enforce_eager=false`. Auto-pin `attention_backend = "FLASHINFER"` so backend metadata (paged_kv_indptr/indices/last_page_len) lands in FlashInfer's persistent cudagraph buffers via `wrapper.plan()` (FLASH_ATTN/TRITON have no equivalent).
- **`engine.py`** — `_capture_cudagraphs()` runs at end of `Engine.load`. Wraps `forward_pass.model` in `CUDAGraphWrapper(runtime_mode=FULL)`, builds a `CudagraphDispatcher`, allocates persistent input buffers (`_cg_inputs_embeds_buf`, `_cg_positions_buf`, `_cg_slot_mapping_buf`), drives one synthetic uniform-decode forward per `BatchDescriptor` inside `graph_capture()`. Zeros KV pages used as warmup scratch.
- **`forward_pass.py`** — `transform()` consults the dispatcher on uniform-decode batches, threads `cudagraph_runtime_mode + batch_descriptor` through `set_forward_context`, pads to a captured size with `slot_mapping=-1` for unused rows, and substitutes the persistent slot_mapping buffer into `common.slot_mapping` before `builder.build()` so any backend that snapshots the tensor picks up the persistent reference. Switched `self.model.forward(...)` → `self.model(...)` so the wrapper's `__call__` activates.
- **Dispatch signal** — gates on the existing `single_token_inference_mode` flag (set by the Rust runtime in `shmem_schema.py` via `flags & 1`, already used by phi3/mistral3/olmo3 for the same purpose). No new field added; no `pie_driver/batching.py` touch. Mirrors how vllm uses `SchedulerOutput.num_decodes`.

## Two correctness fixes during validation

1. **Persistent `slot_mapping` (commit 44359733).** `CUDAGraphWrapper` aliases `data_ptr()` of every tensor flowing into `model.forward` at capture. Pie was constructing per-call slot_mapping → captured graph aliased capture-time addr → replay read garbage → cap output was "Question Instructions Instructions ..." vs eager's "Okay, the user is asking ...". Fix: persistent `_cg_slot_mapping_buf` + substitute into `common.slot_mapping` before `builder.build()`.
2. **FlashInfer auto-pin (commit 44359733).** Only FlashInfer's `BatchDecodeWithPagedKVCacheWrapper.plan()` launders per-call attention metadata into its persistent cudagraph buffers. `loader.py` auto-pins FLASHINFER when cudagraph mode is being promoted.

Both validated on Qwen3-0.6B greedy temp=0: cap and eager produce identical first sentence.

## Cap warmup cost (paid once per `pie serve` session)

- vllm engine warmup: prefill (8 tok) **12.04 s** — torch.compile/inductor compiling FULL decode forward (eager warmup was 0.27 s; the 11.8 s diff IS the compile)
- `[vllm cudagraph] captured FULL graphs for 12 descriptor(s) in 0.20 s (104.0 MiB graph memory)`

For long-lived serving this is essentially free.

## Out of scope

- **Residual 1.06× (pie cap vs vllm-direct = 0.89 ms/tok).** Architectural cost of pie's outside-`GPUModelRunner` driving model: per-fire_batch shmem RPC (~0.5 ms) + persistent-buffer copies (~0.15 ms total) for slot_mapping/embeds/positions. Closing these requires running pie's RPC inside the captured graph's stream context.
- **Spec-decode cudagraph dispatch.** `_cg_query_len` is wired to `1 + num_speculative_tokens` and synthetic capture runs at that shape, but the runtime gate uses `single_token_mode` which the Rust runtime sets to `False` for spec batches. Extending pie's runtime flag for spec-aware uniform detection is a separate follow-up.

## Test plan

- [x] AST-clean on all 3 edited files
- [x] Cap+eager A/B on Qwen3-0.6B (A100): identical first sentence, both coherent. Cap captures 12 descriptors in 0.09 s / 88 MiB.
- [x] 72B-AWQ baseline: pie eager 22.68 ms/tok, vllm-direct 14.5 ms/tok (matches historical decode-overhead ratio within bench noise).
- [x] 72B-AWQ cap measurement: 15.39 ms/tok = −32% vs eager, 1.06× vllm-direct.
- [x] Eager hot path unchanged: `_cg_dispatcher is None` short-circuits the dispatcher gate; eager-mode users see zero added overhead.
- [ ] _(reviewer)_ Verify FlashInfer auto-pin doesn't conflict with explicit user `attention_backend` in any existing config.
- [ ] _(reviewer)_ Confirm `single_token_mode=True` is the right gate for cudagraph dispatch in production batch compositions.

## Recommendation

Keep `enforce_eager = false` as the default. After this merge, that lands in cap mode automatically and is what production should run. Users who want to opt out (debugging) set `enforce_eager = true` and skip both compile + capture costs.

