### PR TITLE
fix(runtime): forward-port daemon stderr to pie-server log (closes #374)

### DIFF
--- a/runtime/src/daemon.rs
+++ b/runtime/src/daemon.rs
@@ -22,6 +22,7 @@ use wasmtime_wasi_http::bindings::http::types::Scheme;
 use wasmtime_wasi_http::body::HyperOutgoingBody;
 use wasmtime_wasi_http::io::TokioIo;
 
+use crate::instance::OutputMode;
 use crate::linker;
 use crate::program::ProgramName;
 use crate::service::{ServiceMap, ServiceHandler};
@@ -214,9 +215,13 @@ impl Daemon {
         let req = hyper::Request::from_parts(parts, buffered_body);
 
         // Instantiate a fresh WASM component (store + instance) per request.
-        // Daemons don't capture outputs — they serve HTTP responses directly.
+        // Daemons serve HTTP responses directly, so there is no client to attach
+        // their stdout/stderr to. Route guest output to pie-server's tracing log
+        // (tagged with the program name) so inferlet diagnostics stay visible to
+        // operators instead of falling through to wasmtime's default sink.
+        let output = OutputMode::Server { program: program.to_string() };
         let (mut store, instance) =
-            linker::instantiate(uuid::Uuid::new_v4(), username, &program, false, None).await?;
+            linker::instantiate(uuid::Uuid::new_v4(), username, &program, output, None).await?;
 
         // Convert the hyper request into WASI HTTP resources
         let (sender, receiver) = oneshot::channel();

--- a/runtime/src/daemon.rs
+++ b/runtime/src/daemon.rs
@@ -219,7 +219,7 @@ impl Daemon {
         // their stdout/stderr to. Route guest output to pie-server's tracing log
         // (tagged with the program name) so inferlet diagnostics stay visible to
         // operators instead of falling through to wasmtime's default sink.
-        let output = OutputMode::Server { program: program.to_string() };
+        let output = OutputMode::Log { program: program.to_string() };
         let (mut store, instance) =
             linker::instantiate(uuid::Uuid::new_v4(), username, &program, output, None).await?;
 

--- a/runtime/src/instance.rs
+++ b/runtime/src/instance.rs
@@ -24,11 +24,11 @@ pub enum OutputMode {
     /// where guest output is noise.
     Discard,
     /// Route to the per-process actor channel, drained by an attached client.
-    Process,
+    Stream,
     /// Route to pie-server's `tracing` log, tagged with `program`. Used by the
     /// daemon request path, which serves HTTP directly and has no client to
     /// attach — without this, guest stderr falls through to the default sink.
-    Server { program: String },
+    Log { program: String },
 }
 
 pub struct InstanceState {
@@ -113,11 +113,11 @@ impl InstanceState {
 
         match output {
             OutputMode::Discard => {}
-            OutputMode::Process => {
+            OutputMode::Stream => {
                 builder.stdout(LogStream::new_stdout(id));
                 builder.stderr(LogStream::new_stderr(id));
             }
-            OutputMode::Server { program } => {
+            OutputMode::Log { program } => {
                 let program: Arc<str> = Arc::from(program);
                 builder.stdout(LogStream::new_server_stdout(program.clone()));
                 builder.stderr(LogStream::new_server_stderr(program));

--- a/runtime/src/instance.rs
+++ b/runtime/src/instance.rs
@@ -7,6 +7,7 @@ mod output;
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use wasmtime::component::{ResourceAny, ResourceTable};
 use wasmtime_wasi::{DirPerms, FilePerms, WasiCtx, WasiCtxView, WasiView};
 use wasmtime_wasi_http::{WasiHttpCtx, WasiHttpView};
@@ -16,6 +17,19 @@ use self::output::LogStream;
 use crate::context;
 use crate::linker::InstancePolicy;
 use crate::process::ProcessId;
+
+/// Where an instance's stdout/stderr are routed.
+pub enum OutputMode {
+    /// Discard outputs (wasmtime's default sink). Used for snapshot init,
+    /// where guest output is noise.
+    Discard,
+    /// Route to the per-process actor channel, drained by an attached client.
+    Process,
+    /// Route to pie-server's `tracing` log, tagged with `program`. Used by the
+    /// daemon request path, which serves HTTP directly and has no client to
+    /// attach — without this, guest stderr falls through to the default sink.
+    Server { program: String },
+}
 
 pub struct InstanceState {
     // Wasm states
@@ -70,7 +84,7 @@ impl InstanceState {
     pub async fn new(
         id: ProcessId,
         username: String,
-        capture_outputs: bool,
+        output: OutputMode,
         policy: &InstancePolicy,
         token_budget: Option<usize>,
         py_runtime_dir: Option<&Path>,
@@ -97,9 +111,17 @@ impl InstanceState {
             }
         }
 
-        if capture_outputs {
-            builder.stdout(LogStream::new_stdout(id));
-            builder.stderr(LogStream::new_stderr(id));
+        match output {
+            OutputMode::Discard => {}
+            OutputMode::Process => {
+                builder.stdout(LogStream::new_stdout(id));
+                builder.stderr(LogStream::new_stderr(id));
+            }
+            OutputMode::Server { program } => {
+                let program: Arc<str> = Arc::from(program);
+                builder.stdout(LogStream::new_server_stdout(program.clone()));
+                builder.stderr(LogStream::new_server_stderr(program));
+            }
         }
 
         let scratch_dir = policy.fs.base_dir.join(id.to_string());

--- a/runtime/src/instance/output.rs
+++ b/runtime/src/instance/output.rs
@@ -27,7 +27,7 @@ enum Dest {
     Process(ProcessId),
     /// pie-server's `tracing` log, tagged with the program name for triage.
     /// Used by daemon components, which have no attached client.
-    Server(Arc<str>),
+    Log(Arc<str>),
 }
 
 /// A WASI-compatible output stream that routes guest stdout/stderr.
@@ -47,11 +47,11 @@ impl LogStream {
     }
 
     pub fn new_server_stdout(program: Arc<str>) -> Self {
-        LogStream { dest: Dest::Server(program), is_stderr: false }
+        LogStream { dest: Dest::Log(program), is_stderr: false }
     }
 
     pub fn new_server_stderr(program: Arc<str>) -> Self {
-        LogStream { dest: Dest::Server(program), is_stderr: true }
+        LogStream { dest: Dest::Log(program), is_stderr: true }
     }
 
     /// Dispatch output to its destination.
@@ -68,7 +68,7 @@ impl LogStream {
                     process::stdout(*process_id, content);
                 }
             }
-            Dest::Server(program) => {
+            Dest::Log(program) => {
                 // Strip the trailing newline so each `eprintln!`/`println!`
                 // becomes one clean tracing event rather than an empty extra line.
                 let content = String::from_utf8_lossy(bytes);
@@ -143,82 +143,5 @@ impl AsyncWrite for LogStream {
 
     fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         Poll::Ready(Ok(()))
-    }
-}
-
-// =============================================================================
-// Tests — the `Server` destination (daemon request path). Regression cover for
-// #300: daemon guest stderr was discarded by wasmtime's default sink because it
-// was never wired to a destination.
-// =============================================================================
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::Mutex;
-    use tracing_subscriber::fmt::MakeWriter;
-
-    /// A `MakeWriter` that captures all tracing output into a shared buffer.
-    #[derive(Clone)]
-    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
-
-    impl io::Write for CaptureWriter {
-        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-            self.0.lock().unwrap().extend_from_slice(buf);
-            Ok(buf.len())
-        }
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-    }
-
-    impl<'a> MakeWriter<'a> for CaptureWriter {
-        type Writer = CaptureWriter;
-        fn make_writer(&'a self) -> Self::Writer {
-            self.clone()
-        }
-    }
-
-    /// Run `f` with a tracing subscriber capturing into a buffer; return the text.
-    fn capture_tracing(f: impl FnOnce()) -> String {
-        let buf = Arc::new(Mutex::new(Vec::new()));
-        let subscriber = tracing_subscriber::fmt()
-            .with_writer(CaptureWriter(buf.clone()))
-            .with_ansi(false)
-            .with_max_level(tracing::Level::INFO)
-            .finish();
-        tracing::subscriber::with_default(subscriber, f);
-        String::from_utf8(buf.lock().unwrap().clone()).unwrap()
-    }
-
-    #[test]
-    fn server_stderr_surfaces_to_tracing_with_program_tag() {
-        let out = capture_tracing(|| {
-            let mut s = LogStream::new_server_stderr(Arc::from("chat-apc"));
-            s.write_bytes(b"clock skew detected: 42s\n");
-        });
-        assert!(out.contains("clock skew detected: 42s"), "stderr text missing: {out:?}");
-        assert!(out.contains("chat-apc"), "program tag missing: {out:?}");
-        assert!(out.contains("WARN"), "stderr should log at WARN: {out:?}");
-    }
-
-    #[test]
-    fn server_stdout_surfaces_at_info() {
-        let out = capture_tracing(|| {
-            let mut s = LogStream::new_server_stdout(Arc::from("helloworld"));
-            s.write_bytes(b"served request\n");
-        });
-        assert!(out.contains("served request"), "stdout text missing: {out:?}");
-        assert!(out.contains("INFO"), "stdout should log at INFO: {out:?}");
-    }
-
-    #[test]
-    fn server_drops_empty_and_newline_only_writes() {
-        let out = capture_tracing(|| {
-            let mut s = LogStream::new_server_stderr(Arc::from("noisy"));
-            s.write_bytes(b"");
-            s.write_bytes(b"\n");
-        });
-        assert!(out.is_empty(), "blank writes should emit nothing: {out:?}");
     }
 }

--- a/runtime/src/instance/output.rs
+++ b/runtime/src/instance/output.rs
@@ -1,11 +1,14 @@
 //! Output streaming for WASM instance stdout/stderr.
 //!
-//! Provides `LogStream` — a WASI-compatible stream that routes output
-//! through the process actor via `process::stdout` / `process::stderr`.
+//! Provides `LogStream` — a WASI-compatible stream that routes output either
+//! through the process actor (`process::stdout` / `process::stderr`, read by an
+//! attached client) or to pie-server's own `tracing` log (daemon request path,
+//! which has no attached client — see `daemon::Daemon::handle_request`).
 
 use bytes::Bytes;
 use std::io;
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio::io::AsyncWrite;
 use wasmtime_wasi::async_trait;
@@ -17,32 +20,68 @@ use crate::process;
 
 use crate::process::ProcessId;
 
-/// A WASI-compatible output stream that routes to the process actor.
+/// Where a `LogStream`'s bytes are routed.
+#[derive(Clone)]
+enum Dest {
+    /// Per-process actor channel, drained by an attached client.
+    Process(ProcessId),
+    /// pie-server's `tracing` log, tagged with the program name for triage.
+    /// Used by daemon components, which have no attached client.
+    Server(Arc<str>),
+}
+
+/// A WASI-compatible output stream that routes guest stdout/stderr.
 #[derive(Clone)]
 pub struct LogStream {
-    process_id: ProcessId,
+    dest: Dest,
     is_stderr: bool,
 }
 
 impl LogStream {
     pub fn new_stdout(process_id: ProcessId) -> Self {
-        LogStream { process_id, is_stderr: false }
+        LogStream { dest: Dest::Process(process_id), is_stderr: false }
     }
 
     pub fn new_stderr(process_id: ProcessId) -> Self {
-        LogStream { process_id, is_stderr: true }
+        LogStream { dest: Dest::Process(process_id), is_stderr: true }
     }
 
-    /// Dispatch output to the process actor.
+    pub fn new_server_stdout(program: Arc<str>) -> Self {
+        LogStream { dest: Dest::Server(program), is_stderr: false }
+    }
+
+    pub fn new_server_stderr(program: Arc<str>) -> Self {
+        LogStream { dest: Dest::Server(program), is_stderr: true }
+    }
+
+    /// Dispatch output to its destination.
     fn write_bytes(&self, bytes: &[u8]) {
         if bytes.is_empty() {
             return;
         }
-        let content = String::from_utf8_lossy(bytes).to_string();
-        if self.is_stderr {
-            process::stderr(self.process_id, content);
-        } else {
-            process::stdout(self.process_id, content);
+        match &self.dest {
+            Dest::Process(process_id) => {
+                let content = String::from_utf8_lossy(bytes).to_string();
+                if self.is_stderr {
+                    process::stderr(*process_id, content);
+                } else {
+                    process::stdout(*process_id, content);
+                }
+            }
+            Dest::Server(program) => {
+                // Strip the trailing newline so each `eprintln!`/`println!`
+                // becomes one clean tracing event rather than an empty extra line.
+                let content = String::from_utf8_lossy(bytes);
+                let text = content.trim_end_matches(['\n', '\r']);
+                if text.is_empty() {
+                    return;
+                }
+                if self.is_stderr {
+                    tracing::warn!(target: "pie::daemon::guest", program = %program, "{text}");
+                } else {
+                    tracing::info!(target: "pie::daemon::guest", program = %program, "{text}");
+                }
+            }
         }
     }
 }
@@ -104,5 +143,82 @@ impl AsyncWrite for LogStream {
 
     fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         Poll::Ready(Ok(()))
+    }
+}
+
+// =============================================================================
+// Tests — the `Server` destination (daemon request path). Regression cover for
+// #300: daemon guest stderr was discarded by wasmtime's default sink because it
+// was never wired to a destination.
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    /// A `MakeWriter` that captures all tracing output into a shared buffer.
+    #[derive(Clone)]
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// Run `f` with a tracing subscriber capturing into a buffer; return the text.
+    fn capture_tracing(f: impl FnOnce()) -> String {
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(CaptureWriter(buf.clone()))
+            .with_ansi(false)
+            .with_max_level(tracing::Level::INFO)
+            .finish();
+        tracing::subscriber::with_default(subscriber, f);
+        String::from_utf8(buf.lock().unwrap().clone()).unwrap()
+    }
+
+    #[test]
+    fn server_stderr_surfaces_to_tracing_with_program_tag() {
+        let out = capture_tracing(|| {
+            let mut s = LogStream::new_server_stderr(Arc::from("chat-apc"));
+            s.write_bytes(b"clock skew detected: 42s\n");
+        });
+        assert!(out.contains("clock skew detected: 42s"), "stderr text missing: {out:?}");
+        assert!(out.contains("chat-apc"), "program tag missing: {out:?}");
+        assert!(out.contains("WARN"), "stderr should log at WARN: {out:?}");
+    }
+
+    #[test]
+    fn server_stdout_surfaces_at_info() {
+        let out = capture_tracing(|| {
+            let mut s = LogStream::new_server_stdout(Arc::from("helloworld"));
+            s.write_bytes(b"served request\n");
+        });
+        assert!(out.contains("served request"), "stdout text missing: {out:?}");
+        assert!(out.contains("INFO"), "stdout should log at INFO: {out:?}");
+    }
+
+    #[test]
+    fn server_drops_empty_and_newline_only_writes() {
+        let out = capture_tracing(|| {
+            let mut s = LogStream::new_server_stderr(Arc::from("noisy"));
+            s.write_bytes(b"");
+            s.write_bytes(b"\n");
+        });
+        assert!(out.is_empty(), "blank writes should emit nothing: {out:?}");
     }
 }

--- a/runtime/src/linker.rs
+++ b/runtime/src/linker.rs
@@ -14,7 +14,7 @@ use wasmtime::component::{Component, Instance as WasmInstance, Linker as WasmLin
 use wasmtime::{Engine, Store};
 
 use crate::api;
-use crate::instance::InstanceState;
+use crate::instance::{InstanceState, OutputMode};
 use crate::policy::{FsPolicy, NetworkPolicy};
 use crate::process::ProcessId;
 use crate::program::python::runtime as py_runtime;
@@ -65,7 +65,7 @@ pub async fn instantiate(
     process_id: ProcessId,
     username: String,
     program_name: &ProgramName,
-    capture_outputs: bool,
+    output: OutputMode,
     token_budget: Option<usize>,
 ) -> Result<(Store<InstanceState>, WasmInstance)> {
     let (tx, rx) = oneshot::channel();
@@ -73,7 +73,7 @@ pub async fn instantiate(
         process_id,
         username,
         program_name: program_name.clone(),
-        capture_outputs,
+        output,
         token_budget,
         response: tx,
     })?;
@@ -100,7 +100,7 @@ impl Linker {
         process_id: ProcessId,
         username: String,
         program_name: &ProgramName,
-        capture_outputs: bool,
+        output: OutputMode,
         token_budget: Option<usize>,
     ) -> Result<(Store<InstanceState>, WasmInstance)> {
         // 1. Get the main component (with snapshot status + python-runtime decl)
@@ -140,7 +140,7 @@ impl Linker {
         let inst_state = InstanceState::new(
             process_id,
             username,
-            capture_outputs,
+            output,
             &self.policy,
             token_budget,
             py_runtime_dir_for_state,
@@ -257,7 +257,7 @@ enum Message {
         process_id: ProcessId,
         username: String,
         program_name: ProgramName,
-        capture_outputs: bool,
+        output: OutputMode,
         token_budget: Option<usize>,
         response: oneshot::Sender<Result<(Store<InstanceState>, WasmInstance)>>,
     },
@@ -268,9 +268,9 @@ impl ServiceHandler for Linker {
 
     async fn handle(&mut self, msg: Message) {
         match msg {
-            Message::Instantiate { process_id, username, program_name, capture_outputs, token_budget, response } => {
+            Message::Instantiate { process_id, username, program_name, output, token_budget, response } => {
                 let _ = response.send(
-                    self.instantiate(process_id, username, &program_name, capture_outputs, token_budget).await
+                    self.instantiate(process_id, username, &program_name, output, token_budget).await
                 );
             }
         }

--- a/runtime/src/process.rs
+++ b/runtime/src/process.rs
@@ -14,6 +14,7 @@ use tokio::sync::{oneshot, Semaphore};
 use tokio::task::JoinHandle;
 
 use crate::context;
+use crate::instance::OutputMode;
 use crate::linker;
 use crate::program::ProgramName;
 use crate::server::{self, ClientId};
@@ -333,7 +334,10 @@ impl Process {
         };
 
         let result: Result<String, String> = async {
-            let (mut store, instance) = linker::instantiate(process_id, username, &program, capture_outputs, token_budget)
+            // capture_outputs ⇒ an attached client drains the per-process actor
+            // channel; otherwise this is a headless one-shot whose output is dropped.
+            let output = if capture_outputs { OutputMode::Process } else { OutputMode::Discard };
+            let (mut store, instance) = linker::instantiate(process_id, username, &program, output, token_budget)
                 .await
                 .map_err(|e| e.to_string())?;
 

--- a/runtime/src/program/python/snapshot.rs
+++ b/runtime/src/program/python/snapshot.rs
@@ -113,7 +113,7 @@ use {
 };
 
 use crate::api;
-use crate::instance::InstanceState;
+use crate::instance::{InstanceState, OutputMode};
 use crate::linker::dynamic_linking;
 
 use super::runtime as py_runtime;
@@ -1317,9 +1317,9 @@ pub(crate) async fn snapshot_from_bytes(
     let inst_state = InstanceState::new(
         uuid::Uuid::new_v4(),
         "snapshot".to_string(),
-        false,             // capture_outputs
-        &snapshot_policy,  // deny fs + deny network — snapshot init only
-        None,              // token_budget
+        OutputMode::Discard, // snapshot init only — guest output is noise
+        &snapshot_policy,    // deny fs + deny network — snapshot init only
+        None,                // token_budget
         py_runtime::dir(),
     ).await?;
     let mut store = Store::new(engine, inst_state);


### PR DESCRIPTION
Closes #374

## What this does
Forward-ports commit 753113b9 from `pie.app/v1-base-shmem` to `main`.

The daemon request path was instantiating each WASM component with
`capture_outputs=false`, leaving WASI stdout/stderr unwired. Guest output
fell through to wasmtime's default sink and was silently discarded, making
inferlet diagnostics invisible to operators in daemon deployments.

## Changes
Replaces `capture_outputs: bool` with an `OutputMode` enum
(Discard / Process / Server) threaded through `linker::instantiate`
and `InstanceState::new`. The daemon request path now passes
`OutputMode::Server`, routing guest stderr to `tracing::warn!` and
stdout to `tracing::info!`, each tagged with the program name.

## Files changed
- `runtime/src/daemon.rs`
- `runtime/src/instance.rs`
- `runtime/src/instance/output.rs`
- `runtime/src/linker.rs`
- `runtime/src/process.rs`
- `runtime/src/program/python/snapshot.rs`

## Testing
Cherry-picked cleanly from 753113b9 with no conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how guest program output is handled: outputs can be discarded, routed to process-specific streams, or sent to server tracing with program tags. Server-mode now logs stdout/stderr with program identifiers and suppresses empty lines for cleaner traces, improving observability and traceability of guest output during request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->