### PR TITLE
driver/portable: load MoE experts from stacked GGUF tensors

### DIFF
--- a/driver/portable/src/model.cpp
+++ b/driver/portable/src/model.cpp
@@ -494,13 +494,21 @@ ggml_tensor* Model::declare_(const std::string& hf_name) {
     // tensor we hand back to the graph builder is typed F32, so the
     // implicit `ggml_cast` in `norm_scale` becomes a no-op. The actual
     // bf16 → f32 byte conversion happens in load_into_backend_().
-    const bool upcast = t.dtype == StDtype::BF16
+    //
+    // GGUF tensors carry their ggml type in `ggml_type_override` and
+    // leave `dtype` as a placeholder F32 (see gguf_archive). The cast
+    // logic below is keyed off `dtype` and would mistrigger on every
+    // GGUF tensor, so we only apply it on the safetensors path.
+    const bool is_safetensors = t.ggml_type_override < 0;
+    const bool upcast = is_safetensors
+                     && t.dtype == StDtype::BF16
                      && is_small_weight_for_upcast(hf_name);
     // Some HF releases (notably Gemma-2-2b) store weights as F32. The F32
     // mul_mat path is ~2x slower than BF16 on tensor-core hardware and
     // doubles VRAM. Downcast large matmul weights at load time, matching
     // llama.cpp's GGUF default. Norms / biases stay F32 (precision).
-    const bool downcast = t.dtype == StDtype::F32
+    const bool downcast = is_safetensors
+                       && t.dtype == StDtype::F32
                        && !is_small_weight_for_upcast(hf_name);
 
     ggml_tensor* tensor;
@@ -784,6 +792,54 @@ void Model::load_moe_layer_(std::int32_t i,
     const std::int64_t ff     = h.moe_intermediate_size > 0
         ? h.moe_intermediate_size : h.intermediate_size;
 
+    // GGUF MoE: experts are stored as three stacked 3D tensors (one slab
+    // per gate / up / down) rather than the per-expert HF safetensors
+    // layout. The GGUF name mapper translates `blk.N.ffn_{gate,up,down}_exps`
+    // to `mlp.experts.{gate,up,down}_proj.weight` uniformly across
+    // qwen3_moe / mixtral / gpt-oss, so a single probe distinguishes
+    // GGUF stacked from per-expert safetensors regardless of `kind`.
+    const std::string gate_stacked = p + "mlp.experts.gate_proj.weight";
+    const std::string up_stacked   = p + "mlp.experts.up_proj.weight";
+    const std::string down_stacked = p + "mlp.experts.down_proj.weight";
+    if (archive_->find(gate_stacked) != nullptr) {
+        // Router. GGUF's `ffn_gate_inp.weight` maps to `mlp.gate.weight`
+        // for both Qwen-MoE and Mixtral, so this is uniform here too.
+        L.moe_router = declare_(p + "mlp.gate.weight");
+
+        const auto& gate_src = archive_->at(gate_stacked);
+        const auto& up_src   = archive_->at(up_stacked);
+        const auto& down_src = archive_->at(down_stacked);
+        // GGUF stores the ggml type directly in ggml_type_override
+        // (Q4_K, Q5_K, F16, ...); st_to_ggml_dtype only covers F32/F16/BF16
+        // and would throw on quants, so use the override path explicitly.
+        auto src_dtype = [&](const StTensor& t, const std::string& nm) {
+            return (t.ggml_type_override >= 0)
+                ? static_cast<ggml_type>(t.ggml_type_override)
+                : st_to_ggml_dtype(t.dtype, nm);
+        };
+        const ggml_type gate_dtype = src_dtype(gate_src, gate_stacked);
+        const ggml_type up_dtype   = src_dtype(up_src,   up_stacked);
+        const ggml_type down_dtype = src_dtype(down_src, down_stacked);
+
+        const std::size_t gate_per_expert = gate_src.nbytes /
+                                            static_cast<std::size_t>(n_exp);
+        const std::size_t up_per_expert   = up_src.nbytes /
+                                            static_cast<std::size_t>(n_exp);
+        const std::size_t down_per_expert = down_src.nbytes /
+                                            static_cast<std::size_t>(n_exp);
+        L.moe_gate_exps = declare_stacked_experts_from_3d_(
+            p + "moe_gate", gate_stacked, hidden, ff, n_exp,
+            gate_per_expert, /*intra_off=*/0, gate_dtype);
+        L.moe_up_exps   = declare_stacked_experts_from_3d_(
+            p + "moe_up",   up_stacked,   hidden, ff, n_exp,
+            up_per_expert,   /*intra_off=*/0, up_dtype);
+        L.moe_down_exps = declare_stacked_experts_from_3d_(
+            p + "moe_down", down_stacked, ff, hidden, n_exp,
+            down_per_expert, /*intra_off=*/0, down_dtype);
+        return;
+    }
+
+    // Per-expert safetensors layout (Qwen-MoE / Mixtral / GPT-OSS HF).
     std::vector<std::string> gate_names, up_names, down_names;
     gate_names.reserve(n_exp);
     up_names.reserve(n_exp);


### PR DESCRIPTION
## TL;DR

* Make MoE GGUFs load: probe for stacked expert slabs, route through `declare_stacked_experts_from_3d_`.
* Fix a pre-existing GGUF blocker: `declare_` was misreading native-F16 GGUF tensors as F32-source.
* Two changes, one file (`driver/portable/src/model.cpp`).

## Why

GGUF stores MoE experts as three stacked 3D tensors (gate / up / down), not the per-expert HF safetensors layout that `load_moe_layer_` assumed. Every MoE GGUF — qwen3_moe, mixtral, gpt-oss — hit `missing tensor` at build time. Separately, `declare_` keyed its cast logic on `StDtype`, which is a placeholder F32 for every GGUF tensor, so native-F16 tensors like `token_embd.weight` crashed at a 2× size mismatch.

## What

`load_moe_layer_` probes for `mlp.experts.gate_proj.weight` (the stacked name the GGUF mapper emits uniformly across families). When present, gate/up/down are loaded via the existing `declare_stacked_experts_from_3d_` helper (same helper qwen3.5-moe's fused safetensors path already uses). Per-expert safetensors path is unchanged and reached as a fallthrough.

`declare_` skips upcast/downcast when `ggml_type_override >= 0` — same `(t.ggml_type_override < 0 ? safetensors : gguf)` convention already used in `new_tensor_from_st`.

## Smoke test

Unsloth's `Qwen3-30B-A3B-Q4_K_M.gguf` on Apple M4 Pro / Metal:

```
[pie-driver-portable] loaded qwen3_moe (48 layers, hidden=2048, heads=32/4 kv,
                                          buf=18117.9 MiB, backend=Apple M4 Pro)
[pie-driver-portable] forward engine ready (total_pages=1024, kv_buf=3072 MiB)
[pie-driver-portable] serving on shmem /pie_shmem_g0
```

Pairs with #361 (the user-facing `.gguf` `hf_repo` entry point) but is independent.