### PR TITLE
pie_driver_vllm: hybrid Transformer+Mamba KV-cache support (qwen3_5_moe / qwen3_next)

### DIFF
--- a/benches/tput.py
+++ b/benches/tput.py
@@ -86,6 +86,8 @@ async def run_benchmark(args):
         }
         if args.vllm_attention_backend is not None:
             driver_subsection["attention_backend"] = args.vllm_attention_backend
+        if args.vllm_max_num_batched_tokens is not None:
+            driver_subsection["max_num_batched_tokens"] = args.vllm_max_num_batched_tokens
     elif args.driver == "native":
         driver_subsection = {
             "gpu_mem_utilization": args.gpu_mem_util,
@@ -293,6 +295,8 @@ def main():
                         help="KV pages for the cuda_native driver. Each page = kv_page_size tokens.")
     parser.add_argument("--vllm-attention-backend", default=None,
                         help="vLLM attention backend (FLASH_ATTN / FLASHINFER / etc.). Only used when --driver=vllm")
+    parser.add_argument("--vllm-max-num-batched-tokens", type=int, default=None,
+                        help="vLLM max_num_batched_tokens. Caps tokens per fire_batch (also pie's max_batch_tokens via DriverCapabilities). Default None = vllm auto. Only used when --driver=vllm")
     parser.add_argument("--sglang-attention-backend", default=None,
                         help="SGLang attention backend (triton / flashinfer / flex_attention / fa3). Only used when --driver=sglang")
     parser.add_argument("--use-cuda-graphs", action="store_true",

--- a/pie/src/pie/capabilities.py
+++ b/pie/src/pie/capabilities.py
@@ -86,6 +86,16 @@ class DriverCapabilities:
     # hook in a follow-up.
     supports_user_attention_mask: bool = False
 
+    # Whether the driver supports KV-context fork (`ctx.fork()`) and the
+    # subsequent copy_d2d/h2d/d2h page transfers. False on the vllm
+    # driver when serving hybrid Transformer+Mamba models (Qwen3.5-MoE,
+    # Qwen3-Next, …) because pie's per-page copy handlers can't migrate
+    # mamba's per-request recurrent state (see ticket #107 / #108).
+    # Defaults True so existing drivers (cuda_native, portable, vllm on
+    # pure-attention models) are treated as fork-capable. Python-only
+    # today; pie's runtime gains an admission hook in a follow-up.
+    supports_kv_fork: bool = True
+
     # ── Filesystem ─────────────────────────────────────────────────────
     # Local directory containing tokenizer.json + config.json. The Rust
     # runtime reads tokenizer.json from `<snapshot_dir>/tokenizer.json`.

--- a/pie/src/pie_driver_vllm/_vllm_compat.py
+++ b/pie/src/pie_driver_vllm/_vllm_compat.py
@@ -59,6 +59,13 @@ from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.worker.utils import bind_kv_cache
 
 
+# ----------------------------------------------------------------------------
+# KV-cache spec types (full attention vs mamba) — used to detect hybrid models
+# ----------------------------------------------------------------------------
+
+from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec, MambaSpec
+
+
 # Per-backend impl classes — imported lazily because vllm's per-backend
 # modules pull in heavy deps (flashinfer kernels, fa3 wheels, etc.). Most
 # call sites need just one impl, so we expose a getter that imports on
@@ -69,6 +76,34 @@ def get_flashinfer_impl():
     return FlashInferImpl
 
 
+# GDN backend, GDNAttentionMetadata, and per-prefill conv1d helpers — only
+# imported when a hybrid model is detected so non-hybrid loads stay clean.
+def get_gdn_backend():
+    from vllm.v1.attention.backends.gdn_attn import (
+        GDNAttentionBackend,
+        GDNAttentionMetadata,
+        GDNAttentionMetadataBuilder,
+    )
+    return GDNAttentionBackend, GDNAttentionMetadata, GDNAttentionMetadataBuilder
+
+
+def get_mamba_helpers():
+    """conv1d-metadata + null-block-id constants used by the GDN builder."""
+    from vllm.v1.attention.backends.utils import (
+        NULL_BLOCK_ID,
+        compute_causal_conv1d_metadata,
+    )
+    return NULL_BLOCK_ID, compute_causal_conv1d_metadata
+
+
+def get_mamba_base():
+    """`MambaBase` is the marker class GDN/Mamba2 layers inherit from. Used to
+    detect mamba layers in the static_forward_context (alongside
+    `AttentionLayerBase` for attention layers)."""
+    from vllm.model_executor.layers.mamba.abstract import MambaBase
+    return MambaBase
+
+
 __all__ = [
     "AttentionLayerBase",
     "BatchDescriptor",
@@ -77,12 +112,18 @@ __all__ = [
     "CommonAttentionMetadata",
     "CudagraphDispatcher",
     "EngineArgs",
+    "FullAttentionSpec",
+    "KVCacheSpec",
+    "MambaSpec",
     "bind_kv_cache",
     "ensure_model_parallel_initialized",
     "extract_layer_index",
     "get_attention_context",
     "get_flashinfer_impl",
     "get_forward_context",
+    "get_gdn_backend",
+    "get_mamba_base",
+    "get_mamba_helpers",
     "get_model_loader",
     "graph_capture",
     "init_distributed_environment",

--- a/pie/src/pie_driver_vllm/engine.py
+++ b/pie/src/pie_driver_vllm/engine.py
@@ -8,6 +8,7 @@ imported directly from `pie_driver`.
 
 from __future__ import annotations
 
+import logging
 import random
 
 import numpy as np
@@ -17,6 +18,28 @@ from pie_driver.config import RuntimeConfig
 from pie_driver import telemetry
 
 from . import _require_vllm
+
+logger = logging.getLogger(__name__)
+
+
+# Existing `_log(msg, level: str)` helpers in this module accept string
+# level names like "INFO" / "WARN" / "DEBUG" (matching pie's log_queue
+# convention). Map them to stdlib logging integer levels so we can route
+# through `logger.log(level_int, ...)` without a method lookup per call.
+# `WARN` is normalized to `WARNING` (stdlib's canonical name).
+_LEVEL_NAME_TO_INT = {
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARN": logging.WARNING,
+    "WARNING": logging.WARNING,
+    "ERROR": logging.ERROR,
+    "CRITICAL": logging.CRITICAL,
+}
+
+
+def _level_to_int(level: str) -> int:
+    """Map a pie log_queue level string to a stdlib logging int level."""
+    return _LEVEL_NAME_TO_INT.get(level.upper(), logging.INFO)
 
 
 class VllmEngine:
@@ -150,9 +173,9 @@ class VllmEngine:
         # and surface downstream as flashinfer "max() iterable empty".
         try:
             engine._warmup_compile(_log)
-        except Exception as _e:
-            import traceback as _tb
-            print(f"[vllm warmup] FAILED: {_e}\n{_tb.format_exc()}", flush=True)
+        except Exception:
+            # logger.exception attaches the active traceback automatically.
+            logger.exception("vllm warmup FAILED")
             raise
 
         # Lever 5 (ticket #100): wrap the model with vllm's FULL-mode
@@ -163,12 +186,9 @@ class VllmEngine:
         # through set_forward_context.
         try:
             engine._capture_cudagraphs(_log)
-        except Exception as _e:
-            import traceback as _tb
-            print(
-                f"[vllm cudagraph] FAILED: {_e}\n{_tb.format_exc()}",
-                flush=True,
-            )
+        except Exception:
+            # logger.exception attaches the active traceback automatically.
+            logger.exception("vllm cudagraph FAILED")
             raise
 
         return engine
@@ -192,7 +212,7 @@ class VllmEngine:
         device = self.forward_pass.device
 
         def _log(msg: str, level: str = "INFO") -> None:
-            print(f"[vllm warmup] {msg}", flush=True)
+            logger.log(_level_to_int(level), "warmup: %s", msg)
             if log_fn is not None:
                 log_fn(msg, level)
 
@@ -329,7 +349,7 @@ class VllmEngine:
         device = self.forward_pass.device
 
         def _log(msg: str, level: str = "INFO") -> None:
-            print(f"[vllm cudagraph] {msg}", flush=True)
+            logger.log(_level_to_int(level), "cudagraph: %s", msg)
             if log_fn is not None:
                 log_fn(msg, level)
 

--- a/pie/src/pie_driver_vllm/engine.py
+++ b/pie/src/pie_driver_vllm/engine.py
@@ -61,6 +61,15 @@ class VllmEngine:
     model_config: object
     kv_cache_at_layer: list[torch.Tensor]
     kv_cache_at_layer_host: list[torch.Tensor]
+    # `(layer_name, conv_state, ssm_state)` per mamba layer on hybrid models.
+    # NOT included in `kv_cache_at_layer` so pie's per-page copy_d2d/h2d/d2h
+    # handlers (which assume page-id indexing valid across all listed layers)
+    # never see them. Hybrid models advertise `supports_kv_fork=False` via
+    # capabilities, so pie's runtime won't issue fork on them; if it does
+    # anyway, attention pages are still copied correctly while mamba state
+    # stays at the (shared) parent slot — see ticket #107 / #108.
+    mamba_layers: list[tuple[str, torch.Tensor, torch.Tensor]]
+    is_hybrid: bool
     swap_pool_size: int
     adapter_at_layer: list
     adapters: dict
@@ -81,6 +90,8 @@ class VllmEngine:
         snapshot_dir: str | None = None,
         kv_cache_at_layer_host: list | None = None,
         swap_pool_size: int = 0,
+        mamba_layers: list | None = None,
+        is_hybrid: bool = False,
     ):
         self.config = config
         self.driver_config = driver_config
@@ -88,6 +99,8 @@ class VllmEngine:
         self.forward_pass = forward_pass
         self.kv_cache_at_layer = kv_cache_at_layer
         self.kv_cache_at_layer_host = kv_cache_at_layer_host or []
+        self.mamba_layers = mamba_layers or []
+        self.is_hybrid = is_hybrid
         self.swap_pool_size = swap_pool_size
         self.adapter_at_layer = adapter_at_layer
         self.arch_type = arch_type
@@ -139,8 +152,10 @@ class VllmEngine:
         )
         _log("Loaded vllm model", "DEBUG")
 
-        kv_cache_at_layer = allocate_and_bind_kv_cache(loaded, config, driver_config)
-        host_kv, pool_size = allocate_host_pool(kv_cache_at_layer, config.swap_budget_bytes)
+        layout = allocate_and_bind_kv_cache(loaded, config, driver_config)
+        host_kv, pool_size = allocate_host_pool(
+            layout.attention_layers_in_order, config.swap_budget_bytes
+        )
 
         forward_pass = VllmForwardPass(
             model=loaded.model,
@@ -148,6 +163,8 @@ class VllmEngine:
             attn_backend=loaded.attn_backend,
             runtime_config=config,
             model_config=loaded.model_config,
+            mamba_layers=layout.mamba_layers,
+            is_hybrid=layout.is_hybrid,
         )
 
         engine = cls(
@@ -155,13 +172,15 @@ class VllmEngine:
             driver_config=driver_config,
             model_config=loaded.model_config,
             forward_pass=forward_pass,
-            kv_cache_at_layer=kv_cache_at_layer,
+            kv_cache_at_layer=layout.attention_layers_in_order,
             adapter_at_layer=[],
             arch_type=loaded.arch_type,
             info=loaded.info,
             snapshot_dir=loaded.snapshot_dir,
             kv_cache_at_layer_host=host_kv,
             swap_pool_size=pool_size,
+            mamba_layers=layout.mamba_layers,
+            is_hybrid=layout.is_hybrid,
         )
 
         # Compile + JIT warmup. Drives a synthetic prefill+decode forward
@@ -310,6 +329,13 @@ class VllmEngine:
         # warmup activations as committed K/V.
         for layer_kv in self.kv_cache_at_layer:
             layer_kv[0].zero_()
+        # Zero slot 0 of every mamba state pool too — warmup wrote
+        # recurrent state at the synthetic request's slot (= first page id
+        # = 0 by construction), so the first real request that's allocated
+        # page 0 must see a clean state.
+        for _name, conv_state, ssm_state in self.mamba_layers:
+            conv_state[0].zero_()
+            ssm_state[0].zero_()
 
         _log(
             f"vllm engine warmup: prefill ({n_prefill} tok) {t_prefill:.2f}s, "
@@ -363,6 +389,17 @@ class VllmEngine:
 
         if cg_mode == CUDAGraphMode.NONE:
             _log("skipped (cudagraph_mode=NONE)", "INFO")
+            return
+
+        if self.is_hybrid:
+            # Hybrid Transformer+Mamba: GDN backend has its own
+            # AttentionCGSupport.UNIFORM_BATCH cudagraph path that captures
+            # the FLA / causal_conv1d kernels itself, with persistent
+            # buffers sized to `decode_cudagraph_max_bs`. Mixing it with
+            # pie's FULL_DECODE_ONLY wrapper around the whole forward
+            # would double-capture and corrupt mamba state. Defer hybrid
+            # cudagraph to ticket #107's perf follow-up; eager works.
+            _log("skipped (hybrid Transformer+Mamba — eager only)", "INFO")
             return
 
         # Pie does not own a vllm GPUModelRunner, so the cudagraph_capture_sizes
@@ -821,5 +858,11 @@ class VllmEngine:
             # causal attention and silently drops user masks. Inferlets
             # that need non-causal patterns must run on `native`.
             supports_user_attention_mask=False,
+            # Hybrid Transformer+Mamba models can't safely fork on the
+            # vllm driver yet — pie's per-page copy_d2d/h2d/d2h handlers
+            # don't migrate mamba's per-request recurrent state. Pure-
+            # attention models on this driver fork like before. See
+            # ticket #107 / #108 for the runtime-cooperation fix.
+            supports_kv_fork=not self.is_hybrid,
             snapshot_dir=str(self.snapshot_dir),
         )

--- a/pie/src/pie_driver_vllm/forward_pass.py
+++ b/pie/src/pie_driver_vllm/forward_pass.py
@@ -43,12 +43,24 @@ class VllmForwardPass:
         attn_backend: Any,
         runtime_config: RuntimeConfig,
         model_config: Any,
+        mamba_layers: list[tuple[str, torch.Tensor, torch.Tensor]] | None = None,
+        is_hybrid: bool = False,
     ):
         self.model = model
         self.vllm_config = vllm_config
         self.runtime_config = runtime_config
         self.model_config = model_config
         self.device = torch.device(runtime_config.device)
