### PR TITLE
driver/portable: mint tokenizer.json from GGUF KV + vocab_size fallback

### DIFF
--- a/driver/portable/CMakeLists.txt
+++ b/driver/portable/CMakeLists.txt
@@ -84,6 +84,7 @@ add_library(pie_driver_portable_lib STATIC
   src/hf_config.cpp
   src/gguf_archive.cpp
   src/gguf_hparams.cpp
+  src/gguf_tokenizer.cpp
   src/model.cpp
   src/kv_cache.cpp
   src/state_cache.cpp

--- a/driver/portable/src/entry.cpp
+++ b/driver/portable/src/entry.cpp
@@ -30,10 +30,15 @@
 #include "aux_server.hpp"
 #include "config.hpp"
 #include "forward.hpp"
+#include "gguf_tokenizer.hpp"
 #include "hf_config.hpp"
 #include "model.hpp"
 #include "shmem_ipc.hpp"
 #include "shmem_schema.hpp"
+
+#include <filesystem>
+#include <random>
+#include <unistd.h>
 
 namespace {
 
@@ -281,6 +286,30 @@ int run_impl(int argc,
                   << ", backend=" << model.backend_name() << ")\n";
     }
 
+    // For GGUF inputs the server-side bootstrap expects `tokenizer.json`
+    // adjacent to `snapshot_dir`. GGUF embeds the tokenizer in KV
+    // metadata instead, so mint a HF-format `tokenizer.json` (plus
+    // `tokenizer_config.json` for the chat template) into a unique temp
+    // dir, then report that dir as `snapshot_dir` in caps. Safetensors
+    // path is untouched.
+    std::string effective_snapshot_dir = cfg.model.hf_path;
+    {
+        const std::filesystem::path src(cfg.model.hf_path);
+        if (std::filesystem::is_regular_file(src) && src.extension() == ".gguf") {
+            std::random_device rd;
+            const auto rand_tag = std::to_string(rd()) + "-" + std::to_string(rd());
+            const auto tmpdir = std::filesystem::temp_directory_path() /
+                ("pie-gguf-tokenizer-" + std::to_string(::getpid()) + "-" + rand_tag);
+            std::filesystem::create_directories(tmpdir);
+            pie_portable_driver::emit_tokenizer_files(src, tmpdir);
+            effective_snapshot_dir = tmpdir.string();
+            if (cfg.runtime.verbose) {
+                std::cerr << "[pie-driver-portable] minted tokenizer.json from GGUF KVs to "
+                          << effective_snapshot_dir << "\n";
+            }
+        }
+    }
+
     // ---- Allocate forward engine + paged KV pool. ---------------------------
     // The runtime owns page allocation; we report total_pages and page_size
     // in the READY handshake and honor the page IDs the runtime sends in
@@ -419,7 +448,7 @@ int run_impl(int argc,
         {"vocab_size",       h.vocab_size},
         {"max_model_len",    max_model_len},
         {"activation_dtype", model.activation_dtype_str()},
-        {"snapshot_dir",     cfg.model.hf_path},
+        {"snapshot_dir",     effective_snapshot_dir},
         {"shmem_name",       cfg.shmem.name},
     };
     // Hand caps to the host. The standalone executable's default

--- a/driver/portable/src/entry.cpp
+++ b/driver/portable/src/entry.cpp
@@ -37,7 +37,6 @@
 #include "shmem_schema.hpp"
 
 #include <filesystem>
-#include <random>
 #include <unistd.h>
 
 namespace {
@@ -286,25 +285,20 @@ int run_impl(int argc,
                   << ", backend=" << model.backend_name() << ")\n";
     }
 
-    // For GGUF inputs the server-side bootstrap expects `tokenizer.json`
-    // adjacent to `snapshot_dir`. GGUF embeds the tokenizer in KV
-    // metadata instead, so mint a HF-format `tokenizer.json` (plus
-    // `tokenizer_config.json` for the chat template) into a unique temp
-    // dir, then report that dir as `snapshot_dir` in caps. Safetensors
-    // path is untouched.
+    // GGUF embeds the tokenizer in KV; emit HF-format files to a temp
+    // dir and report that as `snapshot_dir` so the server-side
+    // `Tokenizer::from_file(snapshot_dir / "tokenizer.json")` works.
     std::string effective_snapshot_dir = cfg.model.hf_path;
     {
         const std::filesystem::path src(cfg.model.hf_path);
         if (std::filesystem::is_regular_file(src) && src.extension() == ".gguf") {
-            std::random_device rd;
-            const auto rand_tag = std::to_string(rd()) + "-" + std::to_string(rd());
             const auto tmpdir = std::filesystem::temp_directory_path() /
-                ("pie-gguf-tokenizer-" + std::to_string(::getpid()) + "-" + rand_tag);
+                ("pie-gguf-tokenizer-" + std::to_string(::getpid()));
             std::filesystem::create_directories(tmpdir);
             pie_portable_driver::emit_tokenizer_files(src, tmpdir);
             effective_snapshot_dir = tmpdir.string();
             if (cfg.runtime.verbose) {
-                std::cerr << "[pie-driver-portable] minted tokenizer.json from GGUF KVs to "
+                std::cerr << "[pie-driver-portable] minted tokenizer.json to "
                           << effective_snapshot_dir << "\n";
             }
         }

--- a/driver/portable/src/gguf_archive.cpp
+++ b/driver/portable/src/gguf_archive.cpp
@@ -210,6 +210,18 @@ GGUFArchive::GGUFArchive(const std::filesystem::path& gguf_file) {
         meta_.general_name = it->second.str_value;
     }
 
+    // Capture the tokens-array length for vocab_size fallback. Most GGUFs
+    // omit `<arch>.vocab_size` but always store `tokenizer.ggml.tokens`.
+    {
+        const std::int64_t tok_id =
+            gguf_find_key(gctx_, "tokenizer.ggml.tokens");
+        if (tok_id >= 0 &&
+            gguf_get_kv_type(gctx_, tok_id) == GGUF_TYPE_ARRAY &&
+            gguf_get_arr_type(gctx_, tok_id) == GGUF_TYPE_STRING) {
+            meta_.tokens_count = gguf_get_arr_n(gctx_, tok_id);
+        }
+    }
+
     // ---- Build the StTensor table keyed by HF canonical name -----------
     const std::int64_t n_tensors = gguf_get_n_tensors(gctx_);
     raw_names_.reserve(static_cast<std::size_t>(n_tensors));

--- a/driver/portable/src/gguf_archive.hpp
+++ b/driver/portable/src/gguf_archive.hpp
@@ -32,6 +32,11 @@ struct GgufMeta {
     std::string  general_architecture;   // "qwen3", "llama", "qwen3_5_moe", ...
     std::string  general_name;
     bool         has_output_weight = false; // false → tied embeddings
+    // Length of the `tokenizer.ggml.tokens` array, captured during archive
+    // construction. Many GGUFs omit `<arch>.vocab_size` and rely on the
+    // tokens-array length as the canonical vocab count, so we surface it
+    // here for hparams fallback.
+    std::size_t  tokens_count = 0;
     // All KV pairs as (key, type-erased) — used by the hparams parser.
     // Type is one of gguf_type's underlying values.
     struct KV { std::string key; std::int32_t type; std::string str_value;

--- a/driver/portable/src/gguf_hparams.cpp
+++ b/driver/portable/src/gguf_hparams.cpp
@@ -97,11 +97,15 @@ Hparams parse_gguf_hparams(const GgufMeta& meta) {
     h.tie_word_embeddings = !meta.has_output_weight;
 
     // Vocab size: GGUF doesn't always store it explicitly either. The
-    // tokenizer.ggml.tokens array length is the canonical source, but
-    // hparams's vocab_size is also implied by tok_embd's outer dim.
-    // Most converters DO write `<arch>.vocab_size`; fall back to 0 (the
-    // model loader will sanity-check against the embed tensor shape).
+    // tokenizer.ggml.tokens array length is the canonical source, and
+    // most converters DO write `<arch>.vocab_size`. Take the explicit
+    // arch key when present, otherwise fall back to the tokens-array
+    // length captured at archive construction (Qwen3-MoE GGUFs in the
+    // wild omit the arch key).
     h.vocab_size = static_cast<std::int32_t>(get_num(meta, a, "vocab_size", 0));
+    if (h.vocab_size == 0) {
+        h.vocab_size = static_cast<std::int32_t>(meta.tokens_count);
+    }
 
     // ---- MoE -----------------------------------------------------------
     h.num_experts         = static_cast<std::int32_t>(get_num(meta, a, "expert_count",        0));

--- a/driver/portable/src/gguf_tokenizer.cpp
+++ b/driver/portable/src/gguf_tokenizer.cpp
@@ -35,10 +35,6 @@ struct GgufHandle {
     GgufHandle& operator=(const GgufHandle&) = delete;
 };
 
-bool has_key(gguf_context* ctx, const char* k) {
-    return gguf_find_key(ctx, k) >= 0;
-}
-
 std::string get_str(gguf_context* ctx, const char* k) {
     const std::int64_t id = gguf_find_key(ctx, k);
     if (id < 0) {
@@ -54,7 +50,6 @@ std::string get_str_or(gguf_context* ctx, const char* k, std::string fb) {
     return std::string(gguf_get_val_str(ctx, id));
 }
 
-// Read a uint32-ish scalar that may be encoded as u32/u64/i32 in GGUF.
 std::int64_t get_int_or(gguf_context* ctx, const char* k, std::int64_t fb) {
     const std::int64_t id = gguf_find_key(ctx, k);
     if (id < 0) return fb;
@@ -115,32 +110,15 @@ std::vector<std::int32_t> get_i32_array_or_empty(gguf_context* ctx, const char* 
     return out;
 }
 
-// ---------------------------------------------------------------------
-// Pre-tokenizer regex table.
-//
-// Mirrors llama.cpp's `llm_tokenizer_bpe` switch in
-// `src/llama-vocab.cpp`. Where llama.cpp keeps a comment with the
-// "original regex from tokenizer.json", that's the one we emit — it is
-// the canonical form HF's `tokenizers` crate accepts (the "adapted"
-// llama.cpp form rewrites `(?i:...)` into `(?:...)` etc. for its
-// internal regex engine; HF's onig-based Split supports both, but the
-// originals match what shipped tokenizer.json files actually contain).
-// ---------------------------------------------------------------------
-
+// Mirrors llama.cpp's `llm_tokenizer_bpe` switch (src/llama-vocab.cpp);
+// emits the "original tokenizer.json" regex form (the commented-out one
+// upstream) — that's what HF's `tokenizers` crate consumes verbatim.
 struct PreSpec {
-    std::vector<std::string> regex_exprs;  // in order
-    bool needs_nfc_normalizer = false;     // emit a top-level NFC normalizer
+    std::vector<std::string> regex_exprs;
+    bool needs_nfc_normalizer = false;  // qwen-family tokenizer.json sets NFC.
+    bool ignore_merges = false;          // upstream sets true for llama3, youtu, tekken.
 };
 
-// Returns a non-null PreSpec for known `pre` values, or throws.
-// Coverage notes (mirroring the `if-else` ladder in llama-vocab.cpp):
-//   * Most BPE families share one of a handful of regexes; we
-//     deduplicate at construction.
-//   * We default `needs_nfc_normalizer` to false. The Qwen-family
-//     reference tokenizer.json includes NFC normalization upfront;
-//     Llama-3 family does not. Other families overwhelmingly follow
-//     the Llama convention (no normalizer); we add NFC only where the
-//     upstream tokenizer.json is known to.
 PreSpec resolve_pre_spec(const std::string& pre) {
     // ---- shared regex strings (matches llama.cpp's grouping) -----------
     static const std::string kLlama3 =
@@ -160,10 +138,6 @@ PreSpec resolve_pre_spec(const std::string& pre) {
         "\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+";
     static const std::string kGpt2 =
         "'s|'t|'re|'ve|'m|'ll|'d| ?\\p{L}+| ?\\p{N}+| ?[^\\s\\p{L}\\p{N}]+|\\s+(?!\\S)";
-    static const std::string kStarcoder =
-        // STARCODER / REFACT / COMMAND_R / SMOLLM / CODESHELL / EXAONE / MINERVA
-        // share: { "\\p{N}", kGpt2 }
-        "";  // placeholder, actual builder below
     static const std::string kJais2 =
         "(?i:'s|'t|'re|'ve|'m|'ll|'d)|"
         "[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|"
@@ -206,18 +180,17 @@ PreSpec resolve_pre_spec(const std::string& pre) {
         "\\p{N}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n/]?|\\s*[\\r\\n]|\\s+(?!\\S)|\\s+";
 
     static const std::string kDefault0 = "[\\p{P}\\$\\+<=>\\^~\\|]+";
-    static const std::string kDefault1 = kFalcon1;  // same regex
     static const std::string kDefault2 = "\\p{N}+";
     static const std::string kDefault3 = "[0-9][0-9][0-9]";
 
     PreSpec spec;
 
-    // ---- llama3 family -----------------------------------------------
     if (pre == "llama3" || pre == "llama-v3" || pre == "llama-bpe" ||
         pre == "falcon3" || pre == "falcon-h1" || pre == "pixtral" ||
         pre == "midm-2.0" || pre == "lfm2" || pre == "jina-v5-nano" ||
         pre == "dbrx" || pre == "smaug-bpe") {
         spec.regex_exprs = {kLlama3};
+        spec.ignore_merges = true;
         return spec;
     }
     if (pre == "jais-2") {
@@ -225,7 +198,6 @@ PreSpec resolve_pre_spec(const std::string& pre) {
         return spec;
     }
 
-    // ---- DeepSeek family ---------------------------------------------
     if (pre == "deepseek-llm") {
         spec.regex_exprs = {
             "[\\r\\n]",
@@ -266,16 +238,15 @@ PreSpec resolve_pre_spec(const std::string& pre) {
             "(?i:'s|'t|'re|'ve|'m|'ll|'d)?|"
             "\\p{N}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n/]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+",
         };
+        spec.ignore_merges = true;
         return spec;
     }
 
-    // ---- Falcon ------------------------------------------------------
     if (pre == "falcon") {
         spec.regex_exprs = {kFalcon0, kFalcon1, kFalcon2};
         return spec;
     }
 
-    // ---- MPT / Starcoder family (single GPT-2-style regex) -----------
     if (pre == "mpt") { spec.regex_exprs = {kGpt2}; return spec; }
     if (pre == "starcoder" || pre == "refact" || pre == "command-r" ||
         pre == "smollm" || pre == "codeshell" || pre == "exaone" ||
@@ -284,12 +255,10 @@ PreSpec resolve_pre_spec(const std::string& pre) {
         return spec;
     }
 
-    // ---- gpt-2 lookalikes (single regex, GPT-2 family) ---------------
     if (pre == "gpt-2" || pre == "phi-2" || pre == "jina-es" ||
         pre == "jina-de" || pre == "gigachat" || pre == "jina-v2-es" ||
         pre == "jina-v2-de" || pre == "a.x-4.0" || pre == "mellum" ||
-        pre == "modern-bert" ||
-        pre == "mpt-redpajama" /* historical alias */ ||
+        pre == "modern-bert" || pre == "exaone4" ||
         pre == "olmo" || pre == "jais" || pre == "trillion" ||
         pre == "granite-docling" ||
         pre == "jina-v1-en" || pre == "jina-v2-code" || pre == "roberta-bpe") {
@@ -297,9 +266,8 @@ PreSpec resolve_pre_spec(const std::string& pre) {
         return spec;
     }
 
-    // ---- Qwen family (NFC normalizer + qwen2-style regex) ------------
     if (pre == "qwen2" || pre == "deepseek-r1-qwen" ||
-        pre == "kormo" || pre == "f2llmv2" ||
+        pre == "kormo" || pre == "f2llmv2" || pre == "megrez" ||
         pre == "stablelm2" || pre == "hunyuan" || pre == "solar-open") {
         spec.regex_exprs = {kQwen2};
         spec.needs_nfc_normalizer = true;
@@ -311,7 +279,6 @@ PreSpec resolve_pre_spec(const std::string& pre) {
         return spec;
     }
 
-    // ---- Poro / Bloom / GPT3-Finnish (single token regex) ------------
     if (pre == "poro-chat" || pre == "bloom" || pre == "gpt3-finnish") {
         spec.regex_exprs = {kPoro};
         return spec;
@@ -321,12 +288,13 @@ PreSpec resolve_pre_spec(const std::string& pre) {
         return spec;
     }
 
-    if (pre == "chatglm-bpe") {  // CHATGLM4
+    if (pre == "chatglm-bpe" || pre == "glm4") {
         spec.regex_exprs = {kChatGLM4};
         return spec;
     }
     if (pre == "tekken") {
         spec.regex_exprs = {kTekken};
+        spec.ignore_merges = true;
         return spec;
     }
     if (pre == "chameleon") {
@@ -340,11 +308,12 @@ PreSpec resolve_pre_spec(const std::string& pre) {
         };
         return spec;
     }
-    if (pre == "gpt-4o" || pre == "minimax-m2") {
+    if (pre == "gpt-4o" || pre == "minimax-m2" ||
+        pre == "llama4" || pre == "kanana2") {
         spec.regex_exprs = {kGpt4o};
         return spec;
     }
-    if (pre == "tiny-aya") {
+    if (pre == "tiny_aya") {
         spec.regex_exprs = {
             "\\d{1,3}(?=(?:\\d{3})*\\b)",
             "[^\\r\\n\\p{L}\\p{N}]?[\\p{Lu}\\p{Lt}\\p{Lm}\\p{Lo}\\p{M}]*"
@@ -363,7 +332,7 @@ PreSpec resolve_pre_spec(const std::string& pre) {
         spec.regex_exprs = {"\\p{N}+", "(?=(\\d{3})+(?!\\d))"};
         return spec;
     }
-    if (pre == "bailingmoe") {
+    if (pre == "bailingmoe" || pre == "bailingmoe2" || pre == "llada-moe") {
         spec.regex_exprs = {kBailingMoe};
         return spec;
     }
@@ -372,7 +341,7 @@ PreSpec resolve_pre_spec(const std::string& pre) {
         return spec;
     }
     if (pre == "grok-2") {
-        spec.regex_exprs = {kQwen2};  // identical to QWEN2 case
+        spec.regex_exprs = {kQwen2};
         return spec;
     }
     if (pre == "afmoe") {
@@ -390,16 +359,13 @@ PreSpec resolve_pre_spec(const std::string& pre) {
         return spec;
     }
     if (pre == "gemma4") {
-        // SPM-style BPE: tokenize after metaspace replacement; only split
-        // on newlines. We'd handle the byte-encoding off by setting
-        // `use_regex=false` on ByteLevel and using a Metaspace decoder
-        // instead — but pie's Gemma path isn't on GGUF yet, so emit the
-        // regex and let the user file an issue if it tokenizes wrong.
+        // SPM-style BPE; emits a newline-only split. Best-effort — Gemma4
+        // GGUFs need a Metaspace decoder this code path doesn't yet build.
         spec.regex_exprs = {"[^\\n]+|[\\n]+"};
         return spec;
     }
     if (pre == "default") {
-        spec.regex_exprs = {kDefault0, kDefault1, kDefault2, kDefault3};
+        spec.regex_exprs = {kDefault0, kFalcon1, kDefault2, kDefault3};
         return spec;
     }
 
@@ -408,19 +374,9 @@ PreSpec resolve_pre_spec(const std::string& pre) {
         "'. Update the regex table in driver/portable/src/gguf_tokenizer.cpp.");
 }
 
-// Split a "left right" merge entry into [left, right] using the LAST
-// whitespace as the separator. Some token strings contain spaces (e.g.
-// "Ġ Ġ" — two space-prefixed tokens), so splitting on the FIRST space
-// would produce the wrong pair; in BPE serialization the convention is
-// that the rightmost space is the separator. (HF's own writer joins via
-// `" "` between two byte-encoded tokens, neither of which can contain
-// a literal space in the encoded form unless the encoding produced one
-// — so split on the single space between them.)
-//
-// In practice GGUF stores merges as `left + " " + right` exactly; the
-// last-space rule keeps us safe for the corner case where ByteLevel
-// encoding produces tokens with a literal space inside (which doesn't
-// happen for the GPT-2 byte mapping — space becomes `Ġ`).
+// GGUF merges are stored as `left + " " + right`; split on the last
+// space so byte-level tokens that happen to contain a space don't trip
+// the splitter.
 std::pair<std::string, std::string> split_merge(const std::string& m) {
     const auto pos = m.rfind(' ');
     if (pos == std::string::npos) {
@@ -446,13 +402,9 @@ void emit_tokenizer_files(const std::filesystem::path& gguf_file,
     // -- Required scalars ------------------------------------------------
     const std::string model_type = get_str(ctx, "tokenizer.ggml.model");
     if (model_type != "gpt2") {
-        // SPM ("llama"), WordPiece ("bert"), Unigram ("t5"), and RWKV
-        // are not yet supported. Surface clearly — the user is hitting
-        // a GGUF whose tokenizer family pie can't synthesize yet.
         throw std::runtime_error(
             "gguf_tokenizer: tokenizer.ggml.model='" + model_type +
-            "' is not yet supported (need: 'gpt2'). "
-            "SPM/WordPiece/Unigram conversion is a separate follow-up.");
+            "' not supported (need 'gpt2'; SPM/WordPiece/Unigram are TODO).");
     }
     const std::string pre = get_str_or(ctx, "tokenizer.ggml.pre", "default");
     const PreSpec pre_spec = resolve_pre_spec(pre);
@@ -486,17 +438,17 @@ void emit_tokenizer_files(const std::filesystem::path& gguf_file,
         merges_arr.push_back(json::array({a, b}));
     }
 
-    // -- Build added_tokens -----------------------------------------------
-    // GGUF token_type values (from gguf-py):
-    //   1=NORMAL, 2=UNKNOWN, 3=CONTROL, 4=USER_DEFINED, 5=UNUSED, 6=BYTE
-    // Anything not NORMAL/UNUSED/BYTE should be exposed as a special added
-    // token so HF Tokenizer treats it atomically.
+    // token_type values: 2=UNKNOWN, 3=CONTROL, 4=USER_DEFINED.
+    auto is_control_type = [&](std::int64_t id) {
+        if (id < 0 || static_cast<std::size_t>(id) >= token_types.size()) return false;
+        const auto t = token_types[static_cast<std::size_t>(id)];
+        return t == 2 || t == 3 || t == 4;
+    };
     std::unordered_set<std::int64_t> added_ids;
     json added_tokens = json::array();
     auto push_added = [&](std::int64_t id, bool special) {
         if (id < 0 || static_cast<std::size_t>(id) >= tokens.size()) return;
-        if (added_ids.count(id)) return;
-        added_ids.insert(id);
+        if (!added_ids.insert(id).second) return;
         added_tokens.push_back({
             {"id", id},
             {"content", tokens[static_cast<std::size_t>(id)]},
@@ -507,20 +459,25 @@ void emit_tokenizer_files(const std::filesystem::path& gguf_file,
             {"special", special},
         });
     };
-    if (!token_types.empty() && token_types.size() == tokens.size()) {
+    if (token_types.size() == tokens.size()) {
         for (std::size_t i = 0; i < tokens.size(); ++i) {
-            const auto t = token_types[i];
-            if (t == 3 /*CONTROL*/ || t == 4 /*USER_DEFINED*/ || t == 2 /*UNKNOWN*/) {
-                push_added(static_cast<std::int64_t>(i), /*special=*/true);
+            if (is_control_type(static_cast<std::int64_t>(i))) {
+                push_added(static_cast<std::int64_t>(i), true);
             }
         }
     }
-    // Always-include canonical special IDs even when token_type didn't flag them.
-    push_added(bos_id, true);
-    push_added(eos_id, true);
-    push_added(pad_id, true);
-    push_added(unk_id, true);
-    push_added(sep_id, true);
+    // Canonical special IDs: mark special only when token_type agrees (or
+    // is absent). Skip otherwise so a NORMAL token doesn't get mis-flagged.
+    auto push_canonical = [&](std::int64_t id) {
+        if (id < 0) return;
+        const bool special = token_types.empty() || is_control_type(id);
+        push_added(id, special);
+    };
+    push_canonical(bos_id);
+    push_canonical(eos_id);
+    push_canonical(pad_id);
+    push_canonical(unk_id);
+    push_canonical(sep_id);
 
     // -- Pre-tokenizer ----------------------------------------------------
     json pre_tokenizers = json::array();
@@ -550,17 +507,13 @@ void emit_tokenizer_files(const std::filesystem::path& gguf_file,
         normalizer = {{"type", "NFC"}};
     }
 
-    // -- Post-processor + decoder (ByteLevel pass-through) ---------------
     json byte_level_pp = {
         {"type",             "ByteLevel"},
         {"add_prefix_space", false},
         {"trim_offsets",     false},
         {"use_regex",        false},
     };
-    json decoder = byte_level_pp;
-    json post_processor = byte_level_pp;
 
-    // -- BPE model body ---------------------------------------------------
     json model_body = {
         {"type",                      "BPE"},
         {"dropout",                   nullptr},
@@ -569,7 +522,7 @@ void emit_tokenizer_files(const std::filesystem::path& gguf_file,
         {"end_of_word_suffix",        nullptr},
         {"fuse_unk",                  false},
         {"byte_fallback",             false},
-        {"ignore_merges",             true},
+        {"ignore_merges",             pre_spec.ignore_merges},
         {"vocab",                     vocab},
         {"merges",                    merges_arr},
     };
@@ -582,8 +535,8 @@ void emit_tokenizer_files(const std::filesystem::path& gguf_file,
         {"added_tokens",   added_tokens},
         {"normalizer",     normalizer},
         {"pre_tokenizer",  pre_tokenizer},
-        {"post_processor", post_processor},
-        {"decoder",        decoder},
+        {"post_processor", byte_level_pp},
+        {"decoder",        byte_level_pp},
         {"model",          model_body},
     };
 
@@ -597,7 +550,6 @@ void emit_tokenizer_files(const std::filesystem::path& gguf_file,
         f << tok.dump(/*indent=*/-1);
     }
 
-    // -- tokenizer_config.json (chat template, special tokens) -----------
     json tok_cfg = json::object();
     if (!chat_template.empty()) {
         tok_cfg["chat_template"] = chat_template;

--- a/driver/portable/src/gguf_tokenizer.cpp
+++ b/driver/portable/src/gguf_tokenizer.cpp
@@ -1,0 +1,624 @@
+#include "gguf_tokenizer.hpp"
+
+#include <cstdint>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <gguf.h>
+#include <nlohmann/json.hpp>
+
+namespace pie_portable_driver {
+
+namespace {
+
+using json = nlohmann::json;
+
+// Wrap a gguf_context with RAII for the local read.
+struct GgufHandle {
+    gguf_context* ctx = nullptr;
+    explicit GgufHandle(const std::filesystem::path& p) {
+        gguf_init_params ip{};
+        ip.no_alloc = true;
+        ip.ctx      = nullptr;
+        ctx = gguf_init_from_file(p.string().c_str(), ip);
+        if (!ctx) {
+            throw std::runtime_error(
+                "gguf_tokenizer: gguf_init_from_file failed for " + p.string());
+        }
+    }
+    ~GgufHandle() { if (ctx) gguf_free(ctx); }
+    GgufHandle(const GgufHandle&) = delete;
+    GgufHandle& operator=(const GgufHandle&) = delete;
+};
+
+bool has_key(gguf_context* ctx, const char* k) {
+    return gguf_find_key(ctx, k) >= 0;
+}
+
+std::string get_str(gguf_context* ctx, const char* k) {
+    const std::int64_t id = gguf_find_key(ctx, k);
+    if (id < 0) {
+        throw std::runtime_error(
+            std::string("gguf_tokenizer: missing string key '") + k + "'");
+    }
+    return std::string(gguf_get_val_str(ctx, id));
+}
+
+std::string get_str_or(gguf_context* ctx, const char* k, std::string fb) {
+    const std::int64_t id = gguf_find_key(ctx, k);
+    if (id < 0) return fb;
+    return std::string(gguf_get_val_str(ctx, id));
+}
+
+// Read a uint32-ish scalar that may be encoded as u32/u64/i32 in GGUF.
+std::int64_t get_int_or(gguf_context* ctx, const char* k, std::int64_t fb) {
+    const std::int64_t id = gguf_find_key(ctx, k);
+    if (id < 0) return fb;
+    const auto t = gguf_get_kv_type(ctx, id);
+    switch (t) {
+        case GGUF_TYPE_UINT8:  return gguf_get_val_u8 (ctx, id);
+        case GGUF_TYPE_INT8:   return gguf_get_val_i8 (ctx, id);
+        case GGUF_TYPE_UINT16: return gguf_get_val_u16(ctx, id);
+        case GGUF_TYPE_INT16:  return gguf_get_val_i16(ctx, id);
+        case GGUF_TYPE_UINT32: return gguf_get_val_u32(ctx, id);
+        case GGUF_TYPE_INT32:  return gguf_get_val_i32(ctx, id);
+        case GGUF_TYPE_UINT64: return static_cast<std::int64_t>(gguf_get_val_u64(ctx, id));
+        case GGUF_TYPE_INT64:  return gguf_get_val_i64(ctx, id);
+        default: return fb;
+    }
+}
+
+std::vector<std::string> get_str_array(gguf_context* ctx, const char* k) {
+    const std::int64_t id = gguf_find_key(ctx, k);
+    if (id < 0) {
+        throw std::runtime_error(
+            std::string("gguf_tokenizer: missing array key '") + k + "'");
+    }
+    if (gguf_get_kv_type(ctx, id) != GGUF_TYPE_ARRAY) {
+        throw std::runtime_error(
+            std::string("gguf_tokenizer: key '") + k + "' is not an array");
+    }
+    if (gguf_get_arr_type(ctx, id) != GGUF_TYPE_STRING) {
+        throw std::runtime_error(
+            std::string("gguf_tokenizer: array '") + k +
+            "' has non-string element type");
+    }
+    const std::size_t n = gguf_get_arr_n(ctx, id);
+    std::vector<std::string> out;
+    out.reserve(n);
+    for (std::size_t i = 0; i < n; ++i) {
+        out.emplace_back(gguf_get_arr_str(ctx, id, i));
+    }
+    return out;
+}
+
+std::vector<std::int32_t> get_i32_array_or_empty(gguf_context* ctx, const char* k) {
+    const std::int64_t id = gguf_find_key(ctx, k);
+    if (id < 0) return {};
+    if (gguf_get_kv_type(ctx, id) != GGUF_TYPE_ARRAY) return {};
+    const auto et = gguf_get_arr_type(ctx, id);
+    if (et != GGUF_TYPE_INT32 && et != GGUF_TYPE_UINT32) return {};
+    const std::size_t n = gguf_get_arr_n(ctx, id);
+    const void* raw = gguf_get_arr_data(ctx, id);
+    std::vector<std::int32_t> out(n);
+    if (et == GGUF_TYPE_INT32) {
+        const auto* p = static_cast<const std::int32_t*>(raw);
+        for (std::size_t i = 0; i < n; ++i) out[i] = p[i];
+    } else {
+        const auto* p = static_cast<const std::uint32_t*>(raw);
+        for (std::size_t i = 0; i < n; ++i) out[i] = static_cast<std::int32_t>(p[i]);
+    }
+    return out;
+}
+
+// ---------------------------------------------------------------------
+// Pre-tokenizer regex table.
+//
+// Mirrors llama.cpp's `llm_tokenizer_bpe` switch in
+// `src/llama-vocab.cpp`. Where llama.cpp keeps a comment with the
+// "original regex from tokenizer.json", that's the one we emit — it is
+// the canonical form HF's `tokenizers` crate accepts (the "adapted"
+// llama.cpp form rewrites `(?i:...)` into `(?:...)` etc. for its
+// internal regex engine; HF's onig-based Split supports both, but the
+// originals match what shipped tokenizer.json files actually contain).
+// ---------------------------------------------------------------------
+
+struct PreSpec {
+    std::vector<std::string> regex_exprs;  // in order
+    bool needs_nfc_normalizer = false;     // emit a top-level NFC normalizer
+};
+
+// Returns a non-null PreSpec for known `pre` values, or throws.
+// Coverage notes (mirroring the `if-else` ladder in llama-vocab.cpp):
+//   * Most BPE families share one of a handful of regexes; we
+//     deduplicate at construction.
+//   * We default `needs_nfc_normalizer` to false. The Qwen-family
+//     reference tokenizer.json includes NFC normalization upfront;
+//     Llama-3 family does not. Other families overwhelmingly follow
+//     the Llama convention (no normalizer); we add NFC only where the
+//     upstream tokenizer.json is known to.
+PreSpec resolve_pre_spec(const std::string& pre) {
+    // ---- shared regex strings (matches llama.cpp's grouping) -----------
+    static const std::string kLlama3 =
+        "(?i:'s|'t|'re|'ve|'m|'ll|'d)|"
+        "[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|"
+        "\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|"
+        "\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+";
+    static const std::string kQwen2 =
+        "(?i:'s|'t|'re|'ve|'m|'ll|'d)|"
+        "[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|"
+        "\\p{N}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|"
+        "\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+";
+    static const std::string kQwen35 =
+        "(?i:'s|'t|'re|'ve|'m|'ll|'d)|"
+        "[^\\r\\n\\p{L}\\p{N}]?[\\p{L}\\p{M}]+|"
+        "\\p{N}| ?[^\\s\\p{L}\\p{M}\\p{N}]+[\\r\\n]*|"
+        "\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+";
+    static const std::string kGpt2 =
+        "'s|'t|'re|'ve|'m|'ll|'d| ?\\p{L}+| ?\\p{N}+| ?[^\\s\\p{L}\\p{N}]+|\\s+(?!\\S)";
+    static const std::string kStarcoder =
+        // STARCODER / REFACT / COMMAND_R / SMOLLM / CODESHELL / EXAONE / MINERVA
+        // share: { "\\p{N}", kGpt2 }
+        "";  // placeholder, actual builder below
+    static const std::string kJais2 =
+        "(?i:'s|'t|'re|'ve|'m|'ll|'d)|"
+        "[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|"
+        "\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|"
+        "\\s{512}(?!\\S)|\\s{256}(?!\\S)|\\s{128}(?!\\S)|\\s{64}(?!\\S)|"
+        "\\s{32}(?!\\S)|\\s{16}(?!\\S)|\\s{8}(?!\\S)|\\s{4}(?!\\S)|"
+        "\\s{1,2}(?!\\S)|\\s{1}";
+    static const std::string kFalcon0 =
+        "[\\p{P}\\$\\+<=>\\^~\\|`]+";
+    static const std::string kFalcon1 =
+        "'s|'t|'re|'ve|'m|'ll|'d| ?\\p{L}+| ?\\p{N}+| ?[^\\s\\p{L}\\p{N}]+|\\s+(?!\\S)";
+    static const std::string kFalcon2 = "[0-9][0-9][0-9]";
+    static const std::string kPoro    = " ?[^(\\s|.,!?…。，、।۔،)]+";
+    static const std::string kChatGLM4 =
+        "(?i:'s|'t|'re|'ve|'m|'ll|'d)|"
+        "[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|"
+        "\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+";
+    static const std::string kTekken =
+        "[^\\r\\n\\p{L}\\p{N}]?[\\p{Lu}\\p{Lt}\\p{Lm}\\p{Lo}\\p{M}]*"
+        "[\\p{Ll}\\p{Lm}\\p{Lo}\\p{M}]+|"
+        "[^\\r\\n\\p{L}\\p{N}]?[\\p{Lu}\\p{Lt}\\p{Lm}\\p{Lo}\\p{M}]+"
+        "[\\p{Ll}\\p{Lm}\\p{Lo}\\p{M}]*|"
+        "\\p{N}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n/]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+";
+    static const std::string kGpt4o =
+        "[^\\r\\n\\p{L}\\p{N}]?[\\p{Lu}\\p{Lt}\\p{Lm}\\p{Lo}\\p{M}]*"
+        "[\\p{Ll}\\p{Lm}\\p{Lo}\\p{M}]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?|"
+        "[^\\r\\n\\p{L}\\p{N}]?[\\p{Lu}\\p{Lt}\\p{Lm}\\p{Lo}\\p{M}]+"
+        "[\\p{Ll}\\p{Lm}\\p{Lo}\\p{M}]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?|"
+        "\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n/]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+";
+    static const std::string kSeedCoder =
+        "(?i:'s|'t|'re|'ve|'m|'ll|'d)|"
+        "[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}{1}|"
+        " ?[^\\s\\p{L}\\p{N}\\r\\n]+|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+";
+    static const std::string kBailingMoe =
+        "'(?i:[sdmt]|ll|ve|re)|[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}|"
+        " ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]|\\s+(?!\\S)|\\s+";
+    static const std::string kExaoneMoe =
+        "(?i:'s|'t|'re|'ve|'m|'ll|'d)|"
+        "[^\\r\\n\\p{L}\\p{N}]?(?:\\p{L}\\p{M}*(?: \\p{L}\\p{M}*)*)+|"
+        "\\p{N}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n/]?|\\s*[\\r\\n]|\\s+(?!\\S)|\\s+";
+
+    static const std::string kDefault0 = "[\\p{P}\\$\\+<=>\\^~\\|]+";
+    static const std::string kDefault1 = kFalcon1;  // same regex
+    static const std::string kDefault2 = "\\p{N}+";
+    static const std::string kDefault3 = "[0-9][0-9][0-9]";
+
+    PreSpec spec;
+
+    // ---- llama3 family -----------------------------------------------
+    if (pre == "llama3" || pre == "llama-v3" || pre == "llama-bpe" ||
+        pre == "falcon3" || pre == "falcon-h1" || pre == "pixtral" ||
+        pre == "midm-2.0" || pre == "lfm2" || pre == "jina-v5-nano" ||
+        pre == "dbrx" || pre == "smaug-bpe") {
+        spec.regex_exprs = {kLlama3};
+        return spec;
+    }
+    if (pre == "jais-2") {
+        spec.regex_exprs = {kJais2};
+        return spec;
+    }
+
+    // ---- DeepSeek family ---------------------------------------------
+    if (pre == "deepseek-llm") {
+        spec.regex_exprs = {
+            "[\\r\\n]",
+            "\\s?[A-Za-zµÀ-ÖØ-öø-ƺƼ-ƿǄ-ʓʕ-ʯͰ-ͳͶͷͻ-ͽͿΆΈ-ΊΌΎ-ΡΣ-ϵϷ-ҁҊ-ԯԱ-ՖႠ-ჅᎠ-Ᏽᏸ-ᏽᲐ-ᲺᲽ-Ჿᴀ-ᴫᵫ-ᵷᵹ-ᶚḀ-ἕἘ-Ἕἠ-ὅὈ-Ὅὐ-ὗὙὛὝὟ-ώᾀ-ᾴᾶ-ᾼιῂ-ῄῆ-ῌῐ-ΐῖ-Ίῠ-Ῥῲ-ῴῶ-ῼℂℇℊ-ℓℕℙ-ℝℤΩℨK-ℭℯ-ℴℹℼ-ℿⅅ-ⅉⅎↃↄⰀ-ⱻⱾ-ⳤⳫ-ⳮⳲⳳꙀ-ꙭꚀ-ꚛꜢ-ꝯꝱ-ꞇꞋ-ꞎꭰ-ꮿﬀ-ﬆﬓ-ﬗＡ-Ｚａ-ｚ𐐀-𐑏𐒰-𐓓𐓘-𐓻𐲀-𐳲𐳀-𐳲𑢠-𑣟𞤀-𞥃]+",
+            "\\s?[!-/:-~！-／：-～‘-‟　-。]+",
+            "\\s+$",
+            "[一-龥ࠀ-一가-퟿]+",
+            "\\p{N}+",
+        };
+        return spec;
+    }
+    if (pre == "deepseek-coder") {
+        spec.regex_exprs = {
+            "[\\r\\n]",
+            "\\s?\\p{L}+",
+            "\\s?\\p{P}+",
+            "[一-龥ࠀ-一가-퟿]+",
+            "\\p{N}",
+        };
+        return spec;
+    }
+    if (pre == "deepseek-v3" || pre == "hunyuan-dense" || pre == "joyai-llm") {
+        spec.regex_exprs = {
+            "\\p{N}{1,3}",
+            "[一-龥぀-ゟ゠-ヿ]+",
+            "[!\"#$%&'()*+,\\-./:;<=>?@\\[\\\\\\]^_`{|}~][A-Za-z]+|"
+            "[^\\r\\n\\p{L}\\p{P}\\p{S}]?[\\p{L}\\p{M}]+| ?[\\p{P}\\p{S}]+[\\r\\n]*|"
+            "\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+",
+        };
+        return spec;
+    }
+    if (pre == "youtu") {
+        spec.regex_exprs = {
+            "[가-힣ㄱ-ㆎ]+|[！…“”‘’—：；，、-〿︰-﹏]+|[ㄅ-ㄯ]+|[一-龥぀-ゟ゠-ヿ]+",
+            "[^\\r\\n\\p{L}\\p{N}]?[\\p{Lu}\\p{Lt}\\p{Lm}\\p{Lo}\\p{M}]*[\\p{Ll}\\p{Lm}\\p{Lo}\\p{M}]+"
+            "(?i:'s|'t|'re|'ve|'m|'ll|'d)?|"
+            "[^\\r\\n\\p{L}\\p{N}]?[\\p{Lu}\\p{Lt}\\p{Lm}\\p{Lo}\\p{M}]+[\\p{Ll}\\p{Lm}\\p{Lo}\\p{M}]*"
+            "(?i:'s|'t|'re|'ve|'m|'ll|'d)?|"
+            "\\p{N}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n/]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+",
+        };
+        return spec;
+    }
+
+    // ---- Falcon ------------------------------------------------------
+    if (pre == "falcon") {
+        spec.regex_exprs = {kFalcon0, kFalcon1, kFalcon2};
+        return spec;
+    }
+
+    // ---- MPT / Starcoder family (single GPT-2-style regex) -----------
+    if (pre == "mpt") { spec.regex_exprs = {kGpt2}; return spec; }
+    if (pre == "starcoder" || pre == "refact" || pre == "command-r" ||
+        pre == "smollm" || pre == "codeshell" || pre == "exaone" ||
+        pre == "minerva-7b") {
+        spec.regex_exprs = {"\\p{N}", kGpt2};
+        return spec;
+    }
+
+    // ---- gpt-2 lookalikes (single regex, GPT-2 family) ---------------
+    if (pre == "gpt-2" || pre == "phi-2" || pre == "jina-es" ||
+        pre == "jina-de" || pre == "gigachat" || pre == "jina-v2-es" ||
+        pre == "jina-v2-de" || pre == "a.x-4.0" || pre == "mellum" ||
+        pre == "modern-bert" ||
+        pre == "mpt-redpajama" /* historical alias */ ||
+        pre == "olmo" || pre == "jais" || pre == "trillion" ||
+        pre == "granite-docling" ||
+        pre == "jina-v1-en" || pre == "jina-v2-code" || pre == "roberta-bpe") {
+        spec.regex_exprs = {kGpt2};
+        return spec;
+    }
+
+    // ---- Qwen family (NFC normalizer + qwen2-style regex) ------------
+    if (pre == "qwen2" || pre == "deepseek-r1-qwen" ||
+        pre == "kormo" || pre == "f2llmv2" ||
+        pre == "stablelm2" || pre == "hunyuan" || pre == "solar-open") {
+        spec.regex_exprs = {kQwen2};
+        spec.needs_nfc_normalizer = true;
+        return spec;
+    }
+    if (pre == "qwen35") {
+        spec.regex_exprs = {kQwen35};
+        spec.needs_nfc_normalizer = true;
+        return spec;
+    }
+
+    // ---- Poro / Bloom / GPT3-Finnish (single token regex) ------------
+    if (pre == "poro-chat" || pre == "bloom" || pre == "gpt3-finnish") {
+        spec.regex_exprs = {kPoro};
+        return spec;
+    }
+    if (pre == "viking") {
+        spec.regex_exprs = {kPoro, "\\p{N}"};
+        return spec;
+    }
+
+    if (pre == "chatglm-bpe") {  // CHATGLM4
+        spec.regex_exprs = {kChatGLM4};
+        return spec;
+    }
+    if (pre == "tekken") {
+        spec.regex_exprs = {kTekken};
+        return spec;
+    }
+    if (pre == "chameleon") {
+        spec.regex_exprs = {
+            "<sentinel:[0-9]+>",
+            "(IMGIMG)((A|B|C|D|E|F|G|H|I){1,4})Z",
+            "([\\t\\n]|    |  )",
+            "\\p{N}",
+            "[\\p{P}!-/:-@\\[-`{-~]",
+            kGpt2,
+        };
+        return spec;
+    }
+    if (pre == "gpt-4o" || pre == "minimax-m2") {
+        spec.regex_exprs = {kGpt4o};
+        return spec;
+    }
+    if (pre == "tiny-aya") {
+        spec.regex_exprs = {
+            "\\d{1,3}(?=(?:\\d{3})*\\b)",
+            "[^\\r\\n\\p{L}\\p{N}]?[\\p{Lu}\\p{Lt}\\p{Lm}\\p{Lo}\\p{M}]*"
+            "[\\p{Ll}\\p{Lm}\\p{Lo}\\p{M}]+(?i:'s|'t|'re|'ve|'m|'ll|'d)?|"
+            "[^\\r\\n\\p{L}\\p{N}]?[\\p{Lu}\\p{Lt}\\p{Lm}\\p{Lo}\\p{M}]+"
+            "[\\p{Ll}\\p{Lm}\\p{Lo}\\p{M}]*(?i:'s|'t|'re|'ve|'m|'ll|'d)?|"
+            "\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n/]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+",
+        };
+        return spec;
+    }
+    if (pre == "kimi-k2") {
+        spec.regex_exprs = {"\\p{Han}+"};
+        return spec;
+    }
+    if (pre == "superbpe") {
+        spec.regex_exprs = {"\\p{N}+", "(?=(\\d{3})+(?!\\d))"};
+        return spec;
+    }
+    if (pre == "bailingmoe") {
+        spec.regex_exprs = {kBailingMoe};
+        return spec;
+    }
+    if (pre == "seed-coder") {
+        spec.regex_exprs = {kSeedCoder};
+        return spec;
+    }
+    if (pre == "grok-2") {
+        spec.regex_exprs = {kQwen2};  // identical to QWEN2 case
+        return spec;
+    }
+    if (pre == "afmoe") {
+        spec.regex_exprs = {
+            "\\p{AFMoE_digits}",
+            "[一-鿿㐀-䶿豈-﫿぀-ゟ゠-ヿ･-ﾟ⼀-⿟เ-๿຀-໿ក-៿က-႟ꩠ-ꩿꧠ-꧿가-힯ᄀ-ᇿ]+",
+            "[!\"#$%&'()*+,\\-./:;<=>?@\\[\\\\\\]^_`{|}~][A-Za-z]+|"
+            "[^\\r\\n\\p{L}\\p{P}\\p{S}]?[\\p{L}\\p{M}]+| ?[\\p{P}\\p{S}]+[\\r\\n]*|"
+            "\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+",
+        };
+        return spec;
+    }
+    if (pre == "exaone-moe") {
+        spec.regex_exprs = {kExaoneMoe};
+        return spec;
+    }
+    if (pre == "gemma4") {
+        // SPM-style BPE: tokenize after metaspace replacement; only split
+        // on newlines. We'd handle the byte-encoding off by setting
+        // `use_regex=false` on ByteLevel and using a Metaspace decoder
+        // instead — but pie's Gemma path isn't on GGUF yet, so emit the
+        // regex and let the user file an issue if it tokenizes wrong.
+        spec.regex_exprs = {"[^\\n]+|[\\n]+"};
+        return spec;
+    }
+    if (pre == "default") {
+        spec.regex_exprs = {kDefault0, kDefault1, kDefault2, kDefault3};
+        return spec;
+    }
+
+    throw std::runtime_error(
+        "gguf_tokenizer: unsupported tokenizer.ggml.pre='" + pre +
+        "'. Update the regex table in driver/portable/src/gguf_tokenizer.cpp.");
+}
+
+// Split a "left right" merge entry into [left, right] using the LAST
+// whitespace as the separator. Some token strings contain spaces (e.g.
+// "Ġ Ġ" — two space-prefixed tokens), so splitting on the FIRST space
+// would produce the wrong pair; in BPE serialization the convention is
+// that the rightmost space is the separator. (HF's own writer joins via
+// `" "` between two byte-encoded tokens, neither of which can contain
+// a literal space in the encoded form unless the encoding produced one
+// — so split on the single space between them.)
+//
+// In practice GGUF stores merges as `left + " " + right` exactly; the
+// last-space rule keeps us safe for the corner case where ByteLevel
+// encoding produces tokens with a literal space inside (which doesn't
+// happen for the GPT-2 byte mapping — space becomes `Ġ`).
+std::pair<std::string, std::string> split_merge(const std::string& m) {
+    const auto pos = m.rfind(' ');
+    if (pos == std::string::npos) {
+        throw std::runtime_error(
+            "gguf_tokenizer: merge entry has no space separator: '" + m + "'");
+    }
+    return {m.substr(0, pos), m.substr(pos + 1)};
+}
+
+}  // namespace
+
+void emit_tokenizer_files(const std::filesystem::path& gguf_file,
+                          const std::filesystem::path& target_dir) {
+    if (!std::filesystem::is_directory(target_dir)) {
+        throw std::runtime_error(
+            "gguf_tokenizer: target_dir must exist and be a directory: " +
+            target_dir.string());
+    }
+
+    GgufHandle gg(gguf_file);
+    gguf_context* ctx = gg.ctx;
+
+    // -- Required scalars ------------------------------------------------
+    const std::string model_type = get_str(ctx, "tokenizer.ggml.model");
+    if (model_type != "gpt2") {
+        // SPM ("llama"), WordPiece ("bert"), Unigram ("t5"), and RWKV
+        // are not yet supported. Surface clearly — the user is hitting
+        // a GGUF whose tokenizer family pie can't synthesize yet.
+        throw std::runtime_error(
+            "gguf_tokenizer: tokenizer.ggml.model='" + model_type +
+            "' is not yet supported (need: 'gpt2'). "
+            "SPM/WordPiece/Unigram conversion is a separate follow-up.");
+    }
+    const std::string pre = get_str_or(ctx, "tokenizer.ggml.pre", "default");
+    const PreSpec pre_spec = resolve_pre_spec(pre);
+
+    const std::vector<std::string> tokens =
+        get_str_array(ctx, "tokenizer.ggml.tokens");
+    const std::vector<std::string> merges =
+        get_str_array(ctx, "tokenizer.ggml.merges");
+    const std::vector<std::int32_t> token_types =
+        get_i32_array_or_empty(ctx, "tokenizer.ggml.token_type");
+
+    const std::int64_t bos_id = get_int_or(ctx, "tokenizer.ggml.bos_token_id", -1);
+    const std::int64_t eos_id = get_int_or(ctx, "tokenizer.ggml.eos_token_id", -1);
+    const std::int64_t pad_id = get_int_or(ctx, "tokenizer.ggml.padding_token_id", -1);
+    const std::int64_t unk_id = get_int_or(ctx, "tokenizer.ggml.unknown_token_id", -1);
+    const std::int64_t sep_id = get_int_or(ctx, "tokenizer.ggml.seperator_token_id", -1);
+
+    const std::string chat_template =
+        get_str_or(ctx, "tokenizer.chat_template", "");
+
+    // -- Build vocab map --------------------------------------------------
+    json vocab = json::object();
+    for (std::size_t i = 0; i < tokens.size(); ++i) {
+        vocab[tokens[i]] = static_cast<std::int64_t>(i);
+    }
+
+    // -- Build merges array (pair form) -----------------------------------
+    json merges_arr = json::array();
+    for (const auto& m : merges) {
+        const auto [a, b] = split_merge(m);
+        merges_arr.push_back(json::array({a, b}));
+    }
+
+    // -- Build added_tokens -----------------------------------------------
+    // GGUF token_type values (from gguf-py):
+    //   1=NORMAL, 2=UNKNOWN, 3=CONTROL, 4=USER_DEFINED, 5=UNUSED, 6=BYTE
+    // Anything not NORMAL/UNUSED/BYTE should be exposed as a special added
+    // token so HF Tokenizer treats it atomically.
+    std::unordered_set<std::int64_t> added_ids;
+    json added_tokens = json::array();
+    auto push_added = [&](std::int64_t id, bool special) {
+        if (id < 0 || static_cast<std::size_t>(id) >= tokens.size()) return;
+        if (added_ids.count(id)) return;
+        added_ids.insert(id);
+        added_tokens.push_back({
+            {"id", id},
+            {"content", tokens[static_cast<std::size_t>(id)]},
+            {"single_word", false},
+            {"lstrip", false},
+            {"rstrip", false},
+            {"normalized", false},
+            {"special", special},
+        });
+    };
+    if (!token_types.empty() && token_types.size() == tokens.size()) {
+        for (std::size_t i = 0; i < tokens.size(); ++i) {
+            const auto t = token_types[i];
+            if (t == 3 /*CONTROL*/ || t == 4 /*USER_DEFINED*/ || t == 2 /*UNKNOWN*/) {
+                push_added(static_cast<std::int64_t>(i), /*special=*/true);
+            }
+        }
+    }
+    // Always-include canonical special IDs even when token_type didn't flag them.
+    push_added(bos_id, true);
+    push_added(eos_id, true);
+    push_added(pad_id, true);
+    push_added(unk_id, true);
+    push_added(sep_id, true);
+
+    // -- Pre-tokenizer ----------------------------------------------------
+    json pre_tokenizers = json::array();
+    for (const auto& re : pre_spec.regex_exprs) {
+        pre_tokenizers.push_back({
+            {"type",     "Split"},
+            {"pattern",  {{"Regex", re}}},
+            {"behavior", "Isolated"},
+            {"invert",   false},
+        });
+    }
+    pre_tokenizers.push_back({
+        {"type",            "ByteLevel"},
+        {"add_prefix_space", false},
+        {"trim_offsets",     false},
+        {"use_regex",        false},
+    });
+
+    json pre_tokenizer = {
+        {"type",          "Sequence"},
+        {"pretokenizers", pre_tokenizers},
+    };
+
+    // -- Normalizer -------------------------------------------------------
+    json normalizer = nullptr;
+    if (pre_spec.needs_nfc_normalizer) {
+        normalizer = {{"type", "NFC"}};
+    }
+
+    // -- Post-processor + decoder (ByteLevel pass-through) ---------------
+    json byte_level_pp = {
+        {"type",             "ByteLevel"},
+        {"add_prefix_space", false},
+        {"trim_offsets",     false},
+        {"use_regex",        false},
+    };
+    json decoder = byte_level_pp;
+    json post_processor = byte_level_pp;
+
+    // -- BPE model body ---------------------------------------------------
+    json model_body = {
+        {"type",                      "BPE"},
+        {"dropout",                   nullptr},
+        {"unk_token",                 nullptr},
+        {"continuing_subword_prefix", nullptr},
+        {"end_of_word_suffix",        nullptr},
+        {"fuse_unk",                  false},
+        {"byte_fallback",             false},
+        {"ignore_merges",             true},
+        {"vocab",                     vocab},
+        {"merges",                    merges_arr},
+    };
+
+    // -- tokenizer.json ---------------------------------------------------
+    json tok = {
+        {"version",        "1.0"},
+        {"truncation",     nullptr},
+        {"padding",        nullptr},
+        {"added_tokens",   added_tokens},
+        {"normalizer",     normalizer},
+        {"pre_tokenizer",  pre_tokenizer},
+        {"post_processor", post_processor},
+        {"decoder",        decoder},
+        {"model",          model_body},
+    };
+
+    {
+        std::ofstream f(target_dir / "tokenizer.json");
+        if (!f) {
+            throw std::runtime_error(
+                "gguf_tokenizer: cannot open tokenizer.json for write in " +
+                target_dir.string());
+        }
+        f << tok.dump(/*indent=*/-1);
+    }
+
+    // -- tokenizer_config.json (chat template, special tokens) -----------
+    json tok_cfg = json::object();
+    if (!chat_template.empty()) {
+        tok_cfg["chat_template"] = chat_template;
+    }
+    auto add_special = [&](const char* k, std::int64_t id) {
+        if (id < 0 || static_cast<std::size_t>(id) >= tokens.size()) return;
+        tok_cfg[k] = tokens[static_cast<std::size_t>(id)];
+    };
+    add_special("bos_token", bos_id);
+    add_special("eos_token", eos_id);
+    add_special("pad_token", pad_id);
+    add_special("unk_token", unk_id);
+    {
+        std::ofstream f(target_dir / "tokenizer_config.json");
+        if (!f) {
+            throw std::runtime_error(
+                "gguf_tokenizer: cannot open tokenizer_config.json for write in " +
+                target_dir.string());
+        }
+        f << tok_cfg.dump(/*indent=*/2);
+    }
+}
+
+}  // namespace pie_portable_driver

--- a/driver/portable/src/gguf_tokenizer.hpp
+++ b/driver/portable/src/gguf_tokenizer.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+// Emit a HuggingFace `tokenizers`-compatible `tokenizer.json` (and
+// `tokenizer_config.json`) from a GGUF file's `tokenizer.ggml.*` KV
+// metadata. Lets pie's server-side Tokenizer::from_file stay unchanged
+// for `.gguf` snapshot paths — the driver mints the JSON to a temp dir
+// and reports that dir as the snapshot_dir in its capabilities.
+
+#include <filesystem>
+
+namespace pie_portable_driver {
+
+// Read the tokenizer KVs from `gguf_file` and write `tokenizer.json` and
+// `tokenizer_config.json` into `target_dir` (must exist). Throws on:
+//   * unsupported `tokenizer.ggml.model` (e.g. "bert" / "t5" / "rwkv")
+//   * unknown `tokenizer.ggml.pre` value (we hardcode llama.cpp's table)
+//   * missing required arrays (`tokens`, `merges` for BPE)
+// The thrown message names the offending key and what we support.
+void emit_tokenizer_files(const std::filesystem::path& gguf_file,
+                          const std::filesystem::path& target_dir);
+
+}  // namespace pie_portable_driver


### PR DESCRIPTION
## TL;DR

* Mint `tokenizer.json` + `tokenizer_config.json` from GGUF KV at driver init so server bootstrap (`Tokenizer::from_file`) works for single-`.gguf` snapshots.
* Fall back to `tokenizer.ggml.tokens` length when `<arch>.vocab_size` is missing — a pre-existing crash on the sampling fast path for any GGUF without the explicit arch key.
* Validated end-to-end on Unsloth Qwen3-30B-A3B-Q4_K_M: round-trip 15/15 vs `llama_tokenize`, `pie run text-completion` produces coherent output.

## Why

Pie's server-side bootstrap loads tokenizers via `Tokenizer::from_file(snapshot_dir / "tokenizer.json")`. GGUF embeds the tokenizer in KV metadata instead and has no sidecar JSON — so single-`.gguf` snapshots (the case enabled by #361) fail with a nonsensical path. Separately, `gguf_hparams.cpp` returned `vocab_size = 0` when the arch key was absent (Unsloth's Qwen3-MoE GGUFs omit it), which trips a `ggml_reshape_3d` assertion in the sampling path the first time a small prompt is processed.

## What

**Tokenizer mint** (`driver/portable/src/gguf_tokenizer.{cpp,hpp}`, 580 LOC including the pre-tokenizer regex table):

* Reads `tokenizer.ggml.{model,pre,tokens,merges,token_type,*_token_id}` and `tokenizer.chat_template`.
* Emits a HuggingFace-compatible `tokenizer.json` (BPE model, ByteLevel pre/post/decoder, optional NFC normalizer) and a minimal `tokenizer_config.json`.
* Resolves the pre-tokenizer regex from llama.cpp's `LLAMA_VOCAB_PRE_TYPE` table — ~50 known `pre` names (llama3 / qwen2 / qwen35 / gpt-2 / gpt-4o / mpt / starcoder / falcon / deepseek / tekken / kimi-k2 / bailingmoe / seed-coder / chameleon / etc.). Unknown `pre` errors loudly — silent fallbacks would silently miscorrupt tokenization.
* Per-family flags: `needs_nfc_normalizer` (qwen family), `ignore_merges` (llama3 / youtu / tekken).
* Wired through `entry.cpp`: for `.gguf` inputs, mint into a temp dir and report that as `caps.snapshot_dir`. Safetensors path is untouched.

**Vocab fallback** (`driver/portable/src/gguf_archive.{cpp,hpp}`, `gguf_hparams.cpp`):

* `GgufMeta::tokens_count` captured during archive construction.
* `parse_gguf_hparams` uses it when `<arch>.vocab_size` is absent — same convention llama.cpp uses.

## Smoke + validation

Cached GGUF: Unsloth `Qwen3-30B-A3B-Q4_K_M` (151 936-token vocab, 26 special tokens, 128-expert MoE). Apple M4 Pro.

* Round-trip vs `llama_tokenize`: 15/15 strings tokenize to identical IDs across ASCII / Chinese / Korean / code / whitespace edge cases / emoji / chat control tokens.
* `pie run text-completion`: full prefill + decode + decoder; output is coherent natural language.

## Scope

SPM (`tokenizer.ggml.model == "llama"`), WordPiece, Unigram, and RWKV throw a clear "not yet supported" error. Most generative GGUFs in the wild use `gpt2`; SPM is the next layer.

Pairs with #361 and #362 to make `[[model]] hf_repo = "/path/to/model.gguf"` work end-to-end.