### PR TITLE
fix(server): surface driver fatal reason on embedded startup error (#356)

### DIFF
--- a/driver/cuda/src/entry.cpp
+++ b/driver/cuda/src/entry.cpp
@@ -1542,14 +1542,18 @@ extern "C" int pie_driver_cuda_run(int argc,
                                    char** argv,
                                    int install_signal_handlers,
                                    pie_driver_cuda_ready_cb ready_cb,
-                                   void* ready_ctx) {
+                                   void* ready_ctx,
+                                   pie_driver_cuda_fatal_cb fatal_cb,
+                                   void* fatal_ctx) {
     try {
         return run_impl(argc, argv, install_signal_handlers, ready_cb, ready_ctx);
     } catch (const std::exception& e) {
         std::cerr << "[pie-driver-cuda] fatal: " << e.what() << "\n";
+        if (fatal_cb) fatal_cb(e.what(), fatal_ctx);
         return -1;
     } catch (...) {
         std::cerr << "[pie-driver-cuda] fatal: unknown exception\n";
+        if (fatal_cb) fatal_cb("unknown exception", fatal_ctx);
         return -1;
     }
 }

--- a/driver/cuda/src/entry.hpp
+++ b/driver/cuda/src/entry.hpp
@@ -17,6 +17,12 @@ extern "C" {
 // the callback.
 typedef void (*pie_driver_cuda_ready_cb)(const char* caps_json, void* ctx);
 
+// Fatal callback. Called at most once with the failure reason (a
+// NUL-terminated UTF-8 string owned by the lib, valid only for the duration
+// of the callback) just before `pie_driver_cuda_run` returns a nonzero exit
+// code. Nullable — pass NULL to keep the legacy stderr-only behavior.
+typedef void (*pie_driver_cuda_fatal_cb)(const char* reason, void* ctx);
+
 // Run the driver with the given argv. Returns a process-style exit code.
 //
 // `install_signal_handlers != 0` installs SIGINT/SIGTERM handlers
@@ -26,11 +32,16 @@ typedef void (*pie_driver_cuda_ready_cb)(const char* caps_json, void* ctx);
 // `ready_cb` must be non-NULL. The standalone executable provides a
 // default callback that writes `READY <json>` to stdout (preserving
 // the Python wrapper's protocol).
+//
+// `fatal_cb` (nullable) is invoked once with `fatal_ctx` and the failure
+// reason just before a nonzero return.
 int pie_driver_cuda_run(int argc,
                         char** argv,
                         int install_signal_handlers,
                         pie_driver_cuda_ready_cb ready_cb,
-                        void* ready_ctx);
+                        void* ready_ctx,
+                        pie_driver_cuda_fatal_cb fatal_cb,
+                        void* fatal_ctx);
 
 // Signal the running driver's shmem-serve loop to exit. Idempotent;
 // safe to call from any thread; no-op until the serve loop is reached.

--- a/driver/cuda/src/main.cpp
+++ b/driver/cuda/src/main.cpp
@@ -22,8 +22,11 @@ void default_ready_to_stdout(const char* caps_json, void* /*ctx*/) {
 }  // namespace
 
 int main(int argc, char** argv) {
+    // Standalone mode already surfaces the fatal reason on stderr; no fatal_cb.
     return pie_driver_cuda_run(argc, argv,
                                /*install_signal_handlers=*/1,
                                default_ready_to_stdout,
-                               /*ready_ctx=*/nullptr);
+                               /*ready_ctx=*/nullptr,
+                               /*fatal_cb=*/nullptr,
+                               /*fatal_ctx=*/nullptr);
 }

--- a/driver/dummy/src/lib.rs
+++ b/driver/dummy/src/lib.rs
@@ -31,17 +31,42 @@ use crate::shmem::{METHOD_TAG_FIRE_BATCH, ShmemServer};
 
 pub type ReadyCb = unsafe extern "C" fn(caps_json: *const c_char, ctx: *mut c_void);
 
+/// Fatal callback type. Invoked at most once with the failure reason
+/// (NUL-terminated) just before a nonzero return. Nullable / opt-in — mirrors
+/// the C++ drivers' `pie_driver_*_fatal_cb`.
+pub type FatalCb = unsafe extern "C" fn(reason: *const c_char, ctx: *mut c_void);
+
 /// Process-global handles to every running dummy shmem server. The Rust
 /// server can embed multiple same-flavor DP replicas in one process, so
 /// `request_stop` must stop all live instances.
 static SERVERS: Mutex<Vec<usize>> = Mutex::new(Vec::new());