+
+        # Hybrid (Transformer + Mamba) support — see kv_cache.py for the
+        # state-slot addressing (state slot = request's first KV page id).
+        self._is_hybrid = is_hybrid
+        # `mamba_layer_names`: layer prefixes for which `transform()` must
+        # publish a `GDNAttentionMetadata` entry into the per-layer
+        # forward-context dict. Order matches `engine.mamba_layers`.
+        self._mamba_layer_names: list[str] = (
+            [name for name, _, _ in (mamba_layers or [])]
+        )
 
         # Lazy: built on first transform() call so we know the resolved
         # backend (set during model construction inside set_current_vllm_config).
@@ -106,6 +118,15 @@ class VllmForwardPass:
         attn_layers.sort(key=lambda x: extract_layer_index(x[0]))
 
         self._layer_names = [name for name, _ in attn_layers]
+        if not attn_layers:
+            # Pure-mamba models — not in pie's smoke-test target. The
+            # FlashInfer builder isn't constructed, but `transform()` still
+            # needs to publish GDN metadata, which only consumes
+            # `CommonAttentionMetadata` (we build it directly below). Set
+            # `_kv_spec` to None and let the GDN-only path handle it.
+            self._kv_spec = None
+            self._builder = None
+            return
         first_layer = attn_layers[0][1]
         backend = first_layer.attn_backend
 
@@ -151,17 +172,23 @@ class VllmForwardPass:
 
         self._ensure_metadata_builder()
 
-        page_size = self._kv_spec.block_size
+        # On hybrid models, `_kv_spec` is the attention spec; the mamba
+        # layers don't share its block_size. Use the attention page_size
+        # for FlashInfer-side metadata; GDN metadata is built independently.
+        page_size = self._kv_spec.block_size if self._kv_spec is not None else 0
         num_tokens = int(input_embeds.shape[0])
 
         # Decide cudagraph dispatch. We dispatch only on uniform-decode
         # batches at query_len=1, gated on the existing pie convention
         # `single_token_mode` (set by the Rust runtime in shmem_schema.py
         # and consumed by phi3/mistral3/olmo3 model files for the same
-        # purpose). This is a pure host-side bool; no GPU sync. Spec-
-        # decode uniform batches (query_len > 1) currently fall through
-        # to eager — separate follow-up to extend pie's runtime flag for
-        # spec-aware uniform detection.
+        # purpose). This is a pure host-side bool; no GPU sync.
+        #
+        # Hybrid models: cudagraph capture is disabled at engine init for
+        # ticket #107 (the GDN backend has its own UNIFORM_BATCH cudagraph
+        # path that conflicts with pie's FULL_DECODE_ONLY capture
+        # machinery). The dispatcher is None on hybrid, so this gate
+        # naturally falls through to eager.
         cudagraph_runtime_mode = CUDAGraphMode.NONE
         batch_descriptor: BatchDescriptor | None = None
         padded_tokens = num_tokens
@@ -225,7 +252,7 @@ class VllmForwardPass:
             kv_page_indices=kv_page_indices_eff,
             kv_page_indptr=kv_page_indptr_eff,
             kv_last_page_lens=kv_last_page_lens_eff,
-            page_size=page_size,
+            page_size=page_size if page_size > 0 else 1,
             device=self.device,
         )
 
@@ -251,17 +278,56 @@ class VllmForwardPass:
             )
             common.slot_mapping = sm_buf[:padded_tokens]
 
-        # Backend-specific metadata. `common_prefix_len=0` disables cascade
-        # attention (we don't use it from pie's side).
-        backend_metadata = self._builder.build(
-            common_prefix_len=0,
-            common_attn_metadata=common,
-        )
+        # Backend-specific attention metadata. `common_prefix_len=0`
+        # disables cascade attention. Returns one dataclass shared by all
+        # attention layers (FlashInfer reads `common.block_table_tensor`
+        # etc. directly out of forward_context, so we only need one).
+        if self._builder is not None:
+            backend_metadata = self._builder.build(
+                common_prefix_len=0,
+                common_attn_metadata=common,
+            )
+        else:
+            backend_metadata = None
 
-        # Same slot_mapping for every layer (no cross-attention or shared KV).
-        slot_mapping_dict = {
-            name: common.slot_mapping for name in self._layer_names
-        }
+        # Per-layer attn_metadata dict. vllm's hybrid path (qwen3-next /
+        # qwen3.5-moe) reads `forward_context.attn_metadata[layer.prefix]`
+        # — Attention layers expect their own FlashInfer struct, GDN
+        # layers expect a `GDNAttentionMetadata`. We always publish a
+        # dict (uniform shape on hybrid and pure-attention) so model code
+        # doesn't branch on the metadata type.
+        per_layer_metadata: dict[str, Any] = {}
+        if backend_metadata is not None:
+            for name in self._layer_names:
+                per_layer_metadata[name] = backend_metadata
+
+        if self._is_hybrid and self._mamba_layer_names:
+            from .gdn_metadata import build_gdn_metadata
+
+            # Reuse `common`'s computed seq_lens / num_computed_tokens to
+            # avoid re-walking pie's CSR. `common.compute_num_computed_tokens()`
+            # caches; second access is free.
+            num_computed_tokens = common.compute_num_computed_tokens()
+            gdn = build_gdn_metadata(
+                qo_indptr=qo_indptr_eff,
+                kv_page_indices=kv_page_indices_eff,
+                kv_page_indptr=kv_page_indptr_eff,
+                seq_lens=common.seq_lens,
+                num_computed_tokens=num_computed_tokens,
+                num_actual_tokens=padded_tokens,
+                device=self.device,
+            )
+            for name in self._mamba_layer_names:
+                per_layer_metadata[name] = gdn
+
+        # Same slot_mapping for every attention layer (no cross-attention
+        # or shared KV). Mamba layers don't read slot_mapping; they get
+        # their state slots via `non_spec_state_indices_tensor` in the
+        # GDN metadata.
+        slot_mapping_dict = (
+            {name: common.slot_mapping for name in self._layer_names}
+            if self._layer_names else {}
+        )
 
         # vllm's RoPE kernel expects int64 positions; pie uses int32.
         positions = position_ids.to(self.device, dtype=torch.int64, non_blocking=True)
