### PR TITLE
fix(qwen3_5_moe): register HF model_types, qwen3_5 instruct arm, fail-loud on hybrid Mamba

### DIFF
--- a/driver/portable/src/hf_config.cpp
+++ b/driver/portable/src/hf_config.cpp
@@ -44,7 +44,9 @@ PieArch hf_model_type_to_pie_arch(const std::string& hf_model_type) {
     if (hf_model_type == "gptoss")      return PieArch::GptOss;
     if (hf_model_type == "phi3")        return PieArch::Phi3;
     if (hf_model_type == "mixtral")     return PieArch::Mixtral;
-    if (hf_model_type == "qwen3_5")     return PieArch::Qwen3_5;
+    if (hf_model_type == "qwen3_5" ||
+        hf_model_type == "qwen3_5_moe" ||
+        hf_model_type == "qwen3_5_moe_text") return PieArch::Qwen3_5;
     if (hf_model_type == "qwen3_moe")   return PieArch::Qwen3_5;
     throw std::runtime_error(
         "hf_config: unsupported model_type '" + hf_model_type + "'");

--- a/pie/src/pie_driver/model/__init__.py
+++ b/pie/src/pie_driver/model/__init__.py
@@ -169,7 +169,7 @@ def _attr_or_key(obj, key, default):
 register("llama3",   "pie_driver.model.llama3",   aliases=("l4ma",), hf_model_types=("llama",))
 register("qwen2",    "pie_driver.model.qwen2",                       hf_model_types=("qwen2",))
 register("qwen3",    "pie_driver.model.qwen3",                       hf_model_types=("qwen3",))
-register("qwen3_5",  "pie_driver.model.qwen3_5",                     hf_model_types=("qwen3_5",))
+register("qwen3_5",  "pie_driver.model.qwen3_5",                     hf_model_types=("qwen3_5", "qwen3_5_moe", "qwen3_5_moe_text"))
 register("phi3",     "pie_driver.model.phi3",                        hf_model_types=("phi3",))
 register("mixtral",  "pie_driver.model.mixtral",                     hf_model_types=("mixtral",))
 register("gemma2",   "pie_driver.model.gemma2",                      hf_model_types=("gemma2",))

--- a/pie/src/pie_driver_vllm/kv_cache.py
+++ b/pie/src/pie_driver_vllm/kv_cache.py
@@ -86,8 +86,40 @@ def allocate_and_bind_kv_cache(
     if not attn_layers:
         raise RuntimeError("No attention layers found in vllm forward context.")
 
+    # Resolve every layer's spec up front so we can detect heterogeneous
+    # layouts (hybrid Transformer + Mamba/GDN models like Qwen3.5 / Qwen3-Next)
+    # and refuse them with a clear error instead of a downstream AttributeError
+    # on `MambaSpec.num_kv_heads`. Hybrid support requires a parallel
+    # state-cache allocator + a GDN attention-metadata builder inside this
+    # driver — tracked as the layer-3 follow-up to pie-agents#102.
+    from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec
+
+    layer_specs: dict[str, KVCacheSpec] = {}
     with set_current_vllm_config(vllm_config):
-        first_spec = next(iter(attn_layers.values())).get_kv_cache_spec(vllm_config)
+        for name, layer in attn_layers.items():
+            layer_specs[name] = layer.get_kv_cache_spec(vllm_config)
+
+    non_full_attention = {
+        name: type(spec).__name__
+        for name, spec in layer_specs.items()
+        if not isinstance(spec, FullAttentionSpec)
+    }
+    if non_full_attention:
+        # Spell out the exact spec mix so the error survives in logs and
+        # points the reader at the right follow-up.
+        sample = ", ".join(f"{n}={t}" for n, t in list(non_full_attention.items())[:5])
+        raise NotImplementedError(
+            f"pie_driver_vllm only supports models whose attention layers all "
+            f"return FullAttentionSpec; got {len(non_full_attention)} layer(s) "
+            f"with a different spec ({sample}{'...' if len(non_full_attention) > 5 else ''}). "
+            f"Hybrid Transformer + Mamba/GDN models (e.g. Qwen3.5 / Qwen3-Next "
+            f"with model_type='qwen3_5_moe' or 'qwen3_next') need a separate "
+            f"per-spec allocator and a GDN attention-metadata builder inside "
+            f"pie_driver_vllm — not yet implemented. Use the cuda_native or "
+            f"portable driver for these models, or track pie-agents#102 layer 3."
+        )
+
+    first_spec = next(iter(layer_specs.values()))
     page_size_bytes = first_spec.page_size_bytes
     block_size = first_spec.block_size
     num_kv_heads = first_spec.num_kv_heads

--- a/runtime/src/model/instruct.rs
+++ b/runtime/src/model/instruct.rs
@@ -114,7 +114,7 @@ pub fn create(arch_name: &str, tokenizer: Arc<Tokenizer>) -> Arc<dyn Instruct> {
     use self::qwen3::{QwenInstruct, ChatMLConfig};
 
     match arch_name {
-        "qwen3" => Arc::new(QwenInstruct::new(tokenizer, ChatMLConfig {
+        "qwen3" | "qwen3_5" => Arc::new(QwenInstruct::new(tokenizer, ChatMLConfig {
             has_thinking: true,
             has_tools: true,
             stop_tokens: &["<|im_end|>", "<|endoftext|>"],
@@ -165,6 +165,23 @@ mod tests {
             ReasoningEvent::Start => {}
             other => panic!(
                 "create(\"qwen3\") gave a no-op reasoning decoder: {other:?}"
+            ),
+        }
+    }
+
+    /// Qwen3.5 reuses the qwen3 ChatML template (thinking + tools, same stop
+    /// tokens). Pinned here so the qwen3_5 arm doesn't silently regress to
+    /// the no-thinking fallback.
+    #[test]
+    fn qwen3_5_pie_name_enables_thinking() {
+        let tok = make_tok();
+        let inst = create("qwen3_5", tok.clone());
+        let mut dec = inst.reasoning_decoder();
+        let think_id = tok.encode("<think>");
+        match dec.feed(&think_id) {
+            ReasoningEvent::Start => {}
+            other => panic!(
+                "create(\"qwen3_5\") gave a no-op reasoning decoder: {other:?}"
             ),
         }
     }


### PR DESCRIPTION
Surfaced from pie-agents#101 / #102. Closes the first three layers of the Qwen3.5-MoE-on-vllm-driver gap; the fourth (hybrid Mamba state allocator + GDN attention metadata builder) is tracked as a follow-up.

## Layer 1 — Python registry + portable C++ mirror (commit `92e55f68`)

`Qwen/Qwen3.5-35B-A3B-FP8` (HF `model_type='qwen3_5_moe'`, `architectures[0]='Qwen3_5MoeForConditionalGeneration'`) crashes pie's vllm-driver loader at `pie_driver.model.resolve()` with `UnknownArchitectureError` before vllm gets a chance to load the model. Multimodal Qwen3.5 variants additionally carry `qwen3_5_moe_text` on the inner `hf_text_config`.

Add both HF model_types to the existing `qwen3_5` pie arch registration (`gemma4` / `gemma4_text` precedent on the next line). Mirror in the C++ portable `hf_config` table whose source-of-truth comment already promises sync.

## Layer 2 — Rust `qwen3_5` instruct arm (commit `d3367813`)

Without a `qwen3_5` arm in `runtime/src/model/instruct.rs`, dispatch silently falls through to the QwenChatML catch-all that disables `has_thinking` and `has_tools`. Same ChatML grammar as `qwen3` — alias the arm rather than duplicate. Test mirrors `qwen3_pie_name_enables_thinking` so the alias can't silently regress.

## Layer 3 — fail-loud on hybrid Transformer+Mamba (commit `ce652511`)

`pie_driver_vllm/kv_cache.py:93` previously read `first_spec.num_kv_heads` on the first attention layer's spec. For hybrid models (Qwen3.5 / Qwen3-Next), vllm returns `MambaSpec` for the GDN layers and that crashes with a cryptic `AttributeError`. Replace with an explicit per-layer spec scan; if any layer is non-`FullAttentionSpec`, raise a `NotImplementedError` that names the spec mix, points at `cuda_native` / `portable` as the supported path today, and references the follow-up.

This does not make Qwen3.5-MoE run on the vllm driver. Full hybrid support requires a parallel Mamba state allocator + GDN attention-metadata builder inside `pie_driver_vllm/`. Out of scope here.

## Test

Direct registry sanity check (full repo install needs CUDA / pie_kernels):

```text
'qwen3_5'           -> 'qwen3_5'
'qwen3_5_moe'       -> 'qwen3_5'
'qwen3_5_moe_text'  -> 'qwen3_5'
'qwen3'             -> 'qwen3'
'gemma4_text'       -> 'gemma4'
unknown still raises: ok
```

Rust instruct unit test added (`qwen3_5_pie_name_enables_thinking`) — pinned so the qwen3_5 alias doesn't silently regress to the no-thinking fallback.

End-to-end: prior-session smoke on Qwen3.5-35B-A3B-FP8 (pod `eqz5fa7zen6cer`, terminated) confirmed the three-layer breakdown; this PR closes layers 1-3. Layer 4 (hybrid allocator + metadata) needs ~2-3 days + pod source-reading and gets a dedicated PR.