### PR TITLE
Show explicit unsupported-driver error on Windows

### DIFF
--- a/server/src/cli/driver_cmd.rs
+++ b/server/src/cli/driver_cmd.rs
@@ -217,6 +217,14 @@ fn run_subprocess(flavor: SubprocessFlavor, action: PerDriverCmd) -> Result<()> 
 }
 
 fn install(flavor: SubprocessFlavor, path: Option<PathBuf>, run: bool) -> Result<()> {
+    #[cfg(windows)]
+    if matches!(flavor, SubprocessFlavor::Dev | SubprocessFlavor::Vllm | SubprocessFlavor::Sglang) {
+        bail!(
+            "{} driver is not supported on Windows. Please use the portable driver on Windows, or use WSL/Linux for dev, vllm, or sglang drivers.",
+            flavor.as_str()
+        );
+    }
+    
     let venv = path.unwrap_or_else(|| crate::paths::pie_home().join("venvs").join(flavor.as_str()));
     let python_bin = venv.join("bin").join("python");
 

--- a/website/docs/guide/install.mdx
+++ b/website/docs/guide/install.mdx
@@ -70,6 +70,9 @@ This provides the standalone `bakery` command and the Python package used by
 
 The `pie` binary runs the embedded `cuda_native` and `portable` drivers without Python. Python is required only for the subprocess drivers: `dev`, `vllm`, and `sglang`. Install one with:
 
+> Note: The `dev`, `vllm`, and `sglang` drivers are currently not supported on Windows.
+> Please use the `portable` driver on Windows, or run these drivers in WSL/Linux.
+
 ```bash
 pie driver dev install ~/.pie/venvs/dev --run
 pie driver dev set venv ~/.pie/venvs/dev


### PR DESCRIPTION
This PR adds an explicit Windows guard for subprocess drivers (dev, vllm, sglang).

Previously, running `pie driver dev install` on Windows would print a Unix-style interpreter path (`<venv>/bin/python`), which is misleading since Windows uses `Scripts/python.exe`.

Since these drivers are currently unsupported on Windows, this change fails early with a clear error message and suggests using the portable driver on Windows or running these drivers in WSL/Linux instead.

Tested on Windows:
- cargo run -p pie-server --no-default-features -- driver dev install

Fixes #366 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Driver install now immediately reports incompatibility on Windows for the dev, vllm, and sglang drivers and directs users to use the portable driver or run those drivers in WSL/Linux.

* **Documentation**
  * Added a Windows compatibility note in the installation guide under "Optional: Python-backed drivers" with guidance on supported alternatives.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pie-project/pie/pull/370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->