### PR TITLE
fix(runtime): one-shot guest output to tracing + 500 on daemon host errors

### DIFF
--- a/runtime/src/daemon.rs
+++ b/runtime/src/daemon.rs
@@ -97,6 +97,38 @@ pub struct DaemonInfo {
 }
 
 // =============================================================================
+// Fault classification for handle_request
+// =============================================================================
+
+/// Fault domain for a daemon HTTP request failure. Mapped to a status code at
+/// the response boundary so the engine-vs-inferlet attribution stays visible
+/// to clients (see `runtime/src/daemon.rs::Daemon::fault_response`).
+#[derive(Clone, Copy, Debug)]
+enum FaultClass {
+    /// Pie-server failed to set up the guest call (body buffer, instantiate,
+    /// missing wasi:http export, new-incoming-request, new-outparam). Status `500`.
+    HostSetup,
+    /// Pie-server set up correctly; the guest violated the WASI HTTP contract
+    /// (set outparam to error, never set outparam, or trapped during `handle`).
+    /// Status `502`.
+    GuestFault,
+    /// The spawned guest task panicked or was aborted in-flight — the engine
+    /// is the immediate culprit from the client's POV. Status `503` with
+    /// `Retry-After: 1`.
+    InFlightCrash,
+}
+
+impl FaultClass {
+    fn status(self) -> hyper::StatusCode {
+        match self {
+            FaultClass::HostSetup => hyper::StatusCode::INTERNAL_SERVER_ERROR,
+            FaultClass::GuestFault => hyper::StatusCode::BAD_GATEWAY,
+            FaultClass::InFlightCrash => hyper::StatusCode::SERVICE_UNAVAILABLE,
+        }
+    }
+}
+
+// =============================================================================
 // Daemon
 // =============================================================================
 