+
+/// Route a fatal reason through `fatal_cb` if one was provided. Mirrors the
+/// `if (fatal_cb) fatal_cb(...)` pattern in the C++ entries; the stderr line
+/// is printed separately by the caller for back-compat.
+///
+/// # Safety
+/// `fatal_cb` must be a valid function pointer and `fatal_ctx` the context it
+/// expects; the callback receives a transient NUL-terminated string.
+unsafe fn report_fatal(reason: &str, fatal_cb: FatalCb, fatal_ctx: *mut c_void) {
+    // A NUL inside the reason would truncate the C string; fall back to a fixed
+    // message so the callback still fires with something meaningful.
+    match CString::new(reason) {
+        Ok(c) => unsafe { fatal_cb(c.as_ptr(), fatal_ctx) },
+        Err(_) => {
+            let fallback = CString::new("fatal reason contained a NUL byte").unwrap();
+            unsafe { fatal_cb(fallback.as_ptr(), fatal_ctx) };
+        }
+    }
+}
 
 /// Library entry point. Mirrors the C++ `pie_driver_portable_run`.
 ///
 /// # Safety
 /// `argv` must point to `argc` C strings; `ready_cb` must be a valid
 /// function pointer or null. The string handed to `ready_cb` is owned
-/// by this function and freed before return.
+/// by this function and freed before return. `fatal_cb` is invoked once with
+/// `fatal_ctx` and the failure reason just before a nonzero return.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn pie_driver_dummy_run(
     argc: c_int,
