### PR TITLE
server/hf: accept single .gguf file as hf_repo target

### DIFF
--- a/server/src/embedded_driver.rs
+++ b/server/src/embedded_driver.rs
@@ -661,9 +661,15 @@ impl EmbeddedDriver {
         group_id: usize,
         tp: Option<TpLaunch>,
     ) -> Result<PendingEmbeddedDriver> {
-        if !snapshot_dir.is_dir() {
+        // Portable allows either a safetensors dir or a single .gguf file
+        // (model.cpp branches on is_regular_file). CUDA + dummy still need
+        // a directory — those drivers fail later with their own message
+        // when handed a file, so we don't gate that here.
+        let is_gguf_file = snapshot_dir.is_file()
+            && snapshot_dir.extension().is_some_and(|e| e == "gguf");
+        if !snapshot_dir.is_dir() && !is_gguf_file {
             return Err(anyhow!(
-                "snapshot_dir {snapshot_dir:?} does not exist or is not a directory"
+                "snapshot_dir {snapshot_dir:?} does not exist, or is not a directory or .gguf file"
             ));
         }
 

--- a/server/src/hf.rs
+++ b/server/src/hf.rs
@@ -1,10 +1,12 @@
 //! HuggingFace snapshot resolver.
 //!
-//! `[[model]].hf_repo` accepts either a local snapshot directory or a
-//! HuggingFace repo ID (`owner/name`). [`resolve_or_download`] returns
-//! a usable on-disk path either way:
+//! `[[model]].hf_repo` accepts a local snapshot directory, a local single
+//! `.gguf` file, or a HuggingFace repo ID (`owner/name`).
+//! [`resolve_or_download`] returns a usable on-disk path in all cases:
 //!
-//!   * Local path → returned as-is.
+//!   * Local directory → returned as-is (HF safetensors snapshot).
+//!   * Local `.gguf` file → returned as-is (portable driver loads it
+//!     directly; see `driver/portable/src/model.cpp::Model`).
 //!   * Repo ID → resolved against the HF cache (`~/.cache/huggingface/hub/`,
 //!     overridable via `$HF_HOME`); downloaded if missing.
 //!
@@ -29,6 +31,14 @@ pub async fn resolve_or_download(repo_id_or_path: &str) -> Result<PathBuf> {
     if p.is_dir() {
         return Ok(p.to_path_buf());
     }
+    // Single .gguf file is also a valid resolved target: the portable
+    // driver accepts either an HF safetensors directory OR a single
+    // .gguf file (see driver/portable/src/model.cpp::Model). Treat the
+    // path as pre-resolved so quantized weights can be wired through
+    // `hf_repo` without a multi-file snapshot directory.
+    if p.is_file() && p.extension().is_some_and(|e| e == "gguf") {
+        return Ok(p.to_path_buf());
+    }
 
     // Looks-like-a-path heuristic: if the user typed an absolute path,
     // a `./`/`../` prefix, or anything with backslashes, they meant a
@@ -42,7 +52,7 @@ pub async fn resolve_or_download(repo_id_or_path: &str) -> Result<PathBuf> {
     {
         bail!(
             "hf_repo {repo_id_or_path:?} looks like a local path but does not \
-             exist or is not a directory"
+             exist, or is not a directory or .gguf file"
         );
     }
 
@@ -130,6 +140,15 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resolved, tmp.path());
+    }
+
+    #[tokio::test]
+    async fn local_gguf_file_short_circuits() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gguf = tmp.path().join("model.gguf");
+        std::fs::write(&gguf, b"dummy").unwrap();
+        let resolved = resolve_or_download(gguf.to_str().unwrap()).await.unwrap();
+        assert_eq!(resolved, gguf);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## TL;DR

`pie model download <repo>` doesn't usefully support GGUF today:

- **No per-file selector.** `snapshot_download` has no `allow_patterns` filter,
  so a GGUF repo like `unsloth/Qwen3-30B-A3B-GGUF` pulls every quant variant
  (~150 GB) when the user wants one (~17 GB for Q4_K_M).
- **`check_pie_compatibility` reads `config.json`,** which GGUF-only repos
  don't have (the metadata is in the .gguf header). So a freshly downloaded
  GGUF lists as `○ owner/repo (no config)` and the post-download line warns
  it's not pie-compatible — even though pie's portable driver can load .gguf
  files just fine.

…but the portable driver in `driver/portable/src/model.cpp::Model`
**already** handles a single .gguf file (`is_regular_file && extension ==
".gguf"`). The only thing missing is letting the user point `hf_repo` at
such a file. Two server-side gates reject file paths before the driver
sees them:

1. `hf::resolve_or_download` — "looks-like-a-path" heuristic rejects an
   existing absolute file path as "looks like a local path but does not
   exist or is not a directory" (misleading: the file exists).
2. `EmbeddedDriver::spawn_rank` — early-returns with the same dir-only
   message before the driver ever sees the path.

This PR relaxes both gates: a path to a single `.gguf` file flows through
as a pre-resolved target. CUDA and dummy drivers still require directories
(they read `config.json`); they fail later with their own error if handed
a file — we don't gate that here.

User-facing UX after this PR:

```bash
# Until `pie model download --file <X.gguf>` exists, use HF's own CLI:
hf download unsloth/Qwen3-30B-A3B-GGUF Qwen3-30B-A3B-Q4_K_M.gguf
```

```toml
# ~/.pie/config.toml
[[model]]
name = "default"
hf_repo = "/Users/<you>/.cache/huggingface/hub/models--unsloth--Qwen3-30B-A3B-GGUF/snapshots/<hash>/Qwen3-30B-A3B-Q4_K_M.gguf"
```

The shared HF cache layout means a model fetched via `hf` / `huggingface-cli`
is interchangeable with anything pie itself might pull — exactly as the
existing `server/src/hf.rs` doc comment already states for safetensors.

## What this PR does NOT do (deliberate scope)

- **Doesn't extend `pie model download` to GGUF.** Adding a `--file <X.gguf>`
  flag + a GGUF-aware compat check (reading the GGUF header instead of
  `config.json`) is the natural next step but ~5–10× the scope and best as
  a separate PR.
- **Doesn't add a `gguf_file` selector field to `[[model]]`.** Schema-wise
  uniform with the rest (`hf_repo = "owner/repo"` + `gguf_file = "X.gguf"`)
  but trips `deny_unknown_fields`; also a separate change.
- **Doesn't change safetensors behavior.** `hf_repo = "Qwen/Qwen3-8B"` still
  resolves and loads exactly as before.

## Three failure modes this fixes

| Input | Pre-PR behavior |
|---|---|
| `hf_repo = "unsloth/Qwen3-30B-A3B-GGUF"` (multi-file GGUF repo) | Pulls the full repo (every quant variant!), then `model.cpp` takes the `is_hf_dir` branch and crashes reading missing `config.json`. |
| `hf_repo = "/Users/.../Qwen3-30B-A3B-Q4_K_M.gguf"` (local file) | Rejected at `hf::resolve_or_download` — "does not exist or is not a directory" (misleading; the file does exist). |
| `hf_repo = "user/repo-with-one-gguf"` (single-quant repo) | Same as #1 — `model.cpp` still takes `is_hf_dir` because the resolved path is a directory, then crashes on missing `config.json`. |

After this PR, case #2 works directly. Cases #1 and #3 remain bounded by
the larger "pick-quant-out-of-multi-file-repo" gap (the future `pie model
download --file` work).

## Test plan

- [x] `cargo test --release -p pie-server --lib hf::` — 7 passed (existing 6
  + new `local_gguf_file_short_circuits`).
- [x] Manual smoke: `pie serve` with
  `hf_repo = "/Users/.../Qwen3-30B-A3B-Q4_K_M.gguf"` reaches the portable
  driver and starts loading the GGUF (vs. pre-patch failure at the resolver):
  ```
  [pie-driver-portable] config loaded
    model.hf_path = /Users/.../Qwen3-30B-A3B-Q4_K_M.gguf
  [pie-driver-portable] loading model from /Users/.../Qwen3-30B-A3B-Q4_K_M.gguf (backend=auto)
  [model] ggml CPU backend pinned to 12 thread(s)
  ```
- [x] CUDA/dummy paths still require a directory — verified by reading
  `read_hf_config_defaults` and `write_cuda_startup_toml`, which both expect
  `snapshot_dir / "config.json"`. No code path silently changed behavior.

## Adjacent finding (not in this PR — needs separate work)

`Qwen3-30B-A3B-Q4_K_M.gguf` then fails to load with
`gguf: missing tensor 'model.layers.0.mlp.experts.0.gate_proj.weight'`.
The `gguf_to_hf_name` mapper in `gguf_archive.cpp:104-112` handles only the
**stacked** MoE form (`ffn_gate_exps.weight` →
`mlp.experts.gate_proj.weight`, no `.E.` index), but `model.cpp`'s
per-architecture loader expects the **per-expert indexed** HF name
(`model.layers.N.mlp.experts.E.gate_proj.weight`). The mapper's comment
claims to cover the per-expert form but the corresponding code paths
aren't present. I can open this as a separate issue with the captured logs.

## Discovered while patching

`cargo build --bin pie` from the workspace root fails on macOS with
`--features driver-cuda is Linux-only`, because `sdk/python-server`
unconditionally activates `["driver-cuda", "driver-portable",
"driver-dummy"]` and Cargo's resolver-2 unifies features across the
workspace. Use `cargo build --release --bin pie -p pie-server` to scope
the build to one crate and avoid the unification. Possibly worth a
`BUILDING.md` note.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying individual `.gguf` model files as direct inputs alongside existing directory support, providing greater flexibility in model specification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pie-project/pie/pull/361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->