@@ -292,7 +358,7 @@ class VllmForwardPass:
             model_positions = positions
 
         with set_forward_context(
-            attn_metadata=backend_metadata,
+            attn_metadata=per_layer_metadata,
             vllm_config=self.vllm_config,
             num_tokens=padded_tokens,
             slot_mapping=slot_mapping_dict,

--- a/pie/src/pie_driver_vllm/forward_pass.py
+++ b/pie/src/pie_driver_vllm/forward_pass.py
@@ -105,13 +105,20 @@ class VllmForwardPass:
         from ._vllm_compat import (
             AttentionLayerBase,
             extract_layer_index,
+            get_mamba_base,
             set_current_vllm_config,
         )
 
+        # vllm 0.20.0 has `MambaBase(AttentionLayerBase)`, so a plain
+        # AttentionLayerBase isinstance check captures GDN/Mamba layers too.
+        # We need only the genuine attention layers here (FlashInfer
+        # metadata is built from their kv_spec).
+        MambaBase = get_mamba_base()
         fc = self.vllm_config.compilation_config.static_forward_context
         attn_layers = [
             (name, layer) for name, layer in fc.items()
             if isinstance(layer, AttentionLayerBase)
+            and not isinstance(layer, MambaBase)
         ]
         # Sort by extracted index so layer ordering is stable & matches
         # pie's swap RPC indexing.

--- a/pie/src/pie_driver_vllm/gdn_metadata.py
+++ b/pie/src/pie_driver_vllm/gdn_metadata.py
@@ -1,0 +1,162 @@
+"""Build vllm `GDNAttentionMetadata` from pie's per-batch CSR layout.
+
+vllm's GDN backend (`vllm/v1/attention/backends/gdn_attn.py`) consumes a
+struct that splits a batch into prefill / decode (and spec-decode, which
+pie does not exercise via vllm — pie's NGRAM drafter is engine-side and
+never produces > 1 query/req on this path). The struct also carries:
+
+* per-request **state-slot indices** — `non_spec_state_indices_tensor`,
+  one int32 per request pointing at the mamba state slot for that request.
+  Pie uses the request's first KV page id as the state slot (see
+  `kv_cache.py` for the addressing rationale).
+* per-prefill **conv1d metadata** — `nums_dict / batch_ptr /
+  token_chunk_offset_ptr`, computed once per batch via
+  `compute_causal_conv1d_metadata`.
+* prefill **chunk indices/offsets** for FLA's chunked gated-delta-rule
+  (qwen3-next / qwen3.5-moe specific) — computed via
+  `prepare_chunk_indices` / `prepare_chunk_offsets` on the non-spec
+  `query_start_loc_cpu`.
+* `has_initial_state` — `True` for prefill rows that carry pre-existing
+  recurrent state (i.e., `num_computed_tokens > 0`).
+
+We don't populate any spec-decode fields (`spec_*`, `num_accepted_tokens`,
+`spec_token_indx`, …) — pie's runtime won't issue spec-decode batches
+through this driver until ticket #107's spec_decode follow-up.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+
+def build_gdn_metadata(
+    *,
+    qo_indptr: torch.Tensor,            # int32 (batch+1,) on GPU or CPU
+    kv_page_indices: torch.Tensor,      # int32 (total_pages,) GPU or CPU
+    kv_page_indptr: torch.Tensor,       # int32 (batch+1,) GPU or CPU
+    seq_lens: torch.Tensor,             # int32 (batch,) GPU
+    num_computed_tokens: torch.Tensor,  # int32 (batch,) GPU
+    num_actual_tokens: int,
+    device: torch.device,
+) -> Any:
+    """Construct a `GDNAttentionMetadata` from pie batch fields.
+
+    `seq_lens` and `num_computed_tokens` are computed by the caller (in
+    `forward_pass`) from the FlashInfer/`CommonAttentionMetadata` build —
+    avoiding redundant CSR sweeps.
+    """
+    from ._vllm_compat import get_gdn_backend, get_mamba_helpers
+
+    _, GDNAttentionMetadata, _ = get_gdn_backend()
+    _, compute_causal_conv1d_metadata = get_mamba_helpers()
+
+    # Move CPU views once. `query_start_loc` is small (≤ batch+1), so the
+    # round-trip is cheap and lets us classify decode-vs-prefill on CPU.
+    if qo_indptr.device.type == "cpu":
+        query_start_loc_cpu = qo_indptr.to(torch.int32)
+    else:
+        query_start_loc_cpu = qo_indptr.to(torch.int32).cpu()
+    if qo_indptr.device.type == "cuda":
+        query_start_loc_gpu = qo_indptr.to(torch.int32)
+    else:
+        query_start_loc_gpu = query_start_loc_cpu.to(device, non_blocking=True)
+
+    if kv_page_indptr.device.type == "cpu":
+        kv_page_indptr_cpu = kv_page_indptr.to(torch.int32)
+    else:
+        kv_page_indptr_cpu = kv_page_indptr.to(torch.int32).cpu()
+    if kv_page_indices.device.type == "cpu":
+        kv_page_indices_cpu = kv_page_indices.to(torch.int32)
+    else:
+        kv_page_indices_cpu = kv_page_indices.to(torch.int32).cpu()
+
+    batch = int(query_start_loc_cpu.shape[0]) - 1
+    query_lens_cpu = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
+
+    # Decode rows = qlen == 1; prefill rows = qlen > 1. Pie never produces
+    # qlen == 0 on this path (an empty request would have been excluded
+    # from the batch by the runtime).
+    decode_mask = query_lens_cpu == 1
+    num_decodes = int(decode_mask.sum().item())
+    num_prefills = batch - num_decodes
+    num_decode_tokens = num_decodes  # qlen=1 each
+    num_prefill_tokens = int(query_lens_cpu.sum().item()) - num_decode_tokens
+
+    # Per-request state-slot index. Pie addresses mamba state by the
+    # request's first KV page id (see `kv_cache.py`); pull that off CPU
+    # CSR and ship a contiguous int32 tensor to GPU.
+    first_pages_cpu = kv_page_indices_cpu[kv_page_indptr_cpu[:-1]]
+    non_spec_state_indices_tensor = first_pages_cpu.to(
+        device, dtype=torch.int32, non_blocking=True
+    )
+
+    # `has_initial_state[req]` flags prefill rows whose recurrent state is
+    # carried over from a prior fire_batch (i.e., `num_computed_tokens >
+    # 0`). Decode rows always have non-zero state but the field is sliced
+    # to non-spec prefill rows only.
+    has_initial_state: torch.Tensor | None = None
+    nums_dict = None
+    batch_ptr = None
+    token_chunk_offset_ptr = None
+    chunk_indices: torch.Tensor | None = None
+    chunk_offsets: torch.Tensor | None = None
+    if num_prefills > 0:
+        has_initial_state = num_computed_tokens > 0
+        # vllm 0.20.0's compute_causal_conv1d_metadata signature:
+        # (query_start_loc_cpu, *, device=...). Earlier versions exposed
+        # a positional-only signature without `device`; both are tolerated
+        # via try/except so the bridge survives a vllm minor bump.
+        try:
+            nums_dict, batch_ptr, token_chunk_offset_ptr = compute_causal_conv1d_metadata(
+                query_start_loc_cpu, device=device
+            )
+        except TypeError:
+            nums_dict, batch_ptr, token_chunk_offset_ptr = compute_causal_conv1d_metadata(
+                query_start_loc_cpu
+            )
+
+        # FLA chunk indices/offsets — qwen3-next / qwen3.5-moe-specific.
+        # vllm 0.20.0 imports these from `model_executor.layers.fla.ops.index`.
+        try:
+            from vllm.model_executor.layers.fla.ops.index import (
+                prepare_chunk_indices,
+                prepare_chunk_offsets,
+            )
+            from vllm.model_executor.layers.fla.ops.utils import FLA_CHUNK_SIZE
+
+            chunk_indices = prepare_chunk_indices(
+                query_start_loc_cpu, FLA_CHUNK_SIZE
+            ).to(device, non_blocking=True)
+            chunk_offsets = prepare_chunk_offsets(
+                query_start_loc_cpu, FLA_CHUNK_SIZE
+            ).to(device, non_blocking=True)
+        except ImportError:
+            # Older vllm without FLA chunk pre-computation; the GDN forward
+            # falls back to its own on-the-fly path. Leave fields as None.
+            pass
+
+    return GDNAttentionMetadata(
+        num_prefills=num_prefills,
+        num_prefill_tokens=num_prefill_tokens,
+        num_decodes=num_decodes,
+        num_decode_tokens=num_decode_tokens,
+        num_spec_decodes=0,
+        num_spec_decode_tokens=0,
+        num_actual_tokens=num_actual_tokens,
+        has_initial_state=has_initial_state,
+        spec_query_start_loc=None,
+        non_spec_query_start_loc=query_start_loc_gpu,
+        spec_state_indices_tensor=None,
+        non_spec_state_indices_tensor=non_spec_state_indices_tensor,
+        spec_sequence_masks=None,
+        spec_token_indx=None,
+        non_spec_token_indx=None,
+        num_accepted_tokens=None,
+        chunk_indices=chunk_indices,
+        chunk_offsets=chunk_offsets,
+        nums_dict=nums_dict,
+        batch_ptr=batch_ptr,
+        token_chunk_offset_ptr=token_chunk_offset_ptr,
+    )

--- a/pie/src/pie_driver_vllm/kv_cache.py
+++ b/pie/src/pie_driver_vllm/kv_cache.py
@@ -1,23 +1,36 @@
 """KV cache allocation for the vllm driver.
 
-Pie cedes physical bytes to vllm: vllm's selected attention backend picks the
-KV layout (FlashAttn: `(2, num_blocks, block_size, kv_heads, head)`, FlashInfer:
+For pure-attention models (Llama, Qwen3, …) pie cedes physical bytes to
+vllm: the resolved attention backend picks the KV layout (FlashAttn:
+`(2, num_blocks, block_size, kv_heads, head)`, FlashInfer:
 `(num_blocks, 2, block_size, kv_heads, head)`, etc.). We allocate one raw
-buffer per attention layer, view it through the backend's preferred shape, and
-bind each `Attention` layer's `self.kv_cache` attribute via `bind_kv_cache`.
+buffer per attention layer, view it through the backend's preferred shape,
+and bind each `Attention` layer's `self.kv_cache` attribute via
+`bind_kv_cache`.
 
-Pie's Rust scheduler still owns block IDs — they're just the integer indices
-into the block dimension of these tensors. The CLI handshake already fixed
-`kv_page_size` (via vllm's preferred block size) before Rust bootstrap, so
-the per-block stride agrees on both sides.
+For hybrid Transformer + Mamba models (Qwen3.5-MoE, Qwen3-Next: alternating
+`full_attention` + `linear_attention` layers) we additionally allocate a
+per-mamba-layer `[conv_state, ssm_state]` pair sized to the same `num_blocks`
+as the attention pool. The state slot for a request is the request's first
+KV page id (see `gdn_metadata.build_gdn_metadata`); since pie's allocator
+gives a request at least one page, that page id doubles as the state slot
+index. We follow vllm's `mamba_cache_mode="none"` (1 block per request) for
+budget computation.
 
-Host pool: skipped in Phase 1.2 (returns empty). Phase 1.5+ will allocate it
-in vllm's chosen layout and add per-backend block-dim awareness to the swap
-RPCs.
+Pie's Rust scheduler still owns block IDs — they're integer indices into
+the block dimension of these tensors. The CLI handshake fixes `kv_page_size`
+(via vllm's preferred block size for attention layers) before Rust bootstrap.
+
+Host pool: skipped on the vllm driver (Phase 1.5+). For hybrid models we
+explicitly refuse a non-zero swap budget — the per-layer copy logic in
+`pie_driver/worker.py` doesn't know about mamba state, so swap-out would
+silently lose recurrent state. Capabilities advertises `supports_kv_fork=False`
+on hybrid so pie's runtime routes fork-using inferlets to a different driver.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import torch
@@ -28,73 +41,131 @@ if TYPE_CHECKING:
     from .loader import LoadedModel
 
 
+@dataclass
+class KVCacheLayout:
+    """Result of `allocate_and_bind_kv_cache` — splits attention vs mamba.
+
+    `attention_layers_in_order` is what pie's worker treats as
+    `engine.kv_cache_at_layer` (one tensor per attention layer, in
+    layer-index order). The existing `_handle_copy_d2d/h2d/d2h` handlers in
+    `pie_driver/worker.py` iterate this list to do per-page index_copy_;
+    they are correct for attention but cannot rebuild mamba's recurrent
+    state, hence `is_hybrid` propagates to capabilities and engine init.
+
+    `mamba_layers` is `(layer_name, conv_state, ssm_state)` tuples; the
+    state tensors are sized `(num_blocks, *spec.shapes[i])` so any pie page
+    id is a valid state-slot index. `mamba_layer.kv_cache = [conv, ssm]` is
+    set during binding so vllm's GatedDeltaNet `_forward` finds it via
+    `self.kv_cache[0]`/`[1]`.
+    """
+
+    attention_layers_in_order: list[torch.Tensor]
+    mamba_layers: list[tuple[str, torch.Tensor, torch.Tensor]]
+    is_hybrid: bool
+
+
 def _compute_num_blocks(
     *,
-    page_size_bytes: int,
-    num_layers: int,
+    attn_page_bytes: int,
+    num_attn_layers: int,
+    mamba_state_bytes: int,
+    num_mamba_layers: int,
     device: torch.device,
     gpu_mem_utilization: float,
 ) -> int:
-    """How many blocks we can afford given the post-load free memory budget.
+    """How many blocks the post-load free memory budget can afford.
 
-    We measure free memory *after* the model has been loaded, then take a
-    fraction (`gpu_mem_utilization`) of it as the KV budget. Total bytes per
-    block across all layers = `page_size_bytes * num_layers`.
+    For pure-attention: total_per_block = attn_page_bytes * num_attn_layers.
+    For hybrid: each "block" of the shared pool also costs one mamba state
+    slot per mamba layer (one (conv_state + ssm_state) per slot). Since
+    we size the mamba pool to num_blocks (so any page id is a valid state
+    slot), each block contributes mamba state bytes too.
     """
     free_bytes, _total = torch.cuda.mem_get_info(device)
     budget = int(free_bytes * gpu_mem_utilization)
-    per_block_total = page_size_bytes * num_layers
+    per_block_total = attn_page_bytes * num_attn_layers
+    per_block_total += mamba_state_bytes * num_mamba_layers
     if per_block_total <= 0:
         return 0
     num_blocks = budget // per_block_total
-    # We need at least a handful for the runtime to schedule anything; fail
-    # loudly if the budget is insufficient.
     if num_blocks < 8:
         raise RuntimeError(
             f"Insufficient KV cache budget: {budget} bytes / "
-            f"{per_block_total} bytes per block × {num_layers} layers = {num_blocks} blocks. "
-            f"Increase gpu_mem_utilization or reduce model size."
+            f"{per_block_total} bytes per block "
+            f"({num_attn_layers} attn + {num_mamba_layers} mamba) "
+            f"= {num_blocks} blocks. Increase gpu_mem_utilization or reduce model size."
         )
     return int(num_blocks)
+
+
+def _mamba_state_bytes_per_slot(spec) -> int:
+    """Bytes consumed by one mamba state slot across all states (conv+ssm).
+
+    Mirrors `MambaSpec.page_size_bytes` directly — vllm computes it the
+    same way for budget accounting in `_get_kv_cache_config_*`. We use this
+    rather than `page_size_bytes` to keep budget math explicit (and so a
+    future `page_size_padded` doesn't sneak into pie's per-block accounting
+    without us noticing).
+    """
+    from math import prod
+
+    total = 0
+    for shape, dtype in zip(spec.shapes, spec.dtypes):
+        total += prod(shape) * torch.empty((), dtype=dtype).element_size()
+    return total
 
 
 def allocate_and_bind_kv_cache(
     loaded: "LoadedModel",
     config: RuntimeConfig,
     driver_config,
-) -> list[torch.Tensor]:
-    """Allocate the GPU KV cache and bind it to every attention layer.
+) -> KVCacheLayout:
+    """Allocate the GPU KV cache and bind it to every attention/mamba layer.
 
-    Returns the per-layer tensor list in layer-index order, which pie's worker
-    treats as `engine.kv_cache_at_layer` for the swap RPCs.
+    Returns a `KVCacheLayout` with both the attention-only list (what pie's
+    worker iterates as `kv_cache_at_layer`) and the mamba state tensors
+    (held separately on the engine; not exposed to pie's per-page
+    copy handlers).
     """
     from ._vllm_compat import (
         AttentionLayerBase,
+        FullAttentionSpec,
+        KVCacheSpec,
+        MambaSpec,
         bind_kv_cache,
         extract_layer_index,
+        get_mamba_base,
         set_current_vllm_config,
     )
+
+    MambaBase = get_mamba_base()
 
     vllm_config = loaded.vllm_config
     fc = vllm_config.compilation_config.static_forward_context
 
+    # Partition `static_forward_context` into attention layers (KV pool)
+    # and mamba layers (recurrent state). Both kinds register themselves in
+    # this dict via their __init__ — see `Attention` and `MambaBase`
+    # subclasses (Qwen3NextGatedDeltaNet, etc.).
     attn_layers: dict[str, "AttentionLayerBase"] = {
         name: layer for name, layer in fc.items()
         if isinstance(layer, AttentionLayerBase)
     }
+    mamba_layers: dict[str, MambaBase] = {
+        name: layer for name, layer in fc.items()
+        if isinstance(layer, MambaBase)
+    }
 
-    if not attn_layers:
-        raise RuntimeError("No attention layers found in vllm forward context.")
+    if not attn_layers and not mamba_layers:
+        raise RuntimeError(
+            "No attention or mamba layers found in vllm forward context."
+        )
 
-    # Resolve every layer's spec up front so we can detect heterogeneous
-    # layouts (hybrid Transformer + Mamba/GDN models like Qwen3.5 / Qwen3-Next)
-    # and refuse them with a clear error instead of a downstream AttributeError
-    # on `MambaSpec.num_kv_heads`. Hybrid support requires a parallel
-    # state-cache allocator + a GDN attention-metadata builder inside this
-    # driver — tracked as the layer-3 follow-up to pie-agents#102.
-    from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheSpec
-
-    layer_specs: dict[str, KVCacheSpec] = {}
+    # Resolve every attention layer's spec up front — pie only handles
+    # `FullAttentionSpec`. Sliding-window / chunked / MLA / cross-attention
+    # remain unsupported (the existing FlashInfer metadata path doesn't
+    # carry their fields). Mamba spec is collected separately below.
+    layer_specs: dict[str, "KVCacheSpec"] = {}
     with set_current_vllm_config(vllm_config):
         for name, layer in attn_layers.items():
             layer_specs[name] = layer.get_kv_cache_spec(vllm_config)
@@ -105,44 +176,92 @@ def allocate_and_bind_kv_cache(
         if not isinstance(spec, FullAttentionSpec)
     }
     if non_full_attention:
-        # Spell out the exact spec mix so the error survives in logs and
-        # points the reader at the right follow-up.
         sample = ", ".join(f"{n}={t}" for n, t in list(non_full_attention.items())[:5])
         raise NotImplementedError(
             f"pie_driver_vllm only supports models whose attention layers all "
             f"return FullAttentionSpec; got {len(non_full_attention)} layer(s) "
             f"with a different spec ({sample}{'...' if len(non_full_attention) > 5 else ''}). "
-            f"Hybrid Transformer + Mamba/GDN models (e.g. Qwen3.5 / Qwen3-Next "
-            f"with model_type='qwen3_5_moe' or 'qwen3_next') need a separate "
-            f"per-spec allocator and a GDN attention-metadata builder inside "
-            f"pie_driver_vllm — not yet implemented. Use the cuda_native or "
-            f"portable driver for these models, or track pie-agents#102 layer 3."
+            f"Sliding-window / chunked / MLA / cross-attention need a separate "
+            f"per-spec metadata path — not yet implemented."
         )
 
-    first_spec = next(iter(layer_specs.values()))
-    page_size_bytes = first_spec.page_size_bytes
-    block_size = first_spec.block_size
-    num_kv_heads = first_spec.num_kv_heads
-    head_size = first_spec.head_size
-    spec_dtype = first_spec.dtype
+    is_hybrid = bool(mamba_layers)
+
+    # On hybrid, swap is unsupported (the existing copy_h2d/d2h handlers
+    # in pie_driver/worker.py only iterate `kv_cache_at_layer` and have no
+    # way to migrate mamba state). Refuse a non-zero swap budget upfront so
+    # the user sees a clear error instead of silent corruption mid-swap.
+    if is_hybrid and config.swap_budget_bytes > 0:
+        raise NotImplementedError(
+            "vllm driver does not support KV swap (CPU offload) on hybrid "
+            "Transformer+Mamba models. Set `swap_budget_bytes=0` / "
+            "`cpu_mem_budget_in_gb=0` for these models."
+        )
+
+    # Resolve mamba spec (one per mamba layer; in current Qwen3-Next /
+    # Qwen3.5-MoE all mamba layers share the same shape, but we don't
+    # assume that — each layer's spec is queried individually).
+    mamba_specs: dict[str, "MambaSpec"] = {}
+    with set_current_vllm_config(vllm_config):
+        for name, layer in mamba_layers.items():
+            spec = MambaSpec(
+                shapes=layer.get_state_shape(),
+                dtypes=layer.get_state_dtype(),
+                # block_size for mamba is irrelevant in our addressing scheme
+                # (we use page id as state slot, not block_size-token chunks);
+                # pick max_model_len to match vllm's "1 block per request"
+                # convention for "none" mode.
+                block_size=int(vllm_config.model_config.max_model_len),
+                mamba_type=layer.mamba_type,
+                num_speculative_blocks=0,
+            )
+            mamba_specs[name] = spec
+
+    # Page bytes for attention layers (first FullAttentionSpec; merged
+    # specs guarantee they all match).
+    if attn_layers:
+        first_attn_spec = next(iter(layer_specs.values()))
+        attn_page_bytes = first_attn_spec.page_size_bytes
+        block_size = first_attn_spec.block_size
+        num_kv_heads = first_attn_spec.num_kv_heads
+        head_size = first_attn_spec.head_size
+        spec_dtype = first_attn_spec.dtype
+    else:
+        # Pure-mamba model — no attention pool. Not in pie's smoke test
+        # target, but the math falls through cleanly.
+        attn_page_bytes = 0
+        block_size = 0
+        num_kv_heads = 0
+        head_size = 0
+        spec_dtype = None
+
+    # Mamba state bytes per slot (sum over all states). All mamba layers
+    # are assumed to share the same per-slot byte cost in current Qwen3
+    # variants; if they ever diverge, we'd need to size each pool
+    # independently.
+    if mamba_layers:
+        mamba_state_bytes = max(
+            _mamba_state_bytes_per_slot(spec) for spec in mamba_specs.values()
+        )
+    else:
+        mamba_state_bytes = 0
 
     device = torch.device(config.device)
     num_blocks = _compute_num_blocks(
-        page_size_bytes=page_size_bytes,
-        num_layers=len(attn_layers),
+        attn_page_bytes=attn_page_bytes,
+        num_attn_layers=len(attn_layers),
+        mamba_state_bytes=mamba_state_bytes,
+        num_mamba_layers=len(mamba_layers),
         device=device,
         gpu_mem_utilization=driver_config.gpu_memory_utilization,
     )
     config.max_num_kv_pages = num_blocks
-    # vLLM's FlexAttention metadata builder asserts `cache_config.num_gpu_blocks`
-    # is set; pie manages its own KV pool, so we sync the count over here so
-    # backends that consult vllm_config see the right value.
+    # vLLM's metadata builders read num_gpu_blocks off cache_config — pie
+    # manages its own pool but we sync the count so anything reading vllm's
+    # config sees the right value.
     vllm_config.cache_config.num_gpu_blocks = num_blocks
 
-    # For each layer, allocate a raw int8 buffer and view it through the
-    # backend's preferred shape. We don't pool buffers across layers (vllm's
-    # runner does for memory locality, but with one tensor per layer we keep
-    # pie's swap RPC math simple).
+    # ── Allocate attention KV ────────────────────────────────────────────
     kv_caches: dict[str, torch.Tensor] = {}
     layer_to_index: dict[str, int] = {}
 
@@ -155,7 +274,6 @@ def allocate_and_bind_kv_cache(
             head_size=head_size,
         )
 
-        # Stride order (some backends want a permutation of the canonical shape).
         try:
             with set_current_vllm_config(vllm_config):
                 stride_order = backend.get_kv_cache_stride_order()
@@ -165,35 +283,64 @@ def allocate_and_bind_kv_cache(
         permuted_shape = tuple(kv_shape[i] for i in stride_order)
         inv_order = [stride_order.index(i) for i in range(len(stride_order))]
 
-        total_bytes = num_blocks * page_size_bytes
+        total_bytes = num_blocks * attn_page_bytes
         raw = torch.zeros(total_bytes, dtype=torch.int8, device=device)
-        # view int8 → spec dtype → backend shape → permute back to canonical
         kv = raw.view(spec_dtype).view(permuted_shape).permute(*inv_order)
         kv_caches[layer_name] = kv
         layer_to_index[layer_name] = extract_layer_index(layer_name)
 
-    # bind_kv_cache writes `layer.kv_cache = tensor` for every attention layer
-    # and fills `runner_kv_caches` in layer-index order (which we want).
+    # `bind_kv_cache` writes `attn_layer.kv_cache = tensor` for every
+    # attention layer and fills `runner_kv_caches` in layer-index order.
     runner_kv_caches: list[torch.Tensor] = []
-    bind_kv_cache(kv_caches, fc, runner_kv_caches)
+    if attn_layers:
+        bind_kv_cache(kv_caches, fc, runner_kv_caches)
 
-    return runner_kv_caches
+    # ── Allocate mamba state pools ───────────────────────────────────────
+    mamba_layers_out: list[tuple[str, torch.Tensor, torch.Tensor]] = []
+    for layer_name, spec in mamba_specs.items():
+        # Shape contract per `_reshape_kv_cache_tensors` (gpu_model_runner.py):
+        # state_tensor[i] has shape (num_blocks, *spec.shapes[i]) and
+        # dtype spec.dtypes[i]. Allocated as separate tensors here (no
+        # shared raw buffer) since the mamba kernel reads each state by its
+        # own dtype and stride; pie doesn't gain anything from packing.
+        states = []
+        for shape, dtype in zip(spec.shapes, spec.dtypes):
+            t = torch.zeros((num_blocks, *shape), dtype=dtype, device=device)
+            states.append(t)
+        # vllm's GDN `_forward` reads `self.kv_cache[0]` (conv) and `[1]`
+        # (ssm) without an outer virtual_engine wrapping (see
+        # `vllm/model_executor/layers/mamba/gdn_linear_attn.py:794-802`).
+        # bind_kv_cache only handles attention; assign directly.
+        fc[layer_name].kv_cache = states
+        # MambaSpec orders shapes as (conv, ssm) per
+        # MambaStateShapeCalculator.gated_delta_net_state_shape; assert
+        # length so a future spec change fails loud rather than miswiring.
+        if len(states) != 2:
+            raise NotImplementedError(
+                f"Expected MambaSpec with 2 states (conv, ssm); got {len(states)} "
+                f"for layer {layer_name!r} (mamba_type={spec.mamba_type!r})."
+            )
+        mamba_layers_out.append((layer_name, states[0], states[1]))
+
+    return KVCacheLayout(
+        attention_layers_in_order=runner_kv_caches,
+        mamba_layers=mamba_layers_out,
+        is_hybrid=is_hybrid,
+    )
 
 
 def allocate_host_pool(
     gpu_kv: list[torch.Tensor],
     swap_budget_bytes: int,
 ) -> tuple[list[torch.Tensor], int]:
-    """CPU swap pool. Skipped in Phase 1.2.
+    """CPU swap pool. Skipped on the vllm driver (Phase 1.5).
 
-    Phase 1.5+ will mirror vllm's GPU layout (block dim depends on backend),
-    pin where supported (CUDA / ROCm / XPU; not TPU), and update pie's swap
-    RPCs to be block-dim aware.
+    Pie's per-layer copy_h2d/d2h handlers iterate `kv_cache_at_layer` and
+    have no path for mamba state migration, so even a future host-pool
+    implementation must be hybrid-aware before we re-enable it.
     """
     if swap_budget_bytes <= 0 or not gpu_kv:
         return [], 0
-    # Until per-backend block-dim awareness is wired, refuse non-zero budgets
-    # rather than silently producing wrong tokens after a swap.
     raise NotImplementedError(
         "CPU swap pool not yet supported on the vllm driver (Phase 1.5). "
         "Set swap_budget_bytes=0 / cpu_mem_budget_in_gb=0 for now."

--- a/pie/src/pie_driver_vllm/kv_cache.py
+++ b/pie/src/pie_driver_vllm/kv_cache.py
@@ -147,13 +147,21 @@ def allocate_and_bind_kv_cache(
     # and mamba layers (recurrent state). Both kinds register themselves in
     # this dict via their __init__ — see `Attention` and `MambaBase`
     # subclasses (Qwen3NextGatedDeltaNet, etc.).
-    attn_layers: dict[str, "AttentionLayerBase"] = {
-        name: layer for name, layer in fc.items()
-        if isinstance(layer, AttentionLayerBase)
-    }
+    #
+    # NB: in vllm 0.20.0 `MambaBase` extends `AttentionLayerBase` (so
+    # GDN/Mamba layers pass the AttentionLayerBase isinstance check too).
+    # The mamba check has to come first, and the attention list must
+    # explicitly EXCLUDE mamba layers — otherwise we'd treat mamba layers
+    # as attention and call `get_kv_cache_spec` on them, which raises
+    # MambaSpec downstream of the attention-only flow.
     mamba_layers: dict[str, MambaBase] = {
         name: layer for name, layer in fc.items()
         if isinstance(layer, MambaBase)
+    }
+    attn_layers: dict[str, "AttentionLayerBase"] = {
+        name: layer for name, layer in fc.items()
+        if isinstance(layer, AttentionLayerBase)
+        and not isinstance(layer, MambaBase)
     }
 
     if not attn_layers and not mamba_layers:

--- a/pie/src/pie_driver_vllm/loader.py
+++ b/pie/src/pie_driver_vllm/loader.py
@@ -362,6 +362,25 @@ def load_vllm_model(
         _log("Bringing up vllm parallel state", "DEBUG")
         _ensure_vllm_distributed(vllm_config, rank=config.rank, local_rank=local_rank)
 
+        # vllm 0.20.0 introduced a process-wide WorkspaceManager that
+        # ALL transformer-layer ops fetch scratch buffers from
+        # (`current_workspace_manager().get_simultaneous(...)`). vllm's
+        # GPUModelRunner.__init__ calls `init_workspace_manager(device)`
+        # before any forward; pie drives the model directly and doesn't
+        # construct GPUModelRunner, so we have to initialize it here. If
+        # an older vllm (no module / no symbol) is in use, swallow the
+        # ImportError so the driver still works on pre-0.20.0 stacks.
+        try:
+            from vllm.v1.worker.workspace import (
+                init_workspace_manager,
+                is_workspace_manager_initialized,
+            )
+            if not is_workspace_manager_initialized():
+                _log("Initializing vllm WorkspaceManager", "DEBUG")
+                init_workspace_manager(torch.device(device_str))
+        except ImportError:
+            pass
+
         _log(f"Loading model weights ({config.hf_repo})", "INFO")
         loader = get_model_loader(vllm_config.load_config)
         model = loader.load_model(

--- a/pie/src/pie_driver_vllm/loader.py
+++ b/pie/src/pie_driver_vllm/loader.py
@@ -7,6 +7,7 @@ This module owns the "what kind of vllm model are we running" decisions so
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any
 
@@ -14,6 +15,8 @@ import torch
 import torch.distributed as dist
 
 from pie_driver.config import RuntimeConfig
+
+logger = logging.getLogger(__name__)
 
 
 # Map pie's RuntimeConfig.activation_dtype (torch.dtype) to vllm's string form.
@@ -182,14 +185,13 @@ def _build_vllm_config(config: RuntimeConfig, driver_config) -> Any:
             # place (it is not frozen); capabilities() will return this value.
             if driver_config.max_num_batched_tokens is None:
                 driver_config.max_num_batched_tokens = 2048
-            print(
-                f"[pie_driver_vllm] setting vllm max_num_batched_tokens={mpe} "
-                f"(from HF max_position_embeddings) for compile-range coverage; "
-                f"pinning pie BatchAccumulator cap to "
-                f"{driver_config.max_num_batched_tokens} so per-batch memory stays bounded. "
-                f"Set [model.X.driver.vllm].max_num_batched_tokens explicitly to "
-                f"override either.",
-                flush=True,
+            logger.info(
+                "setting vllm max_num_batched_tokens=%d "
+                "(from HF max_position_embeddings) for compile-range coverage; "
+                "pinning pie BatchAccumulator cap to %d so per-batch memory stays bounded. "
+                "Set [model.X.driver.vllm].max_num_batched_tokens explicitly to override either.",
+                mpe,
+                driver_config.max_num_batched_tokens,
             )
         else:
             # Probe failed (offline cache miss, malformed config.json, network
@@ -202,17 +204,17 @@ def _build_vllm_config(config: RuntimeConfig, driver_config) -> Any:
             # `max_model_len > 2048`, but only after the operator sees what
             # looks like a regression in this PR's fix. Emit a loud,
             # grep-able warning so it's not silent.
-            print(
-                f"[pie_driver_vllm] WARNING: HF max_position_embeddings probe "
-                f"for {config.hf_repo!r} failed ({probe_err!r}); "
-                f"engine_kwargs['max_num_batched_tokens'] left unset. "
-                f"vllm will use its chat-model default (2048) and the "
-                f"post-create_engine_config backstop will widen the compile "
-                f"range based on model_config.max_model_len after construction. "
-                f"If you see Shape:N out-of-(1,2048) crashes after this, the "
-                f"backstop also failed — re-check vllm version and pie's "
-                f"_set_compile_ranges integration.",
-                flush=True,
+            logger.warning(
+                "HF max_position_embeddings probe for %r failed (%r); "
+                "engine_kwargs['max_num_batched_tokens'] left unset. "
+                "vllm will use its chat-model default (2048) and the "
+                "post-create_engine_config backstop will widen the compile "
+                "range based on model_config.max_model_len after construction. "
+                "If you see Shape:N out-of-(1,2048) crashes after this, the "
+                "backstop also failed — re-check vllm version and pie's "
+                "_set_compile_ranges integration.",
+                config.hf_repo,
+                probe_err,
             )
 
     args = EngineArgs(**engine_kwargs)
@@ -246,11 +248,11 @@ def _build_vllm_config(config: RuntimeConfig, driver_config) -> Any:
         if getattr(sc, "max_num_prefill_tokens", None) == old:
             sc.max_num_prefill_tokens = mc.max_model_len
         vllm_config._set_compile_ranges()
-        print(
-            f"[pie_driver_vllm] backstop raised max_num_batched_tokens "
-            f"{old} -> {mc.max_model_len} (resolved max_model_len exceeded "
-            f"the pre-construction estimate from HF config).",
-            flush=True,
+        logger.info(
+            "backstop raised max_num_batched_tokens %d -> %d "
+            "(resolved max_model_len exceeded the pre-construction estimate from HF config).",
+            old,
+            mc.max_model_len,
         )
 
     # Decode-side cudagraph (Lever 5, ticket #100). Pie drives the model

--- a/pie/src/pie_driver_vllm/loader.py
+++ b/pie/src/pie_driver_vllm/loader.py
@@ -126,8 +126,96 @@ def _build_vllm_config(config: RuntimeConfig, driver_config) -> Any:
     if not driver_config.enforce_eager and driver_config.attention_backend is None:
         engine_kwargs["attention_backend"] = "FLASHINFER"
 
+    # vllm's torch.compile + V1 attention backends (FlashInfer, FlashAttn, …)
+    # size their compile ranges and per-call CPU/GPU buffers to
+    # `scheduler_config.max_num_batched_tokens`. vllm defaults this to 2048
+    # for chat models with chunked prefill enabled — but pie drives the model
+    # outside vllm's GPUModelRunner, so its scheduler chunking does NOT
+    # constrain pie's batches. Pie can fire any single-request prefill up to
+    # the model's max sequence length, and a 2052-token prefill against a
+    # (1, 2048) compile range trips:
+    #   AssertionError: Shape: N out of considered ranges: [(1, 2048)]
+    #     in vllm/compilation/piecewise_backend.py
+    # On the FlashInfer side the same misconfiguration cascades into a
+    # `max() iterable argument is empty` from `flashinfer/decode.py:plan` once
+    # subsequent calls find FlashInfer's persistent metadata corrupted.
+    #
+    # Pie sets vllm's compile ceiling to the HF model's max position
+    # embeddings so any single-request prefill is within compile range. We
+    # probe HF config directly (rather than letting vllm resolve max_model_len
+    # then mutate) because vllm derives `compile_ranges_endpoints` inside
+    # `VllmConfig.__post_init__` against the scheduler value at that time;
+    # setting it before EngineArgs avoids touching vllm's private
+    # `_set_compile_ranges` after the fact.
+    #
+    # Important: we do NOT also raise pie's BatchAccumulator cap. `engine.capabilities()`
+    # reads `driver_config.max_num_batched_tokens` first; only when that's None
+    # does it fall back to `vc.scheduler_config.max_num_batched_tokens`. If we let
+    # capabilities fall through to the raised vllm value, pie's BatchAccumulator
+    # would also widen to max_position_embeddings — bringing 16-context bursts
+    # into single 32K-token forwards and OOM'ing at activation time. Pin the
+    # driver-side cap to vllm's chat-model default (2048) so pie's BatchAccumulator
+    # behaves the same as before this change. Memory cost is therefore bounded
+    # to the extra inductor compile range, which is one extra graph bucket.
+    # Users who want bigger pie batches set `[model.X.driver.vllm].max_num_batched_tokens`
+    # explicitly; we respect that override.
+    if engine_kwargs.get("max_num_batched_tokens") is None:
+        try:
+            from transformers import AutoConfig
+
+            hf_cfg = AutoConfig.from_pretrained(
+                config.hf_repo, trust_remote_code=True, cache_dir=config.cache_dir
+            )
+            # max_position_embeddings is the universal field. Some models also
+            # expose `model_max_length` or rope_scaling-extended context;
+            # max_position_embeddings is the safe lower bound that always
+            # exists for HF causal LMs.
+            mpe = int(getattr(hf_cfg, "max_position_embeddings", 0) or 0)
+        except Exception as _e:
+            mpe = 0
+        if mpe > 0:
+            engine_kwargs["max_num_batched_tokens"] = mpe
+            # Pin pie's BatchAccumulator cap to vllm's pre-fix chat-model default
+            # so memory pressure does not regress. driver_config is mutated in
+            # place (it is not frozen); capabilities() will return this value.
+            if driver_config.max_num_batched_tokens is None:
+                driver_config.max_num_batched_tokens = 2048
+            print(
+                f"[pie_driver_vllm] setting vllm max_num_batched_tokens={mpe} "
+                f"(from HF max_position_embeddings) for compile-range coverage; "
+                f"pinning pie BatchAccumulator cap to "
+                f"{driver_config.max_num_batched_tokens} so per-batch memory stays bounded. "
+                f"Set [model.X.driver.vllm].max_num_batched_tokens explicitly to "
+                f"override either.",
+                flush=True,
+            )
+
     args = EngineArgs(**engine_kwargs)
     vllm_config = args.create_engine_config()
+
+    # Defensive backstop: if vllm's resolved `max_model_len` exceeds the
+    # value we passed in (e.g. rope scaling extends context beyond HF's
+    # max_position_embeddings, or the user lowered max_num_batched_tokens
+    # explicitly), the compile range can still be too narrow. Raise the
+    # scheduler budget and recompute compile ranges. `_set_compile_ranges`
+    # is internal to vllm but the only documented path that re-derives
+    # compile_ranges_endpoints from scheduler_config without rebuilding
+    # the whole VllmConfig.
+    sc = vllm_config.scheduler_config
+    mc = vllm_config.model_config
+    if sc.max_num_batched_tokens < mc.max_model_len:
+        old = sc.max_num_batched_tokens
+        sc.max_num_batched_tokens = mc.max_model_len
+        if getattr(sc, "max_num_prefill_tokens", None) == old:
+            sc.max_num_prefill_tokens = mc.max_model_len
+        if hasattr(vllm_config, "_set_compile_ranges"):
+            vllm_config._set_compile_ranges()
+        print(
+            f"[pie_driver_vllm] backstop raised max_num_batched_tokens "
+            f"{old} -> {mc.max_model_len} (resolved max_model_len exceeded "
+            f"the pre-construction estimate from HF config).",
+            flush=True,
+        )
 
     # Decode-side cudagraph (Lever 5, ticket #100). Pie drives the model
     # outside vllm's GPUModelRunner, so vllm's auto-resolution of

--- a/pie/src/pie_driver_vllm/loader.py
+++ b/pie/src/pie_driver_vllm/loader.py
@@ -160,6 +160,8 @@ def _build_vllm_config(config: RuntimeConfig, driver_config) -> Any:
     # Users who want bigger pie batches set `[model.X.driver.vllm].max_num_batched_tokens`
     # explicitly; we respect that override.
     if engine_kwargs.get("max_num_batched_tokens") is None:
+        mpe = 0
+        probe_err: Exception | None = None
         try:
             from transformers import AutoConfig
 
@@ -172,7 +174,7 @@ def _build_vllm_config(config: RuntimeConfig, driver_config) -> Any:
             # exists for HF causal LMs.
             mpe = int(getattr(hf_cfg, "max_position_embeddings", 0) or 0)
         except Exception as _e:
-            mpe = 0
+            probe_err = _e
         if mpe > 0:
             engine_kwargs["max_num_batched_tokens"] = mpe
             # Pin pie's BatchAccumulator cap to vllm's pre-fix chat-model default
@@ -189,6 +191,29 @@ def _build_vllm_config(config: RuntimeConfig, driver_config) -> Any:
                 f"override either.",
                 flush=True,
             )
+        else:
+            # Probe failed (offline cache miss, malformed config.json, network
+            # error with cache_dir unset, transformers version skew on
+            # trust_remote_code archs, …). Without engine_kwargs[…] set,
+            # vllm derives compile_ranges_endpoints against its 2048 chat
+            # default and any single-request prefill > 2048 trips the
+            # piecewise_backend assertion. The post-`create_engine_config`
+            # backstop below catches this for all models with
+            # `max_model_len > 2048`, but only after the operator sees what
+            # looks like a regression in this PR's fix. Emit a loud,
+            # grep-able warning so it's not silent.
+            print(
+                f"[pie_driver_vllm] WARNING: HF max_position_embeddings probe "
+                f"for {config.hf_repo!r} failed ({probe_err!r}); "
+                f"engine_kwargs['max_num_batched_tokens'] left unset. "
+                f"vllm will use its chat-model default (2048) and the "
+                f"post-create_engine_config backstop will widen the compile "
+                f"range based on model_config.max_model_len after construction. "
+                f"If you see Shape:N out-of-(1,2048) crashes after this, the "
+                f"backstop also failed — re-check vllm version and pie's "
+                f"_set_compile_ranges integration.",
+                flush=True,
+            )
 
     args = EngineArgs(**engine_kwargs)
     vllm_config = args.create_engine_config()
@@ -200,16 +225,27 @@ def _build_vllm_config(config: RuntimeConfig, driver_config) -> Any:
     # scheduler budget and recompute compile ranges. `_set_compile_ranges`
     # is internal to vllm but the only documented path that re-derives
     # compile_ranges_endpoints from scheduler_config without rebuilding
-    # the whole VllmConfig.
+    # the whole VllmConfig — if a vllm version refactor renames or removes
+    # this helper, fail loudly at engine init rather than silently leaving
+    # the compile range narrow (would resurface the Shape:N crash this
+    # branch was added to fix).
     sc = vllm_config.scheduler_config
     mc = vllm_config.model_config
     if sc.max_num_batched_tokens < mc.max_model_len:
+        if not hasattr(vllm_config, "_set_compile_ranges"):
+            raise RuntimeError(
+                "pie_driver_vllm: VllmConfig is missing the private "
+                "_set_compile_ranges helper that this loader relies on to "
+                "re-derive compile_ranges_endpoints after raising "
+                "scheduler_config.max_num_batched_tokens. The installed vllm "
+                "version is incompatible with pie's compile-range backstop. "
+                "Pin a compatible vllm or update pie/pie/src/pie_driver_vllm/loader.py."
+            )
         old = sc.max_num_batched_tokens
         sc.max_num_batched_tokens = mc.max_model_len
         if getattr(sc, "max_num_prefill_tokens", None) == old:
             sc.max_num_prefill_tokens = mc.max_model_len
-        if hasattr(vllm_config, "_set_compile_ranges"):
-            vllm_config._set_compile_ranges()
+        vllm_config._set_compile_ranges()
         print(
             f"[pie_driver_vllm] backstop raised max_num_batched_tokens "
             f"{old} -> {mc.max_model_len} (resolved max_model_len exceeded "

--- a/runtime/src/api/inference.rs
+++ b/runtime/src/api/inference.rs
@@ -12,17 +12,33 @@ use crate::inference::structured::json_schema::{builtin_json_grammar, json_schem
 use crate::inference::structured::regex::regex_to_grammar;
 use crate::inference::structured::compiled_grammar::CompiledGrammar;
 use crate::inference::structured::matcher::GrammarMatcher;
+use crate::context::pagestore::compute_last_page_len;
 use crate::{context, inference};
 use anyhow::Result;
 use std::collections::HashMap;
 use std::iter;
 use std::mem::take;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use tokio::sync::oneshot;
 use wasmtime::component::Resource;
 use wasmtime_wasi::WasiView;
 use wasmtime_wasi::async_trait;
 use wasmtime_wasi::p2::{DynPollable, Pollable, subscribe};
+
+/// Chunked-prefill chunk size in tokens. 0 disables chunking.
+///
+/// Read from env var `PIE_CHUNKED_PREFILL_SIZE` once at first access. Default
+/// 2048 matches vllm's `max_num_batched_tokens` default. Set to 0 to disable
+/// (legacy single-submit prefill).
+fn chunked_prefill_size() -> usize {
+    static CACHED: OnceLock<usize> = OnceLock::new();
+    *CACHED.get_or_init(|| {
+        std::env::var("PIE_CHUNKED_PREFILL_SIZE")
+            .ok()
+            .and_then(|s| s.trim().parse::<usize>().ok())
+            .unwrap_or(2048)
+    })
+}
 
 #[derive(Debug)]
 pub struct ForwardPass {
@@ -426,25 +442,144 @@ impl pie::core::inference::HostForwardPass for InstanceState {
             return Ok(Err(msg));
         }
 
-        let request = ForwardPassRequest {
-            context_id,
-            tokens,
-            positions,
-            speculative_tokens,
-            speculative_positions,
-            output_speculative_tokens,
-            masks,
-            has_user_mask,
-            logit_mask,
-            sampling_indices,
-            samplers,
-            adapter_id,
-            adapter_seed,
+        // Step 5: Submit to inference service (inference actor just dispatches — never blocks).
+        //
+        // Chunked-prefill path: when the request would mega-batch a long
+        // prefill (>chunk_size tokens) we split it into N sequential
+        // sub-requests so concurrent decoders from other contexts can
+        // interleave between chunks. Mirrors vllm's chunked-prefill admission
+        // shape; the wall-clock win comes from decode interleaving, not from
+        // a faster single forward pass. See restore.rs:288+ for the prior-art
+        // sequential-submit pattern this code parallels.
+        //
+        // Guards: `has_user_mask` / `speculative_tokens` would need
+        // mask-slicing or spec-shape rewrite to chunk safely — skipped.
+        // `sampling_indices` outside the last chunk would need per-chunk
+        // sampler emission — also skipped (rare for normal generate).
+        let device_idx = device_id as usize;
+        let chunk_size = chunked_prefill_size();
+        let last_chunk_start = if chunk_size > 0 && num_input_tokens > 0 {
+            ((num_input_tokens - 1) / chunk_size) * chunk_size
+        } else {
+            0
+        };
+        let can_chunk = chunk_size > 0
+            && num_input_tokens > chunk_size
+            && !has_user_mask
+            && speculative_tokens.is_empty()
+            && sampling_indices
+                .iter()
+                .all(|&i| (i as usize) >= last_chunk_start);
+
+        let submit_result: Result<ForwardPassOutput> = if can_chunk {
+            // Borrow the per-chunk slices off the originals; consume the
+            // tail-only fields (samplers, sampling_indices, logit_mask) into
+            // the last chunk's request so we don't allocate them N times.
+            let n_chunks = (num_input_tokens + chunk_size - 1) / chunk_size;
+            let mut last_output: Option<ForwardPassOutput> = None;
+            let mut sampling_indices_opt = Some(sampling_indices);
+            let mut samplers_opt = Some(samplers);
+            let mut logit_mask_opt = logit_mask;
+            let mut chunk_err: Option<String> = None;
+
+            for ci in 0..n_chunks {
+                let start = ci * chunk_size;
+                let end = ((ci + 1) * chunk_size).min(num_input_tokens);
+                let is_last = ci == n_chunks - 1;
+
+                let chunk_tokens = tokens[start..end].to_vec();
+                let chunk_positions = positions[start..end].to_vec();
+                let chunk_masks = masks[start..end].to_vec();
+
+                let total_kv_after = kv_len + end as u32;
+                let num_pages_for_chunk =
+                    ((total_kv_after + page_size - 1) / page_size) as usize;
+                let chunk_phys = physical_page_ids[..num_pages_for_chunk].to_vec();
+                let chunk_last_page_len = compute_last_page_len(
+                    total_kv_after,
+                    num_pages_for_chunk as u32,
+                    page_size,
+                );
+
+                let (chunk_sampling_indices, chunk_samplers, chunk_logit_mask) = if is_last {
+                    let raw_indices = sampling_indices_opt.take().unwrap_or_default();
+                    let remapped: Vec<u32> = raw_indices
+                        .iter()
+                        .map(|&i| i - start as u32)
+                        .collect();
+                    (
+                        remapped,
+                        samplers_opt.take().unwrap_or_default(),
+                        logit_mask_opt.take(),
+                    )
+                } else {
+                    (Vec::new(), Vec::new(), None)
+                };
+
+                let chunk_request = ForwardPassRequest {
+                    context_id,
+                    tokens: chunk_tokens,
+                    positions: chunk_positions,
+                    speculative_tokens: Vec::new(),
+                    speculative_positions: Vec::new(),
+                    output_speculative_tokens: false,
+                    masks: chunk_masks,
+                    has_user_mask: false,
+                    logit_mask: chunk_logit_mask,
+                    sampling_indices: chunk_sampling_indices,
+                    samplers: chunk_samplers,
+                    adapter_id,
+                    adapter_seed,
+                };
+
+                match inference::submit(
+                    model_id, chunk_request, device_idx, chunk_phys, chunk_last_page_len,
+                )
+                .await
+                {
+                    Ok(output) => {
+                        if is_last {
+                            last_output = Some(output);
+                        }
+                        // intermediate-chunk outputs (no samplers) are empty by
+                        // construction and intentionally discarded.
+                    }
+                    Err(e) => {
+                        chunk_err = Some(format!(
+                            "chunk {}/{}: {e:#}", ci + 1, n_chunks
+                        ));
+                        break;
+                    }
+                }
+            }
+
+            match (chunk_err, last_output) {
+                (Some(msg), _) => Err(anyhow::anyhow!(msg)),
+                (None, Some(out)) => Ok(out),
+                (None, None) => Err(anyhow::anyhow!(
+                    "chunked prefill produced no output (n_chunks={n_chunks})"
+                )),
+            }
+        } else {
+            let request = ForwardPassRequest {
+                context_id,
+                tokens,
+                positions,
+                speculative_tokens,
+                speculative_positions,
+                output_speculative_tokens,
+                masks,
+                has_user_mask,
+                logit_mask,
+                sampling_indices,
+                samplers,
+                adapter_id,
+                adapter_seed,
+            };
+            inference::submit(model_id, request, device_idx, physical_page_ids.clone(), last_page_len).await
         };
 
-        // Step 5: Submit to inference service (inference actor just dispatches — never blocks)
-        let device_idx = device_id as usize;
-        match inference::submit(model_id, request, device_idx, physical_page_ids.clone(), last_page_len).await {
+        match submit_result {
             Ok(output) => {
                 // Diagnostic: log prefill metadata to trace corruption
                 // if num_input_tokens > 1 {


### PR DESCRIPTION
## Summary
Adds hybrid Transformer + Mamba KV-cache support to `pie_driver_vllm`, unblocking `qwen3_5_moe` (Qwen3.5-MoE) and `qwen3_next` (Qwen3-Next) on pie's vllm backend. Follows #349 — with that change loads stop at a clear `NotImplementedError` for these models; this PR makes them actually run.

All code-path work is in `pie/src/pie_driver_vllm/` plus a 10-line additive `supports_kv_fork` capability flag in `pie/src/pie/capabilities.py` (default `True` so existing drivers are unaffected).

## What's in this PR
- **`kv_cache.py`** — per-spec MambaSpec allocation. Allocates `[conv_state, ssm_state]` per mamba layer sized `(num_blocks, *spec.shapes[i])` so any pie page id is a valid state-slot index. Returns a `KVCacheLayout` that splits attention from mamba so pie's per-page `copy_d2d/h2d/d2h` handlers don't touch mamba state.
- **`gdn_metadata.py`** (new) — translates pie's CSR (`qo_indptr`, `kv_page_indices`, `kv_page_indptr`, `kv_last_page_lens`) into vllm's `GDNAttentionMetadata`. Splits decodes/prefills, computes `non_spec_state_indices_tensor = first_page_per_request`, has_initial_state from `num_computed_tokens`, conv1d metadata via `compute_causal_conv1d_metadata`, FLA chunk indices via `prepare_chunk_indices/offsets`.
- **`forward_pass.py`** — `transform()` now publishes `attn_metadata` as a per-layer dict keyed by layer prefix (always; uniform shape on hybrid + dense). vllm's `GatedDeltaNet._forward` reads its own `GDNAttentionMetadata` via `forward_context.attn_metadata[layer.prefix]`; FlashInfer attention layers continue to read the shared FlashInfer struct.
- **`engine.py`** — engine tracks `is_hybrid` + `mamba_layers`; cudagraph capture is skipped on hybrid (GDN's `UNIFORM_BATCH` cudagraph would conflict with our `FULL_DECODE_ONLY` whole-forward capture); warmup zeros mamba slot 0 alongside attention page 0; `capabilities()` reports `supports_kv_fork=False` on hybrid.
- **`loader.py`** — initializes vllm 0.20.0's process-wide `WorkspaceManager` (pie bypasses `GPUModelRunner` so we have to do this ourselves; otherwise the first transformer forward asserts).
- **`_vllm_compat.py`** — re-exports `MambaSpec`, `FullAttentionSpec`, lazy getters for `GDNAttentionBackend / Metadata / Builder`, `compute_causal_conv1d_metadata`, `MambaBase`.
- **`capabilities.py`** — adds `supports_kv_fork: bool = True` (default keeps existing drivers fork-capable).

## Bugs caught + fixed in the same branch
- `MambaBase(AttentionLayerBase)` inheritance trap in vllm 0.20.0 — naive `isinstance(layer, AttentionLayerBase)` sweeps in mamba layers; explicit exclusion in both `kv_cache.allocate_and_bind_kv_cache` and `forward_pass._ensure_metadata_builder`.
- `WorkspaceManager not initialized` on first forward — added `init_workspace_manager(device)` to `loader.load_vllm_model`.

## What's deliberately NOT in this PR
- **Copy-on-fork for hybrid mamba state.** Pie's IPC has no stable per-request id that survives fork (committed prefix shared via refcount, working pages copied; first-page indexing is shared between forked siblings, last-page indexing migrates on rollover). Solving this needs runtime cooperation (a per-request slot field in IPC, or a separate kv_cache_group concept in pie's allocator). The capability flag lets pie's runtime route fork-using inferlets away on hybrid models. Tracked as a follow-up.
- **Cudagraph on hybrid.** GDN backend has its own `UNIFORM_BATCH` cudagraph path that captures FLA / `causal_conv1d` kernels; mixing with pie's FULL_DECODE_ONLY whole-forward capture would double-capture. Eager only on hybrid for now. Follow-up.
- **Spec-decode on hybrid.** Pie's NGRAM drafter is engine-side and produces qlen=1 batches that go through GDN's non-spec path; spec-decode metadata fields are left `None`.

## Verification

### Hybrid functional smoke
End-to-end on Qwen/Qwen3.5-35B-A3B-FP8 (`qwen3_5_moe` — 30 `linear_attention` + 10 `full_attention` layers) on A100-SXM4-80GB:
- Engine warmup: 12.0s weights load + 1.0s prefill (8 tok) + 0.10s decode (1 tok) + 0.04s sample.
- Real chat generation produces sensible output (`<think></think>The capital of France is **Paris**.` + a joke).
- Steady-state decode at 128-tok max: **36.8 ms/tok** pie-vllm eager vs **7.71 ms/tok** vllm-direct on the same GPU/model — 4.78× slower. Consistent with the pre-cudagraph pie/vllm-direct gap on dense models; perf closure depends on the cudagraph follow-up.

### Dense regression check (cudagraph capture active)
Programmatic semantic validation of the dict-keyed `attn_metadata` change against pure-attention models. Bench: `Sampler.top_p(0.0, 1.0)` greedy, prompt = `"List the first 100 prime numbers separated by commas, in order. No explanation, no preamble, just the comma-separated list."`, parser strips `<think>...</think>` and finds the longest contiguous run of expected primes in order.

| Model | Cudagraph | Determinism | Semantic check (3 runs) |
|---|---|---|---|
| Qwen/Qwen3-8B-FP8 | 12 FULL descriptors / 88 MiB | byte-for-byte differs in `<think>` block (model-side FP non-determinism); final answer identical | **3/3 PASS** — all 100 primes correct, ending at 541 |
| Qwen/Qwen2.5-72B-Instruct-AWQ | 12 FULL descriptors / 104 MiB | byte-for-byte deterministic across all 3 runs | **3/3 PASS** — all 100 primes correct, plus model continues correctly past prime #100 to prime #166 (983) |

Cudagraph capture sizes/shapes match the existing baseline for this driver. Output is semantically correct on both models. The dict-keyed `attn_metadata` switch does not regress pure-attention models.

## Test plan
- [x] Engine warmup completes on Qwen3.5-35B-A3B-FP8
- [x] Chat generation produces sensible output on hybrid
- [x] Decode steady-state ms/tok measured vs vllm-direct
- [x] Dense regression — Qwen3-8B-FP8 + Qwen2.5-72B-Instruct-AWQ produce semantically-correct first-100-primes output across 3 runs each; cudagraph capture sizes unchanged