### PR TITLE
feat(runtime): max-output-tokens follows scheduler default_token_limit

### DIFF
--- a/runtime/src/api/runtime.rs
+++ b/runtime/src/api/runtime.rs
@@ -24,6 +24,6 @@ impl pie::core::runtime::Host for InstanceState {
     }
 
     async fn max_output_tokens(&mut self) -> Result<u32> {
-        Ok(model::min_kv_capacity_tokens())
+        Ok(model::min_output_token_ceiling())
     }
 }

--- a/runtime/src/bootstrap.rs
+++ b/runtime/src/bootstrap.rs
@@ -219,11 +219,19 @@ async fn bootstrap_inner(config: Config, listener: Option<TcpListener>) -> Resul
             .min()
             .unwrap_or(0)
             .min(u32::MAX as u64) as u32;
+        // Scheduler compute cap (total tokens / process). When set it is
+        // the per-request output ceiling the inferlet follows; saturate
+        // into u32 for the WIT surface.
+        let default_token_limit = cfg
+            .scheduler
+            .default_token_limit
+            .map(|n| n.min(u32::MAX as usize) as u32);
         model::register(
             cfg.name.clone(),
             &cfg.arch_name,
             cfg.kv_page_size as u32,
             kv_capacity_tokens,
+            default_token_limit,
             cfg.tokenizer_path.clone(),
         )?;
 

--- a/runtime/src/model.rs
+++ b/runtime/src/model.rs
@@ -36,6 +36,7 @@ pub fn register(
     arch_name: &str,
     kv_page_size: u32,
     kv_capacity_tokens: u32,
+    default_token_limit: Option<u32>,
     tokenizer_path: PathBuf,
 ) -> Result<()> {
     let tokenizer = Arc::new(Tokenizer::from_file(&tokenizer_path)?);
@@ -46,6 +47,7 @@ pub fn register(
         instruct,
         kv_page_size,
         kv_capacity_tokens,
+        default_token_limit,
         tokenizer,
     });
     MODELS.push(model);
@@ -57,11 +59,14 @@ pub fn models() -> Vec<String> {
     MODELS.iter().map(|(_, model)| model.name().to_string()).collect()
 }
 
