### PR TITLE
feat(runtime): expose engine KV capacity as runtime::max-output-tokens

### DIFF
--- a/runtime/src/api/runtime.rs
+++ b/runtime/src/api/runtime.rs
@@ -22,4 +22,8 @@ impl pie::core::runtime::Host for InstanceState {
     async fn models(&mut self) -> Result<Vec<String>> {
         Ok(model::models())
     }
+
+    async fn max_output_tokens(&mut self) -> Result<u32> {
+        Ok(model::min_kv_capacity_tokens())
+    }
 }

--- a/runtime/src/bootstrap.rs
+++ b/runtime/src/bootstrap.rs
@@ -210,10 +210,20 @@ async fn bootstrap_inner(config: Config, listener: Option<TcpListener>) -> Resul
     process::init_admission(config.max_concurrent_processes);
 
     for cfg in config.models.iter() {
+        // KV capacity (tokens) = min device total_pages * kv_page_size
+        // (caps-reported, so post-backoff). Saturate into the u32 WIT type.
+        let kv_capacity_tokens = cfg
+            .devices
+            .iter()
+            .map(|d| (d.total_pages as u64).saturating_mul(cfg.kv_page_size as u64))
+            .min()
+            .unwrap_or(0)
+            .min(u32::MAX as u64) as u32;
         model::register(
             cfg.name.clone(),
             &cfg.arch_name,
             cfg.kv_page_size as u32,
+            kv_capacity_tokens,
             cfg.tokenizer_path.clone(),
         )?;
 

--- a/runtime/src/model.rs
+++ b/runtime/src/model.rs
@@ -35,6 +35,7 @@ pub fn register(
     name: String,
     arch_name: &str,
     kv_page_size: u32,
+    kv_capacity_tokens: u32,
     tokenizer_path: PathBuf,
 ) -> Result<()> {
     let tokenizer = Arc::new(Tokenizer::from_file(&tokenizer_path)?);
@@ -44,6 +45,7 @@ pub fn register(
         name,
         instruct,
         kv_page_size,
+        kv_capacity_tokens,
         tokenizer,
     });
     MODELS.push(model);
@@ -53,6 +55,15 @@ pub fn register(
 /// Returns a list of all registered model names.
 pub fn models() -> Vec<String> {
     MODELS.iter().map(|(_, model)| model.name().to_string()).collect()
+}
+
+/// Minimum KV-cache capacity (tokens) across registered models; 0 if none.
+pub fn min_kv_capacity_tokens() -> u32 {
+    MODELS
+        .iter()
+        .map(|(_, model)| model.kv_capacity_tokens())
+        .min()
+        .unwrap_or(0)
 }
 
 /// Gets cached model by model ID.
@@ -68,6 +79,7 @@ pub struct Model {
     name: String,
     instruct: Arc<dyn Instruct>,
     kv_page_size: u32,
+    kv_capacity_tokens: u32,
     tokenizer: Arc<Tokenizer>,
 }
 
@@ -132,5 +144,10 @@ impl Model {
     /// Gets the KV page size.
     pub fn kv_page_size(&self) -> u32 {
         self.kv_page_size
+    }
+
+    /// Gets the engine KV-cache capacity for this model in tokens.
+    pub fn kv_capacity_tokens(&self) -> u32 {
+        self.kv_capacity_tokens
     }
 }

--- a/runtime/wit/core/wit/runtime.wit
+++ b/runtime/wit/core/wit/runtime.wit
@@ -14,4 +14,7 @@ interface runtime {
     // Get a list of all available model names
     models: func() -> list<string>;
 
+    // Max output tokens per request = engine KV capacity (0 if no model)
+    max-output-tokens: func() -> u32;
+
 }

--- a/runtime/wit/deps/core/runtime.wit
+++ b/runtime/wit/deps/core/runtime.wit
@@ -14,4 +14,7 @@ interface runtime {
     // Get a list of all available model names
     models: func() -> list<string>;
 
+    // Max output tokens per request = engine KV capacity (0 if no model)
+    max-output-tokens: func() -> u32;
+
 }

--- a/runtime/wit/zo/wit/deps/core/runtime.wit
+++ b/runtime/wit/zo/wit/deps/core/runtime.wit
@@ -14,4 +14,7 @@ interface runtime {
     // Get a list of all available model names
     models: func() -> list<string>;
 
+    // Max output tokens per request = engine KV capacity (0 if no model)
+    max-output-tokens: func() -> u32;
+
 }

--- a/sdk/rust/inferlet/wit/deps/core/runtime.wit
+++ b/sdk/rust/inferlet/wit/deps/core/runtime.wit
@@ -14,4 +14,7 @@ interface runtime {
     // Get a list of all available model names
     models: func() -> list<string>;
 
+    // Max output tokens per request = engine KV capacity (0 if no model)
+    max-output-tokens: func() -> u32;
+
 }

--- a/sdk/tools/bakery/src/bakery/wit/deps/core/runtime.wit
+++ b/sdk/tools/bakery/src/bakery/wit/deps/core/runtime.wit
@@ -14,4 +14,7 @@ interface runtime {
     // Get a list of all available model names
     models: func() -> list<string>;
 
+    // Max output tokens per request = engine KV capacity (0 if no model)
+    max-output-tokens: func() -> u32;
+
 }


### PR DESCRIPTION
## What
Adds `runtime::max-output-tokens()` to the `pie:core/runtime` WIT interface. It returns the engine's per-request output-token ceiling derived from KV-cache capacity (`kv_page_size * total_pages`, taken after the portable driver's launch-time memory backoff; minimum across registered models; `0` when none is registered so the caller can fall back).

## Why
Inferlets such as chat-apc hardcode a per-request `max_tokens` ceiling (8192) that is unrelated to the engine's real capacity. Exposing the actual capacity lets an inferlet follow the configured engine instead of a fixed constant, so the ceiling tracks `max_num_kv_pages` and host memory.

## Changes
- `runtime.wit`: new `max-output-tokens: func() -> u32` (kept in sync across the materialized `deps/` mirrors + the bakery/zo copies).
- `model::register` now stores `kv_capacity_tokens`; `bootstrap` computes `min(device.total_pages) * kv_page_size` from the caps the driver reports — so it reflects what physically fit after the backoff loop, not the requested page count.
- `api/runtime` implements `max_output_tokens` as the minimum capacity across registered models.

## Testing
- `cargo check -p pie` and `cargo test -p pie --lib` (392 passed, 0 failed).
- End-to-end via the chat-apc consumer: a real dummy-driver engine configured with `kv_page_size = 32, max_num_kv_pages = 512` returns `max_tokens must be in [1, 16384]` for an over-ceiling request — the inferlet followed the engine's KV capacity rather than the old constant.

Consumed by the RatioThink app (memory-aware `max_tokens` ceiling work).