@@ -49,6 +74,8 @@ pub unsafe extern "C" fn pie_driver_dummy_run(
     _install_signal_handlers: c_int,
     ready_cb: ReadyCb,
     ready_ctx: *mut c_void,
+    fatal_cb: FatalCb,
+    fatal_ctx: *mut c_void,
 ) -> c_int {
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         run_impl(argc, argv, ready_cb, ready_ctx)
@@ -57,11 +84,14 @@ pub unsafe extern "C" fn pie_driver_dummy_run(
     match result {
         Ok(Ok(())) => 0,
         Ok(Err(e)) => {
-            eprintln!("[pie-driver-dummy] fatal: {e:#}");
+            let reason = format!("{e:#}");
+            eprintln!("[pie-driver-dummy] fatal: {reason}");
+            unsafe { report_fatal(&reason, fatal_cb, fatal_ctx) };
             -1
         }
         Err(_) => {
             eprintln!("[pie-driver-dummy] fatal: panic");
+            unsafe { report_fatal("panic", fatal_cb, fatal_ctx) };
             -1
         }
     }
@@ -98,10 +128,7 @@ fn run_impl(
          \x20 shmem.num_slots = {}\n\
          \x20 vocab_size      = {}\n\
          \x20 arch_name       = {}",
-        cfg.shmem.name,
-        cfg.shmem.num_slots,
-        cfg.dummy.vocab_size,
-        cfg.dummy.arch_name,
+        cfg.shmem.name, cfg.shmem.num_slots, cfg.dummy.vocab_size, cfg.dummy.arch_name,
     );
 
     // Open the shmem region (we are the server — runtime attaches as client).
@@ -201,7 +228,9 @@ fn parse_argv_for_config(argc: c_int, argv: *mut *mut c_char) -> Result<PathBuf>
     while let Some(arg) = iter.next() {
         match *arg {
             "-c" | "--config" => {
-                let val = iter.next().ok_or_else(|| anyhow!("--config needs a value"))?;
+                let val = iter
+                    .next()
+                    .ok_or_else(|| anyhow!("--config needs a value"))?;
                 return Ok(PathBuf::from(val));
             }
             _ if arg.starts_with("--config=") => {
@@ -210,7 +239,5 @@ fn parse_argv_for_config(argc: c_int, argv: *mut *mut c_char) -> Result<PathBuf>
             _ => {}
         }
     }
-    Err(anyhow!(
-        "missing --config <path>; got argv = {args:?}"
-    ))
+    Err(anyhow!("missing --config <path>; got argv = {args:?}"))
 }

--- a/driver/portable/src/entry.cpp
+++ b/driver/portable/src/entry.cpp
@@ -527,14 +527,18 @@ extern "C" int pie_driver_portable_run(int argc,
                                        char** argv,
                                        int install_signal_handlers,
                                        pie_driver_portable_ready_cb ready_cb,
-                                       void* ready_ctx) {
+                                       void* ready_ctx,
+                                       pie_driver_portable_fatal_cb fatal_cb,
+                                       void* fatal_ctx) {
     try {
         return run_impl(argc, argv, install_signal_handlers, ready_cb, ready_ctx);
     } catch (const std::exception& e) {
         std::cerr << "[pie-driver-portable] fatal: " << e.what() << "\n";
+        if (fatal_cb) fatal_cb(e.what(), fatal_ctx);
         return -1;
     } catch (...) {
         std::cerr << "[pie-driver-portable] fatal: unknown exception\n";
+        if (fatal_cb) fatal_cb("unknown exception", fatal_ctx);
         return -1;
     }
 }

--- a/driver/portable/src/entry.hpp
+++ b/driver/portable/src/entry.hpp
@@ -20,6 +20,14 @@ extern "C" {
 // caller passed alongside the callback in `pie_driver_portable_run`.
 typedef void (*pie_driver_portable_ready_cb)(const char* caps_json, void* ctx);
 
+// Fatal callback. Called at most once with the failure reason (a
+// NUL-terminated UTF-8 string, owned by the lib and only valid for the
+// duration of the callback) just before `pie_driver_portable_run` returns a
+// nonzero exit code. Nullable — pass NULL to keep the legacy behavior where
+// the reason only reaches stderr. `ctx` is whatever the caller passed
+// alongside the callback in `pie_driver_portable_run`.
+typedef void (*pie_driver_portable_fatal_cb)(const char* reason, void* ctx);
+
 // Run the driver with the given argv. Returns a process-style exit code.
 //
 // `install_signal_handlers != 0` installs SIGINT/SIGTERM handlers that
@@ -31,11 +39,17 @@ typedef void (*pie_driver_portable_ready_cb)(const char* caps_json, void* ctx);
 // to publish capabilities. The standalone executable provides a default
 // callback that writes `READY <json>` to stdout (preserving the Python
 // wrapper's protocol); library callers route the JSON wherever they want.
+//
+// `fatal_cb` (nullable) is invoked once with `fatal_ctx` and the failure
+// reason just before a nonzero return, so library callers can surface the
+// reason in-process instead of scraping stderr.
 int pie_driver_portable_run(int argc,
                             char** argv,
                             int install_signal_handlers,
                             pie_driver_portable_ready_cb ready_cb,
-                            void* ready_ctx);
+                            void* ready_ctx,
+                            pie_driver_portable_fatal_cb fatal_cb,
+                            void* fatal_ctx);
 
 // Signal the running driver's shmem-serve loop to exit. Idempotent;
 // safe to call from any thread; safe to call before `pie_driver_portable_run`

--- a/driver/portable/src/main.cpp
+++ b/driver/portable/src/main.cpp
@@ -21,8 +21,11 @@ void default_ready_to_stdout(const char* caps_json, void* /*ctx*/) {
 }  // namespace
 
 int main(int argc, char** argv) {
+    // Standalone mode already surfaces the fatal reason on stderr; no fatal_cb.
     return pie_driver_portable_run(argc, argv,
                                    /*install_signal_handlers=*/1,
                                    default_ready_to_stdout,
-                                   /*ready_ctx=*/nullptr);
+                                   /*ready_ctx=*/nullptr,
+                                   /*fatal_cb=*/nullptr,
+                                   /*fatal_ctx=*/nullptr);
 }

--- a/server/src/cli/diag_cmd.rs
+++ b/server/src/cli/diag_cmd.rs
@@ -93,6 +93,15 @@ unsafe extern "C" fn smoke_ready_cb(caps_json: *const c_char, _ctx: *mut c_void)
     println!("[smoke] ready_cb fired with {json}");
 }
 
