### PR TITLE
docs(driver): correct fatal_cb ABI synopsis and nullability wording (#356 F1+F3)

### DIFF
--- a/driver/dummy/src/lib.rs
+++ b/driver/dummy/src/lib.rs
@@ -5,7 +5,8 @@
 //! ```c
 //! int pie_driver_dummy_run(int argc, char** argv,
 //!                          int install_signal_handlers,
-//!                          ready_cb_t ready_cb, void* ready_ctx);
+//!                          ready_cb_t ready_cb, void* ready_ctx,
+//!                          fatal_cb_t fatal_cb, void* fatal_ctx);
 //! void pie_driver_dummy_request_stop(void);
 //! ```
 //!
@@ -32,8 +33,9 @@ use crate::shmem::{METHOD_TAG_FIRE_BATCH, ShmemServer};
 pub type ReadyCb = unsafe extern "C" fn(caps_json: *const c_char, ctx: *mut c_void);
 
 /// Fatal callback type. Invoked at most once with the failure reason
-/// (NUL-terminated) just before a nonzero return. Nullable / opt-in — mirrors
-/// the C++ drivers' `pie_driver_*_fatal_cb`.
+/// (NUL-terminated) just before a nonzero return. Non-nullable — pass a
+/// no-op callback for the legacy stderr-only behavior. Mirrors the C++
+/// drivers' `pie_driver_*_fatal_cb`.
 pub type FatalCb = unsafe extern "C" fn(reason: *const c_char, ctx: *mut c_void);
 
 /// Process-global handles to every running dummy shmem server. The Rust

--- a/server/src/driver_ffi.rs
+++ b/server/src/driver_ffi.rs
@@ -15,8 +15,8 @@ pub type ReadyCb = unsafe extern "C" fn(caps_json: *const c_char, ctx: *mut c_vo
 
 // Fatal callback: invoked at most once with the failure reason
 // (NUL-terminated) just before the driver entry returns a nonzero code.
-// Opt-in / nullable — passing a no-op callback keeps the legacy behavior
-// where the reason only reaches stderr. Lets the embedded host capture the
+// Non-nullable — pass a no-op callback to keep the legacy behavior where
+// the reason only reaches stderr. Lets the embedded host capture the
 // reason on the structured `anyhow::Error` instead of just pointing at
 // stderr (#356).
 pub type FatalCb = unsafe extern "C" fn(reason: *const c_char, ctx: *mut c_void);


### PR DESCRIPTION
Sibling PRs for this ticket:
- pie-project/pie#379 — https://github.com/pie-project/pie/pull/379
- shsym/RatioThink#7 — https://github.com/shsym/RatioThink/pull/7

F3: dummy module-header C synopsis (driver/dummy/src/lib.rs) updated to the current 7-arg ABI — appends `fatal_cb_t fatal_cb, void* fatal_ctx`.

F1: FatalCb doc wording corrected from "nullable / pass NULL" to "non-nullable — pass a no-op callback for legacy stderr-only behavior", in server/src/driver_ffi.rs and driver/dummy/src/lib.rs. Doc-only; ABI unchanged (the Rust FatalCb binding is a bare `extern "C" fn` pointer, not `Option`, so a real callback is always required — the C++ `.hpp` keeps its own genuinely-nullable contract for the standalone exe).

Verify: `cargo test -p pie-server --no-default-features --lib` = 84 pass incl `wait_for_caps_surfaces_driver_fatal_reason`; both edited files are comment-only changes (rustfmt does not reflow doc comments). Follow-up to pie#379.