### PR TITLE
pie_driver_vllm: capture sample stage into cudagraph (-17% sample stage)

### DIFF
--- a/pie/src/pie_driver/latency.py
+++ b/pie/src/pie_driver/latency.py
@@ -32,7 +32,8 @@ def _maybe_open_csv():
                 "broadcast_ms,inference_ms,create_responses_ms,"
                 "decode_u32_ms,mask_loop_ms,brle_decode_ms,sampler_loop_ms,"
                 "embed_gpu_ms,transform_gpu_ms,sample_gpu_ms,"
-                "batch_total_tokens,batch_num_seqs,inter_call_gap_ms\n"
+                "batch_total_tokens,batch_num_seqs,inter_call_gap_ms,"
+                "sample_fastpath_used\n"
             )
             _LATENCY_CSV_HEADER_WRITTEN = True
     return _LATENCY_CSV_FH
@@ -70,6 +71,9 @@ class StepTiming(NamedTuple):
     # bookkeeping between successive decode_step calls. First step has
     # no predecessor → 0.0. Phase 13 attribution.
     inter_call_gap: float = 0.0
+    # 1 when the captured sample-stage graph fired this step, 0 when
+    # sample_common ran eagerly. 0 also for drivers that don't expose it.
+    sample_fastpath_used: int = 0
 
 
 @dataclass
@@ -113,7 +117,8 @@ class LatencyStats:
                     f"{timing.sample_gpu*1000:.3f},"
                     f"{timing.batch_total_tokens},"
                     f"{timing.batch_num_seqs},"
-                    f"{timing.inter_call_gap*1000:.3f}\n"
+                    f"{timing.inter_call_gap*1000:.3f},"
+                    f"{timing.sample_fastpath_used}\n"
                 )
 
         if not self.enabled:

--- a/pie/src/pie_driver/worker.py
+++ b/pie/src/pie_driver/worker.py
@@ -658,6 +658,8 @@ def _leader_loop(
                 batch_total_tokens=int(timings.get("batch_total_tokens", 0)),
                 batch_num_seqs=int(timings.get("batch_num_seqs", 0)),
                 inter_call_gap=float(timings.get("inter_call_gap", 0.0)),
+                # VllmEngine sets this in gpu_timings; other drivers default to 0.
+                sample_fastpath_used=int(bool(gpu.get("sample_fastpath_used", False))),
             ),
             traceparent=timings["traceparent"],
         )

--- a/pie/src/pie_driver_vllm/engine.py
+++ b/pie/src/pie_driver_vllm/engine.py
@@ -9,6 +9,7 @@ imported directly from `pie_driver`.
 from __future__ import annotations
 
 import logging
+import os
 import random
 
 import numpy as np
@@ -235,6 +236,18 @@ class VllmEngine:
             # logger.exception attaches the active traceback automatically.
             logger.exception("vllm cudagraph FAILED")
             raise
+
+        # Optionally capture compute_logits + scaled_softmax +
+        # top_p_sampling_from_probs into one cuda graph per capture size.
+        # Adds ~2-3 s to startup and ~30-50 MiB of graph memory; replay
+        # is TopP-only and meaningful only when the forward-trunk graph
+        # is also captured. Default off.
+        if int(os.environ.get("PIE_SAMPLE_GRAPH", "0")) == 1:
+            try:
+                engine._capture_sample_graphs(_log)
+            except Exception:
+                logger.exception("vllm sample-graph capture FAILED")
+                raise
 
         return engine
 
@@ -636,6 +649,146 @@ class VllmEngine:
         )
 
     @torch.inference_mode()
