### PR TITLE
Expose inferlet max output fallback helper

### DIFF
--- a/sdk/rust/inferlet/src/lib.rs
+++ b/sdk/rust/inferlet/src/lib.rs
@@ -91,6 +91,15 @@ pub mod model {
 
 pub mod runtime {
     pub use crate::pie::core::runtime::*;
+
+    /// Runtime-reported output-token ceiling.
+    ///
+    /// Older Pie WIT does not expose this value. Return `0` as the explicit
+    /// "unknown" sentinel so callers that understand the newer helper can
+    /// fall back locally without failing to compile against this SDK pin.
+    pub fn max_output_tokens() -> u32 {
+        0
+    }
 }
 
 pub mod scheduling {


### PR DESCRIPTION
Sibling PRs for this ticket:
- shsym/RatioThink#67 — https://github.com/shsym/RatioThink/pull/67

## Summary
- add an inferlet runtime max_output_tokens SDK helper that returns 0 as the compatibility/unknown sentinel
- keep older app-side chat-apc code compiling while the outer RatioThink PR #67 local-CI replacement path is reviewed

## Context
RatioThink PR #67 currently needs its Vendor/pie SDK pin to provide the helper expected by current Inferlets/chat-apc. This Pie-side PR is intentionally limited to the SDK compatibility helper so the submodule commit can be reviewed/fetched separately.

## Validation
- cargo test --manifest-path sdk/rust/inferlet/Cargo.toml --lib