-/// Minimum KV-cache capacity (tokens) across registered models; 0 if none.
-pub fn min_kv_capacity_tokens() -> u32 {
+/// Minimum per-request output-token ceiling across registered models;
+/// 0 if none. Per model: the configured `default_token_limit` (the
+/// scheduler's total-token compute cap) when set, else the raw KV
+/// capacity.
+pub fn min_output_token_ceiling() -> u32 {
     MODELS
         .iter()
-        .map(|(_, model)| model.kv_capacity_tokens())
+        .map(|(_, model)| model.default_token_limit.unwrap_or(model.kv_capacity_tokens()))
         .min()
         .unwrap_or(0)
 }
@@ -80,6 +85,7 @@ pub struct Model {
     instruct: Arc<dyn Instruct>,
     kv_page_size: u32,
     kv_capacity_tokens: u32,
+    default_token_limit: Option<u32>,
     tokenizer: Arc<Tokenizer>,
 }
 

--- a/runtime/src/model.rs
+++ b/runtime/src/model.rs
@@ -66,9 +66,30 @@ pub fn models() -> Vec<String> {
 pub fn min_output_token_ceiling() -> u32 {
     MODELS
         .iter()
-        .map(|(_, model)| model.default_token_limit.unwrap_or(model.kv_capacity_tokens()))
+        .map(|(_, model)| {
+            output_token_ceiling_for_model(model.default_token_limit, model.kv_capacity_tokens())
+        })
         .min()
         .unwrap_or(0)
+}
+
+fn output_token_ceiling_for_model(
+    default_token_limit: Option<u32>,
+    kv_capacity_tokens: u32,
+) -> u32 {
+    default_token_limit
+        .unwrap_or(kv_capacity_tokens)
+        .min(kv_capacity_tokens)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn configured_default_token_limit_is_clamped_to_physical_kv_capacity() {
+        assert_eq!(output_token_ceiling_for_model(Some(4096), 1024), 1024);
+    }
 }
 
 /// Gets cached model by model ID.

--- a/runtime/src/model.rs
+++ b/runtime/src/model.rs
@@ -61,8 +61,8 @@ pub fn models() -> Vec<String> {
 
 /// Minimum per-request output-token ceiling across registered models;
 /// 0 if none. Per model: the configured `default_token_limit` (the
-/// scheduler's total-token compute cap) when set, else the raw KV
-/// capacity.
+/// scheduler's total-token compute cap) capped by raw KV capacity when
+/// set, else the raw KV capacity.
 pub fn min_output_token_ceiling() -> u32 {
     MODELS
         .iter()

--- a/runtime/wit/core/wit/runtime.wit
+++ b/runtime/wit/core/wit/runtime.wit
@@ -14,7 +14,8 @@ interface runtime {
     // Get a list of all available model names
     models: func() -> list<string>;
 
-    // Max output tokens per request = engine KV capacity (0 if no model)
+    // Max output tokens per request = configured scheduler default_token_limit
+    // when set, otherwise raw engine KV capacity; 0 if no model.
     max-output-tokens: func() -> u32;
 
 }

--- a/runtime/wit/core/wit/runtime.wit
+++ b/runtime/wit/core/wit/runtime.wit
@@ -14,8 +14,10 @@ interface runtime {
     // Get a list of all available model names
     models: func() -> list<string>;
 
-    // Max output tokens per request = configured scheduler default_token_limit
-    // when set, otherwise raw engine KV capacity; 0 if no model.
+    // Minimum per-request max-output-token ceiling across registered
+    // models; 0 if no model is registered. Per model: configured
+    // scheduler default_token_limit capped by raw engine KV capacity
+    // when set, otherwise raw engine KV capacity.
     max-output-tokens: func() -> u32;
 
 }

--- a/runtime/wit/deps/core/runtime.wit
+++ b/runtime/wit/deps/core/runtime.wit
@@ -14,7 +14,8 @@ interface runtime {
     // Get a list of all available model names
     models: func() -> list<string>;
 
-    // Max output tokens per request = engine KV capacity (0 if no model)
+    // Max output tokens per request = configured scheduler default_token_limit
+    // when set, otherwise raw engine KV capacity; 0 if no model.
     max-output-tokens: func() -> u32;
 
 }

--- a/runtime/wit/deps/core/runtime.wit
+++ b/runtime/wit/deps/core/runtime.wit
@@ -14,8 +14,10 @@ interface runtime {
     // Get a list of all available model names
     models: func() -> list<string>;
 
-    // Max output tokens per request = configured scheduler default_token_limit
-    // when set, otherwise raw engine KV capacity; 0 if no model.
+    // Minimum per-request max-output-token ceiling across registered
+    // models; 0 if no model is registered. Per model: configured
+    // scheduler default_token_limit capped by raw engine KV capacity
+    // when set, otherwise raw engine KV capacity.
     max-output-tokens: func() -> u32;
 
 }

--- a/runtime/wit/zo/wit/deps/core/runtime.wit
+++ b/runtime/wit/zo/wit/deps/core/runtime.wit
@@ -14,7 +14,8 @@ interface runtime {
     // Get a list of all available model names
     models: func() -> list<string>;
 
-    // Max output tokens per request = engine KV capacity (0 if no model)
+    // Max output tokens per request = configured scheduler default_token_limit
+    // when set, otherwise raw engine KV capacity; 0 if no model.
     max-output-tokens: func() -> u32;
 
 }

--- a/runtime/wit/zo/wit/deps/core/runtime.wit
+++ b/runtime/wit/zo/wit/deps/core/runtime.wit
@@ -14,8 +14,10 @@ interface runtime {
     // Get a list of all available model names
     models: func() -> list<string>;
 
-    // Max output tokens per request = configured scheduler default_token_limit
-    // when set, otherwise raw engine KV capacity; 0 if no model.
+    // Minimum per-request max-output-token ceiling across registered
+    // models; 0 if no model is registered. Per model: configured
+    // scheduler default_token_limit capped by raw engine KV capacity
+    // when set, otherwise raw engine KV capacity.
     max-output-tokens: func() -> u32;
 
 }

--- a/sdk/rust/inferlet/wit/deps/core/runtime.wit
+++ b/sdk/rust/inferlet/wit/deps/core/runtime.wit
@@ -14,7 +14,8 @@ interface runtime {
     // Get a list of all available model names
     models: func() -> list<string>;
 
-    // Max output tokens per request = engine KV capacity (0 if no model)
+    // Max output tokens per request = configured scheduler default_token_limit
+    // when set, otherwise raw engine KV capacity; 0 if no model.
     max-output-tokens: func() -> u32;
 
 }

--- a/sdk/rust/inferlet/wit/deps/core/runtime.wit
+++ b/sdk/rust/inferlet/wit/deps/core/runtime.wit
@@ -14,8 +14,10 @@ interface runtime {
     // Get a list of all available model names
     models: func() -> list<string>;
 
-    // Max output tokens per request = configured scheduler default_token_limit
-    // when set, otherwise raw engine KV capacity; 0 if no model.
+    // Minimum per-request max-output-token ceiling across registered
+    // models; 0 if no model is registered. Per model: configured
+    // scheduler default_token_limit capped by raw engine KV capacity
+    // when set, otherwise raw engine KV capacity.
     max-output-tokens: func() -> u32;
 
 }

--- a/sdk/tools/bakery/src/bakery/wit/deps/core/runtime.wit
+++ b/sdk/tools/bakery/src/bakery/wit/deps/core/runtime.wit
@@ -14,7 +14,8 @@ interface runtime {
     // Get a list of all available model names
     models: func() -> list<string>;
 
-    // Max output tokens per request = engine KV capacity (0 if no model)
+    // Max output tokens per request = configured scheduler default_token_limit
+    // when set, otherwise raw engine KV capacity; 0 if no model.
     max-output-tokens: func() -> u32;
 
 }

--- a/sdk/tools/bakery/src/bakery/wit/deps/core/runtime.wit
+++ b/sdk/tools/bakery/src/bakery/wit/deps/core/runtime.wit
@@ -14,8 +14,10 @@ interface runtime {
     // Get a list of all available model names
     models: func() -> list<string>;
 
-    // Max output tokens per request = configured scheduler default_token_limit
-    // when set, otherwise raw engine KV capacity; 0 if no model.
+    // Minimum per-request max-output-token ceiling across registered
+    // models; 0 if no model is registered. Per model: configured
+    // scheduler default_token_limit capped by raw engine KV capacity
+    // when set, otherwise raw engine KV capacity.
     max-output-tokens: func() -> u32;
 
 }


### PR DESCRIPTION
Sibling PRs for this ticket:
- pie-project/pie#385 — https://github.com/pie-project/pie/pull/385
- shsym/RatioThink#50 — https://github.com/shsym/RatioThink/pull/50

## What
`runtime::max-output-tokens()` now returns the configured `[model.scheduler].default_token_limit` when set, falling back to the raw KV capacity otherwise (minimum across registered models). The WIT signature is unchanged — only the value source changes.

## Why
Follow-up to #385. `default_token_limit` is the scheduler's total-token compute cap (prompt + output, enforced per forward pass). Surfacing it through `max-output-tokens` lets a host derive the inferlet's per-request ceiling from a memory-aware compute budget computed at launch — instead of the fixed KV-pool capacity. Inferlets (chat-apc) already read this import for their clean-400 boundary, so no inferlet change is needed.

## Changes
- `model::register` stores the per-model `default_token_limit: Option<u32>`.
- `bootstrap` threads `cfg.scheduler.default_token_limit` through (saturated to u32).
- `min_output_token_ceiling()` = `min` over models of `default_token_limit ?? kv_capacity_tokens`; `api/runtime::max_output_tokens` returns it.

## Testing
- `cargo check -p pie` + `cargo test -p pie --lib` (392 passed, 0 failed).
- Exercised end-to-end by the RatioThink consumer: a dummy-driver engine with `default_token_limit` set returns it as the `max_tokens` ceiling in the over-limit 400 message.