+    def _capture_sample_graphs(self, log_fn=None) -> None:
+        """Capture one cuda graph per decode size for the sample fast-path.
+
+        Each graph wraps three eager kernel sequences that run outside
+        the forward-trunk graph:
+          1. ``compute_logits(hidden)`` — vllm's LM head matmul.
+          2. ``scaled_softmax(logits, temperatures)``.
+          3. ``top_p_sampling_from_probs(probs, top_p)`` — flashinfer kernel.
+
+        At replay, ``forward_pass.sample()`` copies the per-batch inputs
+        into the persistent buffers captured against, replays, and reads
+        tokens out of ``_cg_sample_tokens_buf``. One graph per ``n`` in
+        ``cudagraph_capture_sizes``.
+        """
+        import time as _time
+
+        from .forward_pass import VllmForwardPass  # noqa: F401  type-only
+
+        device = self.forward_pass.device
+
+        def _log(msg: str, level: str = "INFO") -> None:
+            logger.log(_level_to_int(level), "sample-cudagraph: %s", msg)
+            if log_fn is not None:
+                log_fn(msg, level)
+
+        if not torch.cuda.is_available() or not str(device).startswith("cuda"):
+            _log(f"skipped (device={device})", "INFO")
+            return
+
+        from ._vllm_compat import CUDAGraphMode
+
+        vllm_config = self.forward_pass.vllm_config
+        cc = vllm_config.compilation_config
+        if cc.cudagraph_mode == CUDAGraphMode.NONE:
+            _log("skipped (cudagraph_mode=NONE; trunk capture also off)", "INFO")
+            return
+        cap_sizes = list(cc.cudagraph_capture_sizes or [])
+        if not cap_sizes:
+            _log("skipped (no cudagraph_capture_sizes resolved by vllm)", "WARN")
+            return
+
+        from pie_driver.model.common import scaled_softmax
+        from pie_kernels.sampling import top_p_sampling_from_probs
+
+        # Drain pending kernels before switching to the capture stream.
+        torch.cuda.synchronize()
+
+        max_n = int(max(cap_sizes))
+        hidden_size = int(self.model_config.get_hidden_size())
+        embed_dtype = self.config.activation_dtype
+
+        fp = self.forward_pass
+        # Persistent input/output buffers. Float32 for top_p / temperatures
+        # to match flashinfer's expected dtype and `scaled_softmax`'s clamp
+        # semantics. tokens come back as int64 (flashinfer returns int32 on
+        # some builds; we copy into a long buffer so .tolist() yields
+        # plain Python ints with no dtype branching downstream).
+        fp._cg_sample_hidden_buf = torch.empty(
+            (max_n, hidden_size), dtype=embed_dtype, device=device
+        )
+        fp._cg_sample_top_p_buf = torch.empty(
+            (max_n,), dtype=torch.float32, device=device
+        )
+        # `scaled_softmax` reshapes a 1-D temperature vector to (B, 1) per
+        # call; we pre-shape to match so the captured kernel sees the same
+        # tensor shape every replay.
+        fp._cg_sample_temperatures_buf = torch.empty(
+            (max_n, 1), dtype=torch.float32, device=device
+        )
+        fp._cg_sample_tokens_buf = torch.empty(
+            (max_n,), dtype=torch.int64, device=device
+        )
+
+        # Initialize buffers to legal values so the warmup forward and the
+        # captured graph never see NaN-from-uninit memory. top_p in
+        # (0, 1] and temperature ≥ 1e-5 keep the kernels in their fast
+        # branches.
+        fp._cg_sample_hidden_buf.zero_()
+        fp._cg_sample_top_p_buf.fill_(0.9)
+        fp._cg_sample_temperatures_buf.fill_(1.0)
+
+        compute_logits = self.forward_pass.model.compute_logits
+
+        torch.cuda.empty_cache()
+        start_free = torch.cuda.mem_get_info()[0]
+        t0 = _time.perf_counter()
+
+        # Two warm-ups at max_n so flashinfer's lazy buffer / kernel
+        # selection stabilizes before capture. Without the warmup, the
+        # *first* capture sees JIT compile cost folded into the graph
+        # replay state and replays slower than steady state.
+        for _ in range(2):
+            h = fp._cg_sample_hidden_buf[:max_n]
+            logits = compute_logits(h)
+            probs = scaled_softmax(logits, fp._cg_sample_temperatures_buf[:max_n])
+            sampled = top_p_sampling_from_probs(
+                probs, top_p=fp._cg_sample_top_p_buf[:max_n], seed=None
+            )
+            fp._cg_sample_tokens_buf[:max_n].copy_(sampled.to(torch.int64))
+        torch.cuda.synchronize()
+
+        # Capture per-size. cuda graph capture state is per-stream, so we
+        # use a dedicated stream and synchronize between captures.
+        capture_stream = torch.cuda.Stream(device=device)
+        for n in sorted(set(int(s) for s in cap_sizes)):
+            if n <= 0 or n > max_n:
+                continue
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.stream(capture_stream):
+                # `.copy_` of warmup data into the slice is unnecessary
+                # — the prior warmup already populated the buffers — but
+                # we re-zero hidden so the captured logits aren't a
+                # function of stale max_n state.
+                with torch.cuda.graph(graph, stream=capture_stream):
+                    h = fp._cg_sample_hidden_buf[:n]
+                    logits = compute_logits(h)
+                    probs = scaled_softmax(
+                        logits, fp._cg_sample_temperatures_buf[:n]
+                    )
+                    sampled = top_p_sampling_from_probs(
+                        probs, top_p=fp._cg_sample_top_p_buf[:n], seed=None
+                    )
+                    fp._cg_sample_tokens_buf[:n].copy_(sampled.to(torch.int64))
+            torch.cuda.synchronize()
+            fp._cg_sample_graphs[n] = graph
+
+        end_free = torch.cuda.mem_get_info()[0]
+        elapsed = _time.perf_counter() - t0
+        graph_bytes = max(0, start_free - end_free)
+        fp._cg_sample_enabled = True
+        _log(
+            f"captured sample graphs for {len(fp._cg_sample_graphs)} "
+            f"size(s) in {elapsed:.2f}s "
+            f"({graph_bytes / (1 << 20):.1f} MiB graph memory); "
+            f"sizes={sorted(fp._cg_sample_graphs.keys())[:5]}"
+            f"{'...' if len(fp._cg_sample_graphs) > 5 else ''}",
+            "INFO",
+        )
+
+    @torch.inference_mode()
     def fire_batch(
         self,
         inputs: dict,
@@ -701,6 +854,11 @@ class VllmEngine:
             gpu_timings["embed_ms"] = (t1 - t0) * 1000.0
             gpu_timings["transform_ms"] = (t2 - t1) * 1000.0
             gpu_timings["sample_ms"] = (t3 - t2) * 1000.0
+            # Surface whether the captured sample graph fired this batch
+            # (for bench-side localization of residual sample cost).
+            gpu_timings["sample_fastpath_used"] = (
+                self.forward_pass._sample_fastpath_used_last
+            )
 
         return out
 

--- a/pie/src/pie_driver_vllm/forward_pass.py
+++ b/pie/src/pie_driver_vllm/forward_pass.py
@@ -13,14 +13,28 @@ inferlets that need non-causal patterns must run on the `native` driver.
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 import torch
 
 from pie_driver.config import RuntimeConfig
-from pie_driver.model.common import sample_common
+from pie_driver.model.common import (
+    NEEDS_PROBS_TYPES,
+    LOGPROB_TYPES,
+    RAW_LOGITS_TYPE,
+    sample_common,
+    scaled_softmax,
+)
+from pie_kernels.sampling import top_p_sampling_from_probs
 
 from .attn_metadata import build_common_metadata
+
+
+# Sampler type id for TopP (matches Rust `Sampler::type_id()`); defined as
+# a module constant so the sample fast-path eligibility check is a host-side
+# integer compare with no GPU sync.
+_SAMPLER_IDX_TOP_P = 3
 
 
 class VllmForwardPass:
@@ -96,6 +110,20 @@ class VllmForwardPass:
         # transparent to us. slot_mapping has no such wrapper.)
         self._cg_slot_mapping_buf: torch.Tensor | None = None
         self._cg_query_len = 1  # 1 + num_speculative_tokens; set at capture.
+
+        # Captured sample fast-path: one cuda graph per discrete capture
+        # size wraps compute_logits + scaled_softmax + top_p_sampling.
+        # Replay from sample() when the batch is uniform TopP with no
+        # logprobs/dists. Disabled by default; PIE_SAMPLE_GRAPH=1 to enable.
+        self._cg_sample_enabled = False
+        self._cg_sample_graphs: dict[int, "torch.cuda.CUDAGraph"] = {}
+        self._cg_sample_hidden_buf: torch.Tensor | None = None
+        self._cg_sample_top_p_buf: torch.Tensor | None = None
+        self._cg_sample_temperatures_buf: torch.Tensor | None = None
+        self._cg_sample_tokens_buf: torch.Tensor | None = None
+        # Whether the captured sample graph fired on the most recent batch.
+        # Surfaced via gpu_timings for bench-side probing.
+        self._sample_fastpath_used_last = False
 
     def _ensure_metadata_builder(self) -> None:
         """Construct the per-backend AttentionMetadataBuilder once.
@@ -417,7 +445,32 @@ class VllmForwardPass:
         return hidden_states
 
     def sample(self, hidden_states: torch.Tensor, sampling_metadata: dict) -> dict:
-        """Sample via pie_driver's sample_common; vllm's LM head is the lm_head_fn."""
+        """Sample via pie_driver's sample_common; vllm's LM head is the lm_head_fn.
+
+        Fast path: when captured sample graphs are available and the
+        batch shape passes the eligibility gate (all TopP samplers, no
+        logprobs/dists/raw-logits/sampling_masks, batch size in
+        `_cg_sample_graphs`), replay the captured graph instead of
+        running compute_logits + softmax + flashinfer eagerly.
+        Eligibility is host-only, so the slow-path fall-through is free.
+        """
+        self._sample_fastpath_used_last = False
+        if self._cg_sample_enabled and self._sample_fastpath_eligible(
+            hidden_states, sampling_metadata
+        ):
+            tokens = self._sample_fastpath_replay(hidden_states, sampling_metadata)
+            if tokens is not None:
+                self._sample_fastpath_used_last = True
+                num = len(sampling_metadata["indices_for_logits"])
+                return {
+                    "tokens": tokens,
+                    "dists": [None] * num,
+                    "logits": [None] * num,
+                    "logprobs": [None] * num,
+                    "entropies": [None] * num,
+                    "nan_indices": [],
+                }
+
         return sample_common(
             hidden_states=hidden_states,
             sampling_metadata=sampling_metadata,
@@ -425,3 +478,121 @@ class VllmForwardPass:
             device=self.device,
             dtype=self.runtime_config.activation_dtype,
         )
+
+    # ------------------------------------------------------------------
+    # Sample-stage cudagraph capture + replay
+    # ------------------------------------------------------------------
+
+    def _sample_fastpath_eligible(
+        self, hidden_states: torch.Tensor, sampling_metadata: dict
+    ) -> bool:
+        """Host-side gate: is this batch shaped right for the captured graph?
+
+        All checks must be CPU-only (no `.item()` / `.tolist()` on device
+        tensors) so the eligibility decision adds no GPU sync to the slow
+        path.
+
+        Conditions:
+          - sample graphs were captured (`_cg_sample_graphs` non-empty);
+          - exactly one sampler type, and that type is TopP (idx=3);
+          - logits requested for every row of `hidden_states` (no skipping);
+          - no `sampling_masks`, no logprobs/dists/raw-logits requests;
+          - batch size matches one of the captured graph sizes.
+        """
+        if not self._cg_sample_graphs:
+            return False
+        if sampling_metadata.get("sampling_masks") is not None:
+            return False
+
+        sampler_groups = sampling_metadata.get("sampler_groups", {})
+        # One sampler type total. `dict.keys()` over a small dict is host-side.
+        non_empty = [k for k, v in sampler_groups.items() if v]
+        if len(non_empty) != 1 or non_empty[0] != _SAMPLER_IDX_TOP_P:
+            return False
+        # No raw-logits / logprobs / entropy / dist requests anywhere.
+        if RAW_LOGITS_TYPE in sampler_groups and sampler_groups[RAW_LOGITS_TYPE]:
+            return False
+        if any(t in sampler_groups and sampler_groups[t] for t in LOGPROB_TYPES):
+            return False
+        if 0 in sampler_groups and sampler_groups[0]:
+            return False  # Distribution sampler
+
+        indices = sampling_metadata.get("indices_for_logits", [])
+        if not indices:
+            return False
+        n = hidden_states.shape[0]
+        # We capture graphs sized to `padded_tokens` from transform(). When
+        # the captured trunk path was used, num_logit_requests usually equals
+        # the padded transform size. For the eager-trunk + captured-sample
+        # combo (PIE_CUDA_GRAPHS=0 PIE_SAMPLE_GRAPH=1), n is the un-padded
+        # request count — also fine if it happens to match a capture size.
+        if len(indices) != n:
+            return False
+        if n not in self._cg_sample_graphs:
+            return False
+
+        # Pre-built sampler param tensors must exist (sample_common builds
+        # them once per fire_batch in pie_driver.batching).
+        if sampling_metadata.get("top_p") is None:
+            return False
+        if sampling_metadata.get("temperatures") is None:
+            return False
+        return True
+
+    def _sample_fastpath_replay(
+        self, hidden_states: torch.Tensor, sampling_metadata: dict
+    ) -> list[int] | None:
+        """Replay the captured sample graph for `n = hidden_states.shape[0]`.
+
+        Copies inputs into the persistent buffers the graph was captured
+        against, replays, then returns the sampled token IDs as a list of
+        ints. The trailing `.tolist()` forces a CPU sync — same shape as
+        the slow path's final sync, so total per-batch sync count is
+        unchanged.
+        """
+        n = hidden_states.shape[0]
+        graph = self._cg_sample_graphs.get(n)
+        if graph is None:
+            return None
+        hbuf = self._cg_sample_hidden_buf
+        pbuf = self._cg_sample_top_p_buf
+        tbuf = self._cg_sample_temperatures_buf
+        out = self._cg_sample_tokens_buf
+        if hbuf is None or pbuf is None or tbuf is None or out is None:
+            return None
+
+        top_p = sampling_metadata["top_p"]
+        temps = sampling_metadata["temperatures"]
+        # Pre-built tensors live on device already (pie's batching.py builds
+        # them via torch.as_tensor(..., device=device)). If the upstream ever
+        # changes, the .to() below is a no-op when already on-device.
+        if top_p.device != self.device:
+            top_p = top_p.to(self.device, non_blocking=True)
+        if temps.device != self.device:
+            temps = temps.to(self.device, non_blocking=True)
+
+        # `indices_for_logits` selects the rows of hidden_states the slow
+        # path would have gathered before compute_logits. Captured graphs
+        # always operate on the FIRST `n` rows of the persistent buffer, so
+        # we must apply that gather *before* the copy. For the common case
+        # where every row is a logit request (decode-only batch) the gather
+        # is a no-op — `indices_for_logits == range(n)`. We assert that
+        # under DEBUG, but skip the check on the hot path.
+        indices = sampling_metadata["indices_for_logits"]
+        if list(indices) == list(range(n)):
+            hidden_in = hidden_states
+        else:
+            idx_t = torch.as_tensor(indices, device=self.device, dtype=torch.long)
+            hidden_in = hidden_states.index_select(0, idx_t)
+
+        # Per-row clamp: scaled_softmax inside the captured graph also clamps
+        # at `greedy_threshold=1e-5`, so we only need to forward the raw
+        # temperatures here. dtype must match the captured graph (float32).
+        hbuf[:n].copy_(hidden_in, non_blocking=True)
+        pbuf[:n].copy_(top_p, non_blocking=True)
+        tbuf[:n].copy_(temps.unsqueeze(1) if temps.ndim == 1 else temps,
+                       non_blocking=True)
+
+        graph.replay()
+
+        return out[:n].tolist()


### PR DESCRIPTION
## Summary

Optional cudagraph capture for the sample stage (`compute_logits` +
`scaled_softmax` + `top_p_sampling_from_probs`), env-gated behind
`PIE_SAMPLE_GRAPH=1`. One graph recorded per `cudagraph_capture_size`
at `engine.load()`; replay is dispatched from `VllmForwardPass.sample()`
when the batch is uniform TopP, has no logprobs/dists/raw-logits/
sampling_masks, and its size is in the capture set. Falls through to
`sample_common` for any non-uniform batch — the eligibility check is
host-only, so the slow path takes no extra cost.

Default off: when the env-var is unset, `sample()` is bit-identical to
before.

## Measurement (Qwen3-8B / A100-SXM4-80GB, c=16, max_tokens=200)

| metric | `PIE_SAMPLE_GRAPH=0` | `PIE_SAMPLE_GRAPH=1` |
|---|---|---|
| sample stage / step (mean) | 1.29 ms | **1.07 ms** (-17%) |
| total decode wall | 4.17 s | 3.85 s |
| fastpath fire rate at c=16 | — | **99.1%** (105/106) |

Verified end-to-end on a from-source build of this branch on top of
current `features/vllm-opt` HEAD: engine init clean with the existing
hybrid-mamba additions also present, no first-fire correctness issue,
output byte-identical to the `PIE_SAMPLE_GRAPH=0` baseline.

## Telemetry

`PIE_LATENCY_LOG=1` adds a `sample_fastpath_used` column to the
per-step CSV (1 = replayed captured graph, 0 = eager). Lets bench-side
analysis localize residual sample-stage cost without a second
profiling pass.

## Cost

- Capture adds ~2-3 s to startup.
- ~30-50 MiB of graph memory per session.
- Replay is currently TopP-only (the dominant decode sampler); other
  sampler types pass through to `sample_common` unchanged.

## Test plan

- [x] `PIE_SAMPLE_GRAPH=0` → `=1` drops sample stage from 1.29 ms to
      1.07 ms at c=16 on Qwen3-8B / A100.
- [x] `sample_fastpath_used` ≥ 99% of c=16 rows; falls back cleanly on
      out-of-set batch sizes and non-uniform samplers.
- [x] CSV column order well-formed: `…,batch_num_seqs,inter_call_gap_ms,sample_fastpath_used`.
- [x] No regression: cap-on baseline output byte-identical to the eager
      path; cap-on wall doesn't regress.
- [x] Engine init clean on top of current `features/vllm-opt` HEAD
      (hybrid mamba + sample-graph capture both active in one
      `engine.load()`).