### PR TITLE
sdk/inferlet: refuse zero-input forward when sampler still attached

### DIFF
--- a/sdk/rust/inferlet/src/generation.rs
+++ b/sdk/rust/inferlet/src/generation.rs
@@ -429,6 +429,26 @@ impl<'g, 'ctx> GenStep<'g, 'ctx> {
             }));
         }
 
+        // No input + sampler still attached: the SDK once advertised this
+        // as a "no-input bootstrap" path that samples from the last cached
+        // KV position without growing the working tail (see the comment
+        // below). The portable driver's `plan_single_request` rejects
+        // zero-token requests, and silent failure here lets `collect_*`
+        // spin forever firing empty batches once the previous step's
+        // sample came back empty (e.g. grammar mask exhaustion). Fail
+        // loudly so the caller sees the real problem instead of an
+        // infinite retry loop.
+        if n_pending == 0 && n_drafted == 0 && extra_probes.is_empty() {
+            parent.done = true;
+            return Err(
+                "GenStep::execute: no input tokens and no probes — previous \
+                 step likely sampled zero tokens (constraint mask exhausted, \
+                 or driver returned empty response). Refusing to fire a \
+                 zero-input forward pass that the driver would reject."
+                    .to_string(),
+            );
+        }
+
         // Reserve pages for pending (drafts share the working tail —
         // their commit/truncate happens after we know what was accepted).
         // No-input bootstrap path skips reservation: the host samples from

--- a/sdk/rust/inferlet/src/generation.rs
+++ b/sdk/rust/inferlet/src/generation.rs
@@ -418,41 +418,26 @@ impl<'g, 'ctx> GenStep<'g, 'ctx> {
         let n_pending = pending.len() as u32;
         let n_drafted = drafts.len() as u32;
 
-        if n_pending == 0 && n_drafted == 0 && user_cleared_sampler && extra_probes.is_empty() {
-            // Truly nothing to do — no input, no sampler, no probes.
-            // Mark done so collect_* sugars terminate cleanly.
-            parent.done = true;
-            return Ok(Output::new(RawOutput {
-                slots: Vec::new(),
-                spec_tokens: Vec::new(),
-                spec_positions: Vec::new(),
-            }));
-        }
-
-        // No input + sampler still attached: the SDK once advertised this
-        // as a "no-input bootstrap" path that samples from the last cached
-        // KV position without growing the working tail (see the comment
-        // below). The portable driver's `plan_single_request` rejects
-        // zero-token requests, and silent failure here lets `collect_*`
-        // spin forever firing empty batches once the previous step's
-        // sample came back empty (e.g. grammar mask exhaustion). Fail
-        // loudly so the caller sees the real problem instead of an
-        // infinite retry loop.
+        // Nothing to compute. With the sampler cleared this is a clean
+        // exit; otherwise the driver would reject a zero-input request
+        // and collect_* would spin firing empty batches.
         if n_pending == 0 && n_drafted == 0 && extra_probes.is_empty() {
             parent.done = true;
+            if user_cleared_sampler {
+                return Ok(Output::new(RawOutput {
+                    slots: Vec::new(),
+                    spec_tokens: Vec::new(),
+                    spec_positions: Vec::new(),
+                }));
+            }
             return Err(
-                "GenStep::execute: no input tokens and no probes — previous \
-                 step likely sampled zero tokens (constraint mask exhausted, \
-                 or driver returned empty response). Refusing to fire a \
-                 zero-input forward pass that the driver would reject."
+                "GenStep::execute: no input, no probes — refusing zero-input forward pass."
                     .to_string(),
             );
         }
 
         // Reserve pages for pending (drafts share the working tail —
         // their commit/truncate happens after we know what was accepted).
-        // No-input bootstrap path skips reservation: the host samples from
-        // the last cached KV position without growing the working tail.
         let n_total_input = n_pending + n_drafted;
         if n_total_input > 0 {
             let total_after = parent.ctx.working_tokens + n_total_input;


### PR DESCRIPTION
Sibling PRs for this ticket:
- pie-project/pie#364 — https://github.com/pie-project/pie/pull/364

## TL;DR

* `GenStep::execute` could silently fire a zero-input forward pass that the driver rejects; `collect_*` then looped forever firing empty batches.
* Refuse it loudly: when `n_pending == 0 && n_drafted == 0 && extra_probes.is_empty()`, mark the generator done and return `Err` (or `Ok` if the sampler was cleared).
* Defensive guard — not a verified fix for a specific user-visible failure path. Frame accordingly.

## Why

`GenStep::execute` had one early-exit branch that fired only when the caller had explicitly cleared the sampler. With a sampler still attached, an empty `pending` (previous step's sampler came back with no accepted tokens — exhausted grammar mask, empty driver response, …) fell through to a forward pass with no `input_tokens` call. The portable driver's `plan_single_request` rejects zero-token requests and `forward.cpp` returns an empty payload on plan failure; the SDK reads that as another zero-sample step, so `collect_text` / `collect_tokens` retries forever.

Observed downstream while running a grammar-constrained inferlet (`pr-review@0.1.1`) against pie serving Unsloth Qwen3-30B-A3B-Q4_K_M: the first prefill+sample came back with no accepted token, then ~100 k zero-token batches per minute until the WS timed out.

## What

In `GenStep::execute`, fold the two adjacent early-exit branches into one shared `nothing_to_compute` predicate. Clean exit (`Ok(empty Output)`) when `user_cleared_sampler` is true — that's what the existing branch covered. Otherwise return `Err` with a one-line message. Either way, set `parent.done = true` so the surrounding loop terminates.

```rust
let nothing_to_compute =
    n_pending == 0 && n_drafted == 0 && extra_probes.is_empty();
if nothing_to_compute {
    parent.done = true;
    if user_cleared_sampler { return Ok(empty_output); }
    return Err("GenStep::execute: no input, no probes — refusing zero-input forward pass.".into());
}
```

## Honest framing

In the only end-to-end run we have, this guard's `Err` branch was not taken — the rebuilt inferlet succeeded for an unrelated reason (likely SDK changes since the registry build of `inferlet@0.3`). So this is a **defensive guard against a real failure mode I observed**, not a verified fix for a specific user-visible symptom. It cannot make any currently-working flow fail: it only fires on a request shape the driver already rejects.

## Companion work

Pairs with #361, #362, #364 in the GGUF-on-pie series, but is fully independent. Once this lands and a new `inferlet` crate is published, downstream inferlets (e.g. `pr-review`) can bump their pin.