@@ -194,78 +226,166 @@ impl Daemon {
     ///
     /// Each request gets a fresh Store and component instance. The WASM
     /// component must export `wasi:http/incoming-handler@0.2.4`.
+    ///
+    /// Failures are classified into three fault domains and surfaced to the
+    /// client as a status code plus a stable, short body tag (no anyhow chain,
+    /// no internal paths or symbols — those stay in `tracing::error!`):
+    ///   - `500` host setup fault (body buffer, instantiate, missing export,
+    ///     new-incoming-request, new-outparam).
+    ///   - `502` upstream/guest fault (guest set outparam to error, guest
+    ///     never set outparam, handler trap).
+    ///   - `503` in-flight engine crash (spawned handler task panicked or was
+    ///     aborted); includes `Retry-After: 1`.
+    /// Once the guest writes to the outparam, its response is returned
+    /// verbatim — guest status codes are not rewritten.
     async fn handle_request(
         username: String,
         program: ProgramName,
         _input: String,
         req: hyper::Request<hyper::body::Incoming>,
     ) -> Result<hyper::Response<HyperOutgoingBody>> {
-        // Buffer the request body before the WASM handler runs in a spawned
-        // task below. hyper's Incoming body uses a zero-capacity channel that
-        // requires sender and receiver to poll in the same task; a spawned
-        // handler deadlocks on bodies spanning multiple TCP segments (>~16KB).
-        let (parts, body) = req.into_parts();
-        let collected = http_body_util::BodyExt::collect(body)
-            .await
-            .map_err(|e| anyhow!("Failed to read request body: {e}"))?;
-        let buffered_body = http_body_util::BodyExt::map_err(
-            http_body_util::Full::new(collected.to_bytes()),
-            |never: std::convert::Infallible| -> hyper::Error { match never {} },
-        );
-        let req = hyper::Request::from_parts(parts, buffered_body);
+        type HandleErr = (FaultClass, &'static str, anyhow::Error);
 
-        // Instantiate a fresh WASM component (store + instance) per request.
-        // Daemons serve HTTP responses directly, so there is no client to attach
-        // their stdout/stderr to. Route guest output to pie-server's tracing log
-        // (tagged with the program name) so inferlet diagnostics stay visible to
-        // operators instead of falling through to wasmtime's default sink.
-        let output = OutputMode::Server { program: program.to_string() };
-        let (mut store, instance) =
-            linker::instantiate(uuid::Uuid::new_v4(), username, &program, output, None).await?;
+        let result: std::result::Result<hyper::Response<HyperOutgoingBody>, HandleErr> = async {
+            // Buffer the request body before the WASM handler runs in a spawned
+            // task below. hyper's Incoming body uses a zero-capacity channel that
+            // requires sender and receiver to poll in the same task; a spawned
+            // handler deadlocks on bodies spanning multiple TCP segments (>~16KB).
+            let (parts, body) = req.into_parts();
+            let collected = http_body_util::BodyExt::collect(body).await.map_err(|e| {
+                (FaultClass::HostSetup, "body-buffer-failed",
+                 anyhow!("Failed to read request body: {e}"))
+            })?;
+            let buffered_body = http_body_util::BodyExt::map_err(
+                http_body_util::Full::new(collected.to_bytes()),
+                |never: std::convert::Infallible| -> hyper::Error { match never {} },
+            );
+            let req = hyper::Request::from_parts(parts, buffered_body);
 
-        // Convert the hyper request into WASI HTTP resources
-        let (sender, receiver) = oneshot::channel();
-        let req = store.data_mut().new_incoming_request(Scheme::Http, req)?;
-        let out = store.data_mut().new_response_outparam(sender)?;
+            // Instantiate a fresh WASM component (store + instance) per request.
+            // Daemons serve HTTP responses directly, so there is no client to attach
+            // their stdout/stderr to. Route guest output to pie-server's tracing log
+            // (tagged with the program name) so inferlet diagnostics stay visible to
+            // operators instead of falling through to wasmtime's default sink.
+            let output = OutputMode::Server { program: program.to_string() };
+            let (mut store, instance) =
+                linker::instantiate(uuid::Uuid::new_v4(), username, &program, output, None)
+                    .await
+                    .map_err(|e| (FaultClass::HostSetup, "instantiate-failed", e))?;
 
-        // Find the incoming-handler export
-        let (_, serve_export) = instance
-            .get_export(&mut store, None, "wasi:http/incoming-handler@0.2.4")
-            .ok_or_else(|| anyhow!("No 'wasi:http/incoming-handler' interface found"))?;
+            // Convert the hyper request into WASI HTTP resources
+            let (sender, receiver) = oneshot::channel();
+            let req = store
+                .data_mut()
+                .new_incoming_request(Scheme::Http, req)
+                .map_err(|e| (FaultClass::HostSetup, "new-incoming-request-failed", e))?;
+            let out = store
+                .data_mut()
+                .new_response_outparam(sender)
+                .map_err(|e| (FaultClass::HostSetup, "new-outparam-failed", e))?;
 
-        let (_, handle_func_export) = instance
-            .get_export(&mut store, Some(&serve_export), "handle")
-            .ok_or_else(|| anyhow!("No 'handle' function found"))?;
+            // Find the incoming-handler export
+            let (_, serve_export) = instance
+                .get_export(&mut store, None, "wasi:http/incoming-handler@0.2.4")
+                .ok_or_else(|| {
+                    (FaultClass::HostSetup, "missing-export",
+                     anyhow!("No 'wasi:http/incoming-handler' interface found"))
+                })?;
 
-        let handle_func = instance
-            .get_typed_func::<(Resource<IncomingRequest>, Resource<ResponseOutparam>), ()>(
-                &mut store,
-                &handle_func_export,
-            )
-            .map_err(|e| anyhow!("Failed to get 'handle' function: {e}"))?;
+            let (_, handle_func_export) = instance
+                .get_export(&mut store, Some(&serve_export), "handle")
+                .ok_or_else(|| {
+                    (FaultClass::HostSetup, "missing-export",
+                     anyhow!("No 'handle' function found"))
+                })?;
 
-        // Spawn the WASM handler — it writes the response via the outparam
-        let task = tokio::task::spawn(async move {
-            handle_func
-                .call_async(&mut store, (req, out))
-                .await
-                .map_err(|e| anyhow!("Handler error: {e}"))
-        });
+            let handle_func = instance
+                .get_typed_func::<(Resource<IncomingRequest>, Resource<ResponseOutparam>), ()>(
+                    &mut store,
+                    &handle_func_export,
+                )
+                .map_err(|e| {
+                    (FaultClass::HostSetup, "missing-export",
+                     anyhow!("Failed to get 'handle' function: {e}"))
+                })?;
 
-        // Wait for the response from the outparam channel
-        match receiver.await {
-            Ok(Ok(resp)) => Ok(resp),
-            Ok(Err(e)) => Err(e.into()),
-            Err(_) => {
-                // Outparam was never set — check the task for the real error
-                let e = match task.await {
-                    Ok(Err(e)) => e,
-                    Err(e) => e.into(),
-                    Ok(Ok(())) => anyhow!("handler completed without setting response"),
-                };
-                Err(e.context("guest never invoked `response-outparam::set` method"))
+            // Spawn the WASM handler — it writes the response via the outparam
+            let task = tokio::task::spawn(async move {
+                handle_func
+                    .call_async(&mut store, (req, out))
+                    .await
+                    .map_err(|e| anyhow!("Handler error: {e}"))
+            });
+
+            // Wait for the response from the outparam channel
+            match receiver.await {
+                Ok(Ok(resp)) => Ok(resp),
+                Ok(Err(e)) => Err((FaultClass::GuestFault, "outparam-error", e.into())),
+                Err(_) => {
+                    // Outparam was never set — discriminate guest trap vs task panic.
+                    match task.await {
+                        Ok(Err(e)) => Err((
+                            FaultClass::GuestFault,
+                            "handler-trap",
+                            e.context("guest never invoked `response-outparam::set` method"),
+                        )),
+                        Err(join_err) => Err((
+                            FaultClass::InFlightCrash,
+                            "handler-panic",
+                            anyhow!("{join_err}")
+                                .context("guest handler task panicked or was aborted"),
+                        )),
+                        Ok(Ok(())) => Err((
+                            FaultClass::GuestFault,
+                            "outparam-never-set",
+                            anyhow!("handler completed without setting response"),
+                        )),
+                    }
+                }
             }
         }
+        .await;
+
+        match result {
+            Ok(resp) => Ok(resp),
+            Err((class, tag, err)) => {
+                let status = class.status().as_u16();
+                tracing::error!(
+                    fault_class = ?class, fault_tag = tag, fault_status = status,
+                    "Daemon handle_request failed: {err:#}",
+                );
+                Ok(Self::fault_response(class, tag))
+            }
+        }
+    }
+
+    /// Build a fault response with a status from `class` and a short, stable
+    /// plain-text body equal to `tag`. The anyhow chain is intentionally NOT
+    /// placed in the body — it would leak internal topology / runtime versions
+    /// / wasmtime symbols to any caller, and would also lock pie's host-error
+    /// wire format to whatever `Display for anyhow::Error` happens to render.
+    /// Callers wanting a coded shape can match on the tag string; the detail
+    /// is recorded once via `tracing::error!`.
+    ///
+    /// Body tags currently in use:
+    /// `body-buffer-failed`, `instantiate-failed`,
+    /// `new-incoming-request-failed`, `new-outparam-failed`, `missing-export`
+    /// (status 500); `outparam-error`, `handler-trap`, `outparam-never-set`
+    /// (status 502); `handler-panic` (status 503, with `Retry-After: 1`).
+    fn fault_response(class: FaultClass, tag: &'static str) -> hyper::Response<HyperOutgoingBody> {
+        use http_body_util::{BodyExt, Full};
+        let body: HyperOutgoingBody = Full::new(bytes::Bytes::from_static(tag.as_bytes()))
+            .map_err(|never: std::convert::Infallible| match never {})
+            .boxed_unsync();
+        let mut builder = hyper::Response::builder()
+            .status(class.status())
+            .header(hyper::header::CONTENT_TYPE, "text/plain; charset=utf-8");
+        if matches!(class, FaultClass::InFlightCrash) {
+            builder = builder.header(hyper::header::RETRY_AFTER, "1");
+        }
+        builder
+            .body(body)
+            .expect("response builder never fails on static status + header + infallible body")
     }
 
     /// Cleanup: abort the listener and unregister.

--- a/runtime/src/process.rs
+++ b/runtime/src/process.rs
@@ -335,8 +335,15 @@ impl Process {
 
         let result: Result<String, String> = async {
             // capture_outputs ⇒ an attached client drains the per-process actor
-            // channel; otherwise this is a headless one-shot whose output is dropped.
-            let output = if capture_outputs { OutputMode::Process } else { OutputMode::Discard };
+            // channel; otherwise this is a headless one-shot with no client, so
+            // route guest stdout/stderr to pie-server's tracing log (tagged with
+            // the program name) — same treatment the daemon path uses — instead
+            // of falling through to wasmtime's default sink.
+            let output = if capture_outputs {
+                OutputMode::Process
+            } else {
+                OutputMode::Server { program: program.to_string() }
+            };
             let (mut store, instance) = linker::instantiate(process_id, username, &program, output, token_budget)
                 .await
                 .map_err(|e| e.to_string())?;


### PR DESCRIPTION
Follow-up to the #300 daemon-stderr fix (PR #373). Two pre-existing silent-failure findings flagged in the review of #373; tracked as ticket #303.

## F4 — Headless one-shot still discards guest stderr (runtime/src/process.rs)
`Process::run` used `OutputMode::Discard` whenever `capture_outputs=false`, so all interim stdout/stderr from headless one-shots fell through to wasmtime's default sink — the same silent-drop class #300 fixed for the daemon path, but left out of scope.

Switch the non-captured branch to `OutputMode::Server { program: program.to_string() }`. Interim guest output now lands in pie-server's `tracing` log tagged with the program name, the same treatment the daemon request path uses. The final `Return`/`Error` event delivery (terminate → deliver_event) is untouched, so the run outcome is still surfaced exactly as before; only interim diagnostics gain visibility.

## F5 — Daemon host-error returns dropped connection instead of 500 (runtime/src/daemon.rs)
`Daemon::handle_request` propagated any `anyhow::Error` out of `service_fn`. hyper logged it via the `serve_connection` future at `daemon.rs:178` (\`tracing::error!\`), but the HTTP client saw a reset/dropped TCP connection rather than a structured response. Review flagged the `instantiate` call site (line 224), but every other host-side failure in this function (`get_export`, `get_typed_func`, body buffer error, the outparam-never-set `anyhow!` paths) had the same shape.

Wrap the entire existing handler body in an inner `async {}` block, then map `Err` to a `500 Internal Server Error` response with a plain-text body carrying the error chain (\`format!(\"{e:#}\")\`). Errors are still logged via `tracing::error!`. A new `internal_error_response` helper builds the response — a `Full<Bytes>` mapped to `ErrorCode` and `boxed_unsync()`-ed to land as `HyperOutgoingBody`. Once the WASM handler writes to the outparam, its response is returned verbatim — guest status codes are **not** rewritten.

## Notes on the cross-boundary error contract
pie-mac PR shsym/pie-mac#55 (#298 G2) added `HTTPEngineError.api(status, code, message)` for enveloped responses and routes bare-text 500 bodies through `HTTPEngineError.http(status, body)` (no envelope code = engine-internal). This change emits exactly that shape on host setup failure: pre-handshake errors (instantiate/missing-export/outparam-never-set) reach the client as 500 + plain text and slot into the established taxonomy with no wire-format change. Chat-apc inferlets continue to emit their own `{error:{code,message}}` envelopes via the outparam path, untouched.

## Verification
- \`cargo check -p pie\` — clean (lib unchanged warnings only).
- \`cargo clippy -p pie --lib\` — no new lints on \`daemon.rs\`/\`process.rs\`.
- Existing test-binary compile failures (\`lookup_snapshot\` / \`ForwardPassResponse\` fields) are pre-existing on \`pie.app/v1-base-shmem\` and unrelated to these files.

Closes nothing upstream (tracked downstream as her-code-v3 ticket #303).