+// Fatal callback for the smoke probe — echoes the reason the driver reported
+// before returning nonzero.
+unsafe extern "C" fn smoke_fatal_cb(reason: *const c_char, _ctx: *mut c_void) {
+    let reason = unsafe { CStr::from_ptr(reason) }
+        .to_string_lossy()
+        .into_owned();
+    println!("[smoke] fatal_cb fired with {reason}");
+}
+
 fn smoke_ffi(flavor: Flavor) -> Result<()> {
     println!(
         "[smoke] invoking pie_driver_{}_run(--help)…\n",
@@ -113,6 +122,8 @@ fn smoke_ffi(flavor: Flavor) -> Result<()> {
             argv_ptrs.as_mut_ptr(),
             0,
             smoke_ready_cb,
+            std::ptr::null_mut(),
+            smoke_fatal_cb,
             std::ptr::null_mut(),
         )
     };

--- a/server/src/driver_ffi.rs
+++ b/server/src/driver_ffi.rs
@@ -13,6 +13,14 @@ use crate::config::DriverKind;
 
 pub type ReadyCb = unsafe extern "C" fn(caps_json: *const c_char, ctx: *mut c_void);
 
+// Fatal callback: invoked at most once with the failure reason
+// (NUL-terminated) just before the driver entry returns a nonzero code.
+// Opt-in / nullable — passing a no-op callback keeps the legacy behavior
+// where the reason only reaches stderr. Lets the embedded host capture the
+// reason on the structured `anyhow::Error` instead of just pointing at
+// stderr (#356).
+pub type FatalCb = unsafe extern "C" fn(reason: *const c_char, ctx: *mut c_void);
+
 #[cfg(feature = "driver-portable")]
 unsafe extern "C" {
     fn pie_driver_portable_run(
@@ -21,6 +29,8 @@ unsafe extern "C" {
         install_signal_handlers: c_int,
         ready_cb: ReadyCb,
         ready_ctx: *mut c_void,
+        fatal_cb: FatalCb,
+        fatal_ctx: *mut c_void,
     ) -> c_int;
     fn pie_driver_portable_request_stop();
 }
@@ -33,6 +43,8 @@ unsafe extern "C" {
         install_signal_handlers: c_int,
         ready_cb: ReadyCb,
         ready_ctx: *mut c_void,
+        fatal_cb: FatalCb,
+        fatal_ctx: *mut c_void,
     ) -> c_int;
     fn pie_driver_cuda_request_stop();
 }
@@ -174,6 +186,10 @@ pub fn default_flavor() -> Option<Flavor> {
 /// Invoke the driver entry for the given flavor. Mirrors the C
 /// signature: blocks until the driver's serve loop exits, returns
 /// the driver's rc.
+///
+/// `fatal_cb` (with `fatal_ctx`) is invoked at most once with the failure
+/// reason just before the driver returns a nonzero rc; pass a no-op callback
+/// to keep the legacy stderr-only behavior.
 pub unsafe fn run(
     flavor: Flavor,
     argc: c_int,
@@ -181,18 +197,44 @@ pub unsafe fn run(
     install_signal_handlers: c_int,
     ready_cb: ReadyCb,
     ready_ctx: *mut c_void,
+    fatal_cb: FatalCb,
+    fatal_ctx: *mut c_void,
 ) -> c_int {
     match flavor {
         #[cfg(feature = "driver-portable")]
         Flavor::Portable => unsafe {
-            pie_driver_portable_run(argc, argv, install_signal_handlers, ready_cb, ready_ctx)
+            pie_driver_portable_run(
+                argc,
+                argv,
+                install_signal_handlers,
+                ready_cb,
+                ready_ctx,
+                fatal_cb,
+                fatal_ctx,
+            )
         },
         #[cfg(feature = "driver-cuda")]
         Flavor::Cuda => unsafe {
-            pie_driver_cuda_run(argc, argv, install_signal_handlers, ready_cb, ready_ctx)
+            pie_driver_cuda_run(
+                argc,
+                argv,
+                install_signal_handlers,
+                ready_cb,
+                ready_ctx,
+                fatal_cb,
+                fatal_ctx,
+            )
         },
         Flavor::Dummy => unsafe {
-            pie_driver_dummy_run(argc, argv, install_signal_handlers, ready_cb, ready_ctx)
+            pie_driver_dummy_run(
+                argc,
+                argv,
+                install_signal_handlers,
+                ready_cb,
+                ready_ctx,
+                fatal_cb,
+                fatal_ctx,
+            )
         },
     }
 }

--- a/server/src/embedded_driver.rs
+++ b/server/src/embedded_driver.rs
@@ -194,24 +194,38 @@ impl PendingEmbeddedDriver {
         }
     }
 
-    /// Join the (exited) driver thread, reclaim the leaked caps box, and
-    /// build the "exited before caps" error carrying the thread's rc.
-    /// Shared by `wait_for_caps`'s thread-exit and channel-disconnect paths.
+    /// Join the (exited) driver thread, recover any fatal reason it reported
+    /// through `embedded_fatal_cb`, reclaim the leaked caps box, and build the
+    /// "exited before caps" error carrying the thread's rc. Shared by
+    /// `wait_for_caps`'s thread-exit and channel-disconnect paths.
     fn exited_before_caps_err(&mut self) -> anyhow::Error {
         let rc = self
             .thread
             .take()
             .map(|h| h.join().unwrap_or(-1))
             .unwrap_or(-1);
+        // The join above establishes happens-before, so the fatal write (if
+        // any) is visible here. Take it before we drop the box.
+        let reason = if self.caps_ctx.is_null() {
+            None
+        } else {
+            unsafe { (*self.caps_ctx).fatal.lock().unwrap().take() }
+        };
         if !self.caps_ctx.is_null() {
             unsafe { drop(Box::from_raw(self.caps_ctx)) };
             self.caps_ctx = std::ptr::null_mut();
         }
-        anyhow!(
-            "driver thread exited (rc={rc}) before emitting capabilities; \
-             check stderr for the [pie-driver-{}] error message",
-            self.flavor.as_str(),
-        )
+        match reason {
+            Some(r) => anyhow!(
+                "pie-driver-{} failed during startup (rc={rc}): {r}",
+                self.flavor.as_str()
+            ),
+            None => anyhow!(
+                "driver thread exited (rc={rc}) before emitting capabilities; \
+                 check stderr for the [pie-driver-{}] error message",
+                self.flavor.as_str()
+            ),
+        }
     }
 
     fn into_driver(mut self, caps: DriverCapabilities) -> EmbeddedDriver {
@@ -581,9 +595,14 @@ pub(crate) fn write_cuda_startup_toml(
 
 /// Per-launch callback target. Held alive by the parent `EmbeddedDriver`
 /// for the whole lifetime of the driver thread; the thread reads from
-/// it through a raw pointer.
+/// it through a raw pointer. Both the ready and fatal callbacks share one
+/// box (passed as their respective `ctx`).
 struct CapsCtx {
     tx: Mutex<Option<mpsc::SyncSender<String>>>,
+    /// Slot the fatal callback fills with the driver's failure reason just
+    /// before the thread exits nonzero. Read by `exited_before_caps_err`
+    /// after the thread joins (#356).
+    fatal: Mutex<Option<String>>,
 }
 
 unsafe extern "C" fn embedded_caps_cb(caps_json: *const c_char, ctx: *mut c_void) {
@@ -597,6 +616,20 @@ unsafe extern "C" fn embedded_caps_cb(caps_json: *const c_char, ctx: *mut c_void
     if let Some(tx) = ctx_ref.tx.lock().unwrap().take() {
         let _ = tx.send(json);
     }
+}
+
+/// C callback the driver invokes with its failure reason just before it
+/// returns nonzero. Stores the reason so `exited_before_caps_err` can attach
+/// it to the structured error instead of leaving it on stderr only (#356).
+unsafe extern "C" fn embedded_fatal_cb(reason: *const c_char, ctx: *mut c_void) {
+    if ctx.is_null() || reason.is_null() {
+        return;
+    }
+    let msg = unsafe { CStr::from_ptr(reason) }
+        .to_string_lossy()
+        .into_owned();
+    let ctx_ref = unsafe { &*(ctx as *const CapsCtx) };
+    *ctx_ref.fatal.lock().unwrap() = Some(msg);
 }
 
 /// Owns the embedded driver thread + its on-disk launch state. The
@@ -718,8 +751,8 @@ impl EmbeddedDriver {
         // (model.cpp branches on is_regular_file). CUDA + dummy still need
         // a directory — those drivers fail later with their own message
         // when handed a file, so we don't gate that here.
-        let is_gguf_file = snapshot_dir.is_file()
-            && snapshot_dir.extension().is_some_and(|e| e == "gguf");
+        let is_gguf_file =
+            snapshot_dir.is_file() && snapshot_dir.extension().is_some_and(|e| e == "gguf");
         if !snapshot_dir.is_dir() && !is_gguf_file {
             return Err(anyhow!(
                 "snapshot_dir {snapshot_dir:?} does not exist, or is not a directory or .gguf file"
@@ -781,6 +814,7 @@ impl EmbeddedDriver {
         let (caps_tx, caps_rx) = mpsc::sync_channel::<String>(1);
         let caps_ctx = Box::into_raw(Box::new(CapsCtx {
             tx: Mutex::new(Some(caps_tx)),
+            fatal: Mutex::new(None),
         }));
 
         let toml_path_str = toml_path
@@ -817,6 +851,9 @@ impl EmbeddedDriver {
                     .iter()
                     .map(|s| s.as_ptr() as *mut c_char)
                     .collect();
+                // Both callbacks reach the same caps box through this pointer;
+                // it outlives the thread and is reclaimed after the join.
+                let caps_ctx_ptr = caps_ctx_addr as *mut c_void;
                 unsafe {
                     driver_ffi::run(
                         flavor,
@@ -824,7 +861,9 @@ impl EmbeddedDriver {
                         argv_ptrs.as_mut_ptr(),
                         /*install_signal_handlers=*/ 0,
                         embedded_caps_cb,
-                        caps_ctx_addr as *mut c_void,
+                        caps_ctx_ptr,
+                        embedded_fatal_cb,
+                        caps_ctx_ptr,
                     )
                 }
             })
@@ -924,6 +963,7 @@ mod tests {
         let (caps_tx, caps_rx) = mpsc::sync_channel::<String>(1);
         let caps_ctx = Box::into_raw(Box::new(CapsCtx {
             tx: Mutex::new(Some(caps_tx)),
+            fatal: Mutex::new(None),
         }));
         let thread = std::thread::Builder::new()
             .name("pie-driver-test-dead".into())
@@ -963,6 +1003,65 @@ mod tests {
             elapsed < timeout / 2,
             "wait_for_caps must detect thread exit promptly, not block the \
              full ready_timeout (took {elapsed:?} of {timeout:?})"
+        );
+    }
+
+    #[test]
+    fn wait_for_caps_surfaces_driver_fatal_reason() {
+        // #356: when the driver reports a fatal reason through
+        // `embedded_fatal_cb` before dying, `wait_for_caps` must surface that
+        // reason (and the flavor) on the structured error rather than the
+        // generic "check stderr" message. FFI-free: we store the reason via the
+        // real `embedded_fatal_cb` and let the thread exit nonzero without ever
+        // publishing caps (the same connected-but-silent channel as #347). Thread
+        // death is detected by the `is_finished()` poll, so this stays fast.
+        const REASON: &str = "gguf: gguf_init_from_file failed: bad magic";
+
+        let (caps_tx, caps_rx) = mpsc::sync_channel::<String>(1);
+        let caps_ctx = Box::into_raw(Box::new(CapsCtx {
+            tx: Mutex::new(Some(caps_tx)),
+            fatal: Mutex::new(None),
+        }));
+
+        // Simulate the driver calling the fatal callback just before it returns
+        // nonzero. This exercises the real `embedded_fatal_cb` storage path.
+        let reason_c = CString::new(REASON).unwrap();
+        unsafe { embedded_fatal_cb(reason_c.as_ptr(), caps_ctx as *mut c_void) };
+
+        let thread = std::thread::Builder::new()
+            .name("pie-driver-test-fatal".into())
+            .spawn(|| -> i32 { 7 })
+            .unwrap();
+
+        let mut pending = PendingEmbeddedDriver {
+            flavor: Flavor::Dummy,
+            shmem_name: "/pie_shmem_test".to_string(),
+            aux_socket_path: PathBuf::from("/tmp/pie-test-aux.sock"),
+            thread: Some(thread),
+            caps_ctx,
+            caps_rx: Some(caps_rx),
+            state_dir: PathBuf::from("/tmp/pie-test-state"),
+        };
+
+        let timeout = Duration::from_secs(5);
+        let start = Instant::now();
+        let err = pending
+            .wait_for_caps(timeout)
+            .expect_err("a driver that exits before caps must surface an error");
+        let elapsed = start.elapsed();
+
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains(REASON),
+            "the driver's fatal reason must ride the error, got: {msg}"
+        );
+        assert!(
+            msg.contains(Flavor::Dummy.as_str()),
+            "the flavor must appear in the error, got: {msg}"
+        );
+        assert!(
+            elapsed < timeout / 2,
+            "must detect thread exit promptly (took {elapsed:?} of {timeout:?})"
         );
     }
 


### PR DESCRIPTION
## What

Follow-on to #347. After #347, embedded-driver startup fast-fails in ~1s via
`PendingEmbeddedDriver::exited_before_caps_err` instead of hanging the full
`ready_timeout_s`. But the error it returns is generic:

> driver thread exited (rc=N) before emitting capabilities; check stderr for the [pie-driver-*] error message

The actual fatal reason (e.g. `gguf: gguf_init_from_file failed: …`) is written by
the driver entry's `catch` block to the **process's stderr** and is never captured
into the Rust error. A host that suppresses or redirects the driver's stderr — e.g.
a GUI launcher that consumes only structured errors — cannot see the reason at all,
only `rc=N, look at stderr (which you may not have)`.

## How

Add a dedicated, **opt-in** `fatal_cb` to each driver entry, parallel to the
existing `ready_cb`:

- `driver/portable/src/entry.{hpp,cpp}`, `driver/cuda/src/entry.{hpp,cpp}`: append
  `*_fatal_cb fatal_cb, void* fatal_ctx` to `pie_driver_*_run`. In each `catch`
  block, after the existing `std::cerr << "[pie-driver-*] fatal: …"` (kept for
  back-compat), call `if (fatal_cb) fatal_cb(reason, fatal_ctx);` just before the
  nonzero return.
- `driver/dummy/src/lib.rs`: add the matching `FatalCb` and route the dummy's
  `Err`/panic arms through it (NUL-safe).
- `server/src/driver_ffi.rs`: add `pub type FatalCb` and thread the two new params
  through the extern decls and the `run()` dispatcher.
- `server/src/embedded_driver.rs`: `CapsCtx` gains a `fatal: Mutex<Option<String>>`
  slot; a new `embedded_fatal_cb` stores the reason; `spawn_rank` passes it
  (reusing the same leaked caps box as `fatal_ctx`); `exited_before_caps_err` —
  **after** joining the thread (happens-before) and before dropping the box —
  takes the reason and, when present, returns
  `pie-driver-{flavor} failed during startup (rc=N): {reason}`. Falls back to the
  original "check stderr" message when no reason was captured (hard crash / null cb).

The standalone executables (`driver/*/src/main.cpp`) pass `nullptr` for the new
params, so the legacy `READY`-to-stdout subprocess protocol is **unchanged** — the
reason is NOT overloaded onto `ready_cb`, which both code paths share.

## Why a separate callback (not `ready_cb`)

The same `pie_driver_*_run` symbols back both the in-process embedded library and
the standalone `pie_driver_*` executable (Python-subprocess path), which emits
`READY <json>` to stdout via its own `ready_cb`. Overloading `ready_cb` with an
error envelope would corrupt that protocol. A distinct, nullable `fatal_cb` keeps
embedded and subprocess behavior cleanly separated and is purely additive (opt-in).

## Test

FFI-free regression test `wait_for_caps_surfaces_driver_fatal_reason`
(`server/src/embedded_driver.rs`, `Flavor::Dummy`), modeled on #347's
`wait_for_caps_reports_thread_exit_without_blocking_full_timeout`: drives the real
`embedded_fatal_cb` storage path, exits the thread nonzero without caps, and asserts
the returned `Err` contains both the reason and the flavor, promptly.

```
cargo test -p pie-server --no-default-features --lib   # 84 passed (incl. #347 + new)
cargo build -p pie-server --features driver-portable    # RC=0 (compiles the C++ portable entry)
```
cuda is ABI-mirrored to portable but only compiles under CI/Linux.