### PR TITLE
MCTS, Modular-Cache, Hierarchical-Attention Inferlet Examples

### DIFF
--- a/inferlets/hierarchical-attention-js/Pie.toml
+++ b/inferlets/hierarchical-attention-js/Pie.toml
@@ -1,0 +1,21 @@
+[package]
+name = "hierarchical-attention-js"
+version = "0.1.0"
+description = "TypeScript hierarchical attention mask demo over chunk summaries plus selected local chunk"
+authors = ["Abraam Mankaruse"]
+
+[runtime]
+core = "^0.2.0"
+mcp = "^0.2.0"
+
+[parameters]
+prompt = {type = "string", optional = true, description = "User prompt"}
+max_tokens = {type = "int", optional = true, description = "Maximum number of output tokens"}
+
+chunk_size_words = {type = "int", optional = true, description = "Approximate words per chunk"}
+sink_tokens = {type = "int", optional = true, description = "Initial tokens always visible"}
+summary_tokens_per_chunk = {type = "int", optional = true, description = "Header tokens kept for every chunk"}
+local_window_tokens = {type = "int", optional = true, description = "Recent committed tokens always visible"}
+selected_chunks = {type = "int", optional = true, description = "How many full chunk bodies to keep visible (default 1)"}
+selection_mode = {type = "string", optional = true, description = "Chunk relevance scoring: 'lexical' (default)"}
+

--- a/inferlets/hierarchical-attention-js/index.ts
+++ b/inferlets/hierarchical-attention-js/index.ts
@@ -1,0 +1,256 @@
+// Hierarchical-attention inferlet in TypeScript.
+//
+// Mirrors the canonical Rust version (`hierarchical-attention-rust`). A long
+// prompt is split into chunks; during a manual decode loop, each step builds a
+// BRLE attention mask that keeps a *hierarchy* visible:
+//
+//   global instructions      (sink tokens at the start)
+//     chunk summaries        (a header range per chunk)
+//       selected chunk(s)    (the full body of the most relevant chunk)
+//         recent window      (a sliding window at the end)
+//
+// How this differs from the existing attention examples:
+//   attention-sink         = first sink tokens            + recent window
+//   windowed-attention     = recent window only
+//   hierarchical-attention = sink + ALL chunk summaries + selected full chunk + recent window
+//
+// MVP: "summaries" are the first N tokens of each chunk header, relevance is
+// lexical overlap, and one shared mask is applied to every query token per pass.
+// Demonstrates the programmable attention-mask path; no speedup is claimed.
+
+import { Context, Model, Sampler, chat, runtime } from 'inferlet';
+
+interface Input {
+    prompt?: string;
+    max_tokens?: number;
+    chunk_size_words?: number;
+    sink_tokens?: number;
+    summary_tokens_per_chunk?: number;
+    local_window_tokens?: number;
+    selected_chunks?: number;
+    selection_mode?: string;
+}
+
+interface Range {
+    start: number;
+    end: number;
+}
+
+// =============================================================================
+// Pure helpers
+// =============================================================================
+
+// Split text into chunks of at most `chunkWords` words. An empty prompt yields
+// a single empty chunk so range bookkeeping always has a target.
+function splitWords(text: string, chunkWords: number): string[] {
+    const words = text.split(/\s+/).filter(Boolean);
+    if (words.length === 0) return [''];
+    const n = Math.max(1, chunkWords);
+    const chunks: string[] = [];
+    for (let i = 0; i < words.length; i += n) {
+        chunks.push(words.slice(i, i + n).join(' '));
+    }
+    return chunks;
+}
+
+// First `n` words of `text` — the stand-in "summary" for a chunk.
+function summarizeWords(text: string, n: number): string {
+    return text.split(/\s+/).filter(Boolean).slice(0, n).join(' ');
+}
+
+// Pick the `k` chunks with the highest lexical overlap with `query`. Overlap =
+// count of query words (>3 chars, lowercased) appearing in the chunk. Ties
+// break toward the earlier chunk. Returned indices are in positional order.
+function selectRelevantChunks(chunks: string[], query: string, k: number): number[] {
+    if (chunks.length === 0) return [];
+    const q = new Set(
+        query
+            .split(/\s+/)
+            .map((w) => w.toLowerCase())
+            .filter((w) => w.length > 3),
+    );
+    const scored = chunks.map((chunk, i) => {
+        let score = 0;
+        for (const w of chunk.split(/\s+/)) {
+            if (q.has(w.toLowerCase())) score++;
+        }
+        return { i, score };
+    });
+    // Sort by score desc, then index asc.
+    scored.sort((a, b) => b.score - a.score || a.i - b.i);
+    const take = Math.max(1, Math.min(k, chunks.length));
+    return scored
+        .slice(0, take)
+        .map((s) => s.i)
+        .sort((a, b) => a - b);
+}
+
+// Clip ranges to [0, total), drop empties, sort, and merge overlapping or
+// touching ranges into a minimal disjoint set.
+function mergeRanges(ranges: Range[], total: number): Range[] {
+    const clipped = ranges
+        .map((r) => ({
+            start: Math.max(0, Math.min(total, r.start)),
+            end: Math.max(0, Math.min(total, r.end)),
+        }))
+        .filter((r) => r.start < r.end)
+        .sort((a, b) => a.start - b.start);
+
+    const merged: Range[] = [];
+    for (const r of clipped) {
+        const last = merged[merged.length - 1];
+        if (last && r.start <= last.end) {
+            last.end = Math.max(last.end, r.end);
+        } else {
+            merged.push({ ...r });
+        }
+    }
+    return merged;
+}
+
+// BRLE attention mask over [0, total) keeping `ranges`. BRLE alternates run
+// lengths starting with a false run: [false, true, false, ...]. [0, total]
+// means "all true". An empty / fully-clipped keep-set returns [0, total]
+// (all-true / no restriction), never an all-false mask.
+function buildBrleMask(total: number, ranges: Range[]): number[] {
+    const merged = mergeRanges(ranges, total);
+    if (merged.length === 0) return [0, total];
+
+    const out: number[] = [];
+    let cursor = 0;
+    for (const r of merged) {
+        out.push(r.start - cursor); // false run up to this range
+        out.push(r.end - r.start); // true run covering this range
+        cursor = r.end;
+    }
+    if (cursor < total) out.push(total - cursor); // trailing false run
+    return out;
+}
+
+// Number of attended positions = sum of the true runs (odd indices).
+function maskTrueCount(mask: number[]): number {
+    let sum = 0;
+    for (let i = 1; i < mask.length; i += 2) sum += mask[i];
+    return sum;
+}
+
+function fmtRanges(ranges: Range[]): string {
+    return '[' + ranges.map((r) => `[${r.start},${r.end})`).join(', ') + ']';
+}
+
+// =============================================================================
+// Entry point
+// =============================================================================
+
+export async function main(input: Input): Promise<string> {
+    const model = Model.load(runtime.models()[0]);
+    const tokenizer = model.tokenizer();
+
+    const prompt =
+        input.prompt ??
+        'Explain how LLM serving systems use KV cache, batching, scheduling, and ' +
+            'attention masks. Include one practical example.';
+    const maxTokens = input.max_tokens ?? 128;
+    const chunkWords = Math.max(8, input.chunk_size_words ?? 80);
+    const sinkTokens = input.sink_tokens ?? 64;
+    const summaryTokensPerChunk = input.summary_tokens_per_chunk ?? 24;
+    const localWindowTokens = input.local_window_tokens ?? 128;
+    const selectedChunks = Math.max(1, input.selected_chunks ?? 1);
+    const selectionMode = input.selection_mode ?? 'lexical';
+
+    const chunks = splitWords(prompt, chunkWords);
+    const selected = selectRelevantChunks(chunks, prompt, selectedChunks);
+
+    const promptTokens: number[] = [];
+    const summaryRanges: Range[] = [];
+    const fullRanges: Range[] = [];
+
+    promptTokens.push(
+        ...Array.from(
+            chat.system(
+                model,
+                'You are a concise assistant. Use the visible hierarchy: global ' +
+                    'instructions, the chunk summaries, and the selected local chunk.',
+            ),
+        ),
+    );
+
+    chunks.forEach((chunk, i) => {
+        const header = `Chunk ${i} summary: ${summarizeWords(chunk, 20)}\n`;
+        const body = `Chunk ${i} full text:\n${chunk}\n`;
+
+        const headerStart = promptTokens.length;
+        promptTokens.push(...Array.from(chat.user(model, header)));
+        const headerEnd = promptTokens.length;
+        summaryRanges.push({
+            start: headerStart,
+            end: Math.min(headerEnd, headerStart + summaryTokensPerChunk),
+        });
+
+        const bodyStart = promptTokens.length;
+        promptTokens.push(...Array.from(chat.user(model, body)));
+        const bodyEnd = promptTokens.length;
+        fullRanges.push({ start: bodyStart, end: bodyEnd });
+    });
+
+    promptTokens.push(
+        ...Array.from(
+            chat.user(
+                model,
+                'Answer the original request using the selected local chunk(s) and the ' +
+                    'global chunk summaries.',
+            ),
+        ),
+    );
+    promptTokens.push(...Array.from(chat.cue(model)));
+
+    console.log('--- hierarchical-attention-js ---');
+    console.log(`chunks=${chunks.length}`);
+    console.log(`selected_chunk=[${selected.join(', ')}] (mode=${selectionMode})`);
+    console.log(`summary_ranges=${fmtRanges(summaryRanges)}`);
+    console.log(`full_ranges=${fmtRanges(fullRanges)}`);
+
+    const ctx = new Context(model);
+    let pending = promptTokens;
+    const generated: number[] = [];
+    const stopTokens = new Set<number>(Array.from(chat.stopTokens(model)));
+    let loggedMask = false;
+
+    for (let i = 0; i < maxTokens; ++i) {
+        if (pending.length === 0) break;
+
+        const fwd = ctx.forward();
+        const totalAfter = fwd.startPosition() + pending.length;
+
+        const keep: Range[] = [];
+        keep.push({ start: 0, end: Math.min(sinkTokens, totalAfter) }); // 1. sink
+        keep.push(...summaryRanges); // 2. summaries
+        for (const idx of selected) {
+            if (idx < fullRanges.length) keep.push(fullRanges[idx]); // 3. selected bodies
+        }
+        keep.push({ start: Math.max(0, totalAfter - localWindowTokens), end: totalAfter }); // 4. window
+
+        const mask = buildBrleMask(totalAfter, keep);
+
+        if (!loggedMask) {
+            console.log(`mask_true_tokens=${maskTrueCount(mask)} / total=${totalAfter}`);
+            loggedMask = true;
+        }
+
+        fwd.input(new Uint32Array(pending));
+        // One shared mask per query token in this pass (MVP simplification).
+        fwd.attentionMask(pending.map(() => new Uint32Array(mask)));
+
+        const h = fwd.sample([pending.length - 1], Sampler.argmax());
+        const out = await fwd.execute();
+        const token = out.token(h);
+
+        if (token === undefined || stopTokens.has(token)) break;
+
+        generated.push(token);
+        pending = [token];
+    }
+
+    console.log(`generated_tokens=${generated.length}`);
+    return tokenizer.decode(new Uint32Array(generated));
+}

--- a/inferlets/hierarchical-attention-js/package.json
+++ b/inferlets/hierarchical-attention-js/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "hierarchical-attention-js",
+    "version": "0.1.0",
+    "type": "module",
+    "main": "index.ts"
+}

--- a/inferlets/hierarchical-attention-python/Pie.toml
+++ b/inferlets/hierarchical-attention-python/Pie.toml
@@ -1,0 +1,22 @@
+[package]
+name = "hierarchical-attention-python"
+version = "0.1.0"
+description = "Python hierarchical attention mask demo over chunk summaries plus selected local chunk"
+authors = ["Abraam Mankaruse"]
+
+[runtime]
+core = "^0.2.0"
+mcp = "^0.2.0"
+python-runtime = "^0.4.0"
+
+[parameters]
+prompt = {type = "string", optional = true, description = "User prompt"}
+max_tokens = {type = "int", optional = true, description = "Maximum number of output tokens"}
+
+chunk_size_words = {type = "int", optional = true, description = "Approximate words per chunk"}
+sink_tokens = {type = "int", optional = true, description = "Initial tokens always visible"}
+summary_tokens_per_chunk = {type = "int", optional = true, description = "Header tokens kept for every chunk"}
+local_window_tokens = {type = "int", optional = true, description = "Recent committed tokens always visible"}
+selected_chunks = {type = "int", optional = true, description = "How many full chunk bodies to keep visible (default 1)"}
+selection_mode = {type = "string", optional = true, description = "Chunk relevance scoring: 'lexical' (default)"}
+

--- a/inferlets/hierarchical-attention-python/main.py
+++ b/inferlets/hierarchical-attention-python/main.py
@@ -1,0 +1,226 @@
+"""Hierarchical-attention inferlet in Python.
+
+Mirrors the canonical Rust version (`hierarchical-attention-rust`). A long prompt
+is split into chunks; during a manual decode loop, each step builds a BRLE
+attention mask that keeps a *hierarchy* visible:
+
+    global instructions      (sink tokens at the start)
+      chunk summaries        (a header range per chunk)
+        selected chunk(s)    (the full body of the most relevant chunk)
+          recent window      (a sliding window at the end)
+
+This uses manual `ctx.forward()` passes because `ctx.generate()` does not expose
+a different attention mask per generation step. See the README for how this
+differs from `attention-sink` / `windowed-attention`. The pure helpers
+(`split_words`, `select_relevant_chunks`, `merge_ranges`, `build_brle_mask`) are
+model-free and unit-tested in `test_hierarchical_attention.py`.
+"""
+
+from inferlet import Context, Model, Sampler, chat, runtime
+
+
+# =============================================================================
+# Pure helpers (unit-tested)
+# =============================================================================
+
+
+def split_words(text: str, chunk_words: int) -> list[str]:
+    """Split text into chunks of at most ``chunk_words`` words. An empty prompt
+    yields a single empty chunk so range bookkeeping always has a target."""
+    words = text.split()
+    if not words:
+        return [""]
+    n = max(1, chunk_words)
+    return [" ".join(words[i : i + n]) for i in range(0, len(words), n)]
+
+
+def summarize_words(text: str, n: int) -> str:
+    """First ``n`` words of ``text`` — the stand-in 'summary' for a chunk."""
+    return " ".join(text.split()[:n])
+
+
+def select_relevant_chunks(chunks: list[str], query: str, k: int) -> list[int]:
+    """Pick the ``k`` chunks with the highest lexical overlap with ``query``.
+
+    Overlap = count of query words (>3 chars, lowercased) appearing in the
+    chunk. Ties break toward the earlier chunk. Returned indices are in
+    positional order. Always returns at least one index when chunks exist.
+    """
+    if not chunks:
+        return []
+    q = {w.lower() for w in query.split() if len(w) > 3}
+    scored = []
+    for i, chunk in enumerate(chunks):
+        score = sum(1 for w in chunk.split() if w.lower() in q)
+        scored.append((i, score))
+    # Sort by score desc, then index asc.
+    scored.sort(key=lambda t: (-t[1], t[0]))
+    take = max(1, min(k, len(chunks)))
+    return sorted(i for i, _ in scored[:take])
+
+
+def merge_ranges(ranges: list[tuple[int, int]], total: int) -> list[tuple[int, int]]:
+    """Clip ranges to ``[0, total)``, drop empties, sort, and merge overlapping
+    or touching ranges into a minimal disjoint set."""
+    clipped = []
+    for start, end in ranges:
+        start = max(0, min(total, start))
+        end = max(0, min(total, end))
+        if start < end:
+            clipped.append((start, end))
+    clipped.sort()
+
+    merged: list[tuple[int, int]] = []
+    for start, end in clipped:
+        if merged and start <= merged[-1][1]:  # `<=` merges touching ranges
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def build_brle_mask(total: int, ranges: list[tuple[int, int]]) -> list[int]:
+    """BRLE attention mask over ``[0, total)`` keeping ``ranges``.
+
+    BRLE alternates run lengths starting with a **false** run:
+    ``[false, true, false, true, ...]``. ``[0, total]`` means 'all true'.
+
+    An empty / fully-clipped keep-set returns ``[0, total]`` (all-true / no
+    restriction), never an all-false mask (which the runtime rejects as
+    attending to nothing).
+    """
+    merged = merge_ranges(ranges, total)
+    if not merged:
+        return [0, total]
+
+    out: list[int] = []
+    cursor = 0
+    for start, end in merged:
+        out.append(start - cursor)  # false run up to this range
+        out.append(end - start)     # true run covering this range
+        cursor = end
+    if cursor < total:
+        out.append(total - cursor)  # trailing false run
+    return out
+
+
+def mask_true_count(mask: list[int]) -> int:
+    """Number of attended positions = sum of the true runs (odd indices)."""
+    return sum(mask[1::2])
+
+
+def _fmt_ranges(ranges: list[tuple[int, int]]) -> str:
+    return "[" + ", ".join(f"[{s},{e})" for s, e in ranges) + "]"
+
+
+# =============================================================================
+# Entry point
+# =============================================================================
+
+
+async def main(input: dict) -> str:
+    model = Model.load(runtime.models()[0])
+    tokenizer = model.tokenizer()
+
+    prompt = input.get(
+        "prompt",
+        "Explain how LLM serving systems use KV cache, batching, scheduling, and "
+        "attention masks. Include one practical example.",
+    )
+    max_tokens = int(input.get("max_tokens", 128))
+    chunk_words = max(8, int(input.get("chunk_size_words", 80)))
+    sink_tokens = int(input.get("sink_tokens", 64))
+    summary_tokens_per_chunk = int(input.get("summary_tokens_per_chunk", 24))
+    local_window_tokens = int(input.get("local_window_tokens", 128))
+    selected_chunks = max(1, int(input.get("selected_chunks", 1)))
+    selection_mode = input.get("selection_mode", "lexical")
+
+    chunks = split_words(prompt, chunk_words)
+    selected = select_relevant_chunks(chunks, prompt, selected_chunks)
+
+    prompt_tokens: list[int] = []
+    summary_ranges: list[tuple[int, int]] = []
+    full_ranges: list[tuple[int, int]] = []
+
+    prompt_tokens.extend(
+        chat.system(
+            model,
+            "You are a concise assistant. Use the visible hierarchy: global "
+            "instructions, the chunk summaries, and the selected local chunk.",
+        )
+    )
+
+    for i, chunk in enumerate(chunks):
+        header = f"Chunk {i} summary: {summarize_words(chunk, 20)}\n"
+        body = f"Chunk {i} full text:\n{chunk}\n"
+
+        header_start = len(prompt_tokens)
+        prompt_tokens.extend(chat.user(model, header))
+        header_end = len(prompt_tokens)
+        summary_ranges.append(
+            (header_start, min(header_end, header_start + summary_tokens_per_chunk))
+        )
+
+        body_start = len(prompt_tokens)
+        prompt_tokens.extend(chat.user(model, body))
+        body_end = len(prompt_tokens)
+        full_ranges.append((body_start, body_end))
+
+    prompt_tokens.extend(
+        chat.user(
+            model,
+            "Answer the original request using the selected local chunk(s) and the "
+            "global chunk summaries.",
+        )
+    )
+    prompt_tokens.extend(chat.cue(model))
+
+    print("--- hierarchical-attention-python ---")
+    print(f"chunks={len(chunks)}")
+    print(f"selected_chunk={selected} (mode={selection_mode})")
+    print(f"summary_ranges={_fmt_ranges(summary_ranges)}")
+    print(f"full_ranges={_fmt_ranges(full_ranges)}")
+
+    ctx = Context(model)
+    pending = prompt_tokens
+    generated: list[int] = []
+    stop_tokens = set(chat.stop_tokens(model))
+    logged_mask = False
+
+    for _ in range(max_tokens):
+        if not pending:
+            break
+
+        fwd = ctx.forward()
+        total_after = fwd.start_position() + len(pending)
+
+        keep: list[tuple[int, int]] = []
+        keep.append((0, min(sink_tokens, total_after)))           # 1. sink
+        keep.extend(summary_ranges)                               # 2. summaries
+        for idx in selected:                                      # 3. selected bodies
+            if idx < len(full_ranges):
+                keep.append(full_ranges[idx])
+        keep.append((max(0, total_after - local_window_tokens), total_after))  # 4. window
+
+        mask = build_brle_mask(total_after, keep)
+
+        if not logged_mask:
+            print(f"mask_true_tokens={mask_true_count(mask)} / total={total_after}")
+            logged_mask = True
+
+        fwd.input(pending)
+        # One shared mask per query token in this pass (MVP simplification).
+        fwd.attention_mask([list(mask) for _ in pending])
+
+        h = fwd.sample([len(pending) - 1], Sampler.argmax())
+        out = await fwd.execute()
+        token = out.token(h)
+
+        if token is None or token in stop_tokens:
+            break
+
+        generated.append(int(token))
+        pending = [int(token)]
+
+    print(f"generated_tokens={len(generated)}")
+    return tokenizer.decode(generated)

--- a/inferlets/hierarchical-attention-rust/Cargo.toml
+++ b/inferlets/hierarchical-attention-rust/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "hierarchical-attention-rust"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+inferlet = { path = "../../sdk/rust/inferlet" }
+serde = { version = "1.0", features = ["derive"] }
+
+[profile.release]
+lto = true

--- a/inferlets/hierarchical-attention-rust/Pie.toml
+++ b/inferlets/hierarchical-attention-rust/Pie.toml
@@ -1,0 +1,21 @@
+[package]
+name = "hierarchical-attention-rust"
+version = "0.1.0"
+description = "Hierarchical attention mask demo over chunk summaries plus selected local chunk"
+authors = ["Abraam Mankaruse"]
+
+[runtime]
+core = "^0.2.0"
+mcp = "^0.2.0"
+
+[parameters]
+prompt = {type = "string", optional = true, description = "User prompt"}
+max_tokens = {type = "int", optional = true, description = "Maximum number of output tokens"}
+
+chunk_size_words = {type = "int", optional = true, description = "Approximate words per chunk"}
+sink_tokens = {type = "int", optional = true, description = "Initial tokens always visible"}
+summary_tokens_per_chunk = {type = "int", optional = true, description = "Header tokens kept for every chunk"}
+local_window_tokens = {type = "int", optional = true, description = "Recent committed tokens always visible"}
+selected_chunks = {type = "int", optional = true, description = "How many full chunk bodies to keep visible (default 1)"}
+selection_mode = {type = "string", optional = true, description = "Chunk relevance scoring: 'lexical' (default)"}
+

--- a/inferlets/hierarchical-attention-rust/src/lib.rs
+++ b/inferlets/hierarchical-attention-rust/src/lib.rs
@@ -1,0 +1,329 @@
+//! Hierarchical-attention inferlet.
+//!
+//! A standalone example of **application-controlled, structured attention**.
+//! The repo already ships `attention-sink` (keep the first few tokens + a
+//! recent window) and `windowed-attention` (keep only a recent window). This
+//! inferlet keeps a *hierarchy* visible during generation:
+//!
+//! ```text
+//!   global instructions            (sink tokens at the very start)
+//!     chunk summaries              (a short header range per chunk)
+//!       selected chunk detail      (the full body of the most relevant chunk)
+//!         recent generated text    (a sliding local window at the end)
+//! ```
+//!
+//! A long prompt is split into word chunks. Each chunk contributes a short
+//! header (its "summary") and a full body. We record the token ranges of every
+//! header and body, pick the chunk(s) most relevant to the task by lexical
+//! overlap, then run a **manual decode loop**. At each step we build a BRLE
+//! attention mask whose *true* runs are exactly: the sink, every chunk header,
+//! the selected chunk body, and the recent window. Everything else is masked.
+//!
+//! How this differs from the existing examples:
+//!
+//! ```text
+//!   attention-sink         = first sink tokens            + recent window
+//!   windowed-attention     = recent window only
+//!   hierarchical-attention = sink + ALL chunk summaries + selected full chunk + recent window
+//! ```
+//!
+//! MVP scope: "summaries" are the first N tokens of each chunk header, and
+//! relevance is lexical overlap. One shared mask is applied to every query
+//! token in a pass (the pseudocode's documented simplification). The point is
+//! to demonstrate Pie's programmable attention-mask interface
+//! (`ctx.forward()` + `pass.attention_mask(...)`), not to ship a tuned policy.
+//! No speedup is claimed — masked KV pages still occupy memory; the mask only
+//! controls what the model *attends to*.
+
+use inferlet::{Context, Result, model::Model, runtime, sample::Sampler};
+use serde::Deserialize;
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, Deserialize)]
+struct Input {
+    #[serde(default = "default_prompt")]
+    prompt: String,
+    #[serde(default = "default_max_tokens")]
+    max_tokens: usize,
+    #[serde(default = "default_chunk_words")]
+    chunk_size_words: usize,
+    #[serde(default = "default_sink")]
+    sink_tokens: u32,
+    #[serde(default = "default_summary")]
+    summary_tokens_per_chunk: u32,
+    #[serde(default = "default_window")]
+    local_window_tokens: u32,
+    #[serde(default = "default_selected_chunks")]
+    selected_chunks: usize,
+    #[serde(default = "default_selection_mode")]
+    selection_mode: String,
+}
+
+fn default_prompt() -> String {
+    "Explain how LLM serving systems use KV cache, batching, scheduling, and \
+     attention masks. Include one practical example."
+        .into()
+}
+fn default_max_tokens() -> usize { 128 }
+fn default_chunk_words() -> usize { 80 }
+fn default_sink() -> u32 { 64 }
+fn default_summary() -> u32 { 24 }
+fn default_window() -> u32 { 128 }
+fn default_selected_chunks() -> usize { 1 }
+fn default_selection_mode() -> String { "lexical".into() }
+
+/// A half-open `[start, end)` token range.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Range {
+    start: u32,
+    end: u32,
+}
+
+impl Range {
+    fn new(start: u32, end: u32) -> Self {
+        Range { start, end }
+    }
+}
+
+#[inferlet::main]
+async fn main(input: Input) -> Result<String> {
+    let model = Model::load(runtime::models().first().ok_or("No models available")?)?;
+    let stop_tokens = inferlet::chat::stop_tokens(&model);
+
+    // Minimum chunk size guards against degenerate 1-word chunks blowing up the
+    // header/body bookkeeping.
+    let chunk_words = input.chunk_size_words.max(8);
+    let chunks = split_words(&input.prompt, chunk_words);
+
+    let selected = select_relevant_chunks(&chunks, &input.prompt, input.selected_chunks.max(1));
+
+    // Build one prompt token stream, recording the header (summary) and body
+    // (full) token ranges for each chunk as we go.
+    let mut prompt_tokens: Vec<u32> = Vec::new();
+    let mut summary_ranges: Vec<Range> = Vec::new();
+    let mut full_ranges: Vec<Range> = Vec::new();
+
+    prompt_tokens.extend(inferlet::chat::system(
+        &model,
+        "You are a concise assistant. Use the visible hierarchy: global \
+         instructions, the chunk summaries, and the selected local chunk.",
+    ));
+
+    for (i, chunk) in chunks.iter().enumerate() {
+        let header = format!("Chunk {} summary: {}\n", i, summarize_words(chunk, 20));
+        let body = format!("Chunk {} full text:\n{}\n", i, chunk);
+
+        // Header → keep only its first `summary_tokens_per_chunk` tokens as a
+        // global summary range.
+        let header_start = prompt_tokens.len() as u32;
+        prompt_tokens.extend(inferlet::chat::user(&model, &header));
+        let header_end = prompt_tokens.len() as u32;
+        let summary_end = header_start + input.summary_tokens_per_chunk.min(header_end - header_start);
+        summary_ranges.push(Range::new(header_start, summary_end));
+
+        // Body → record the full range so a selected chunk can be kept whole.
+        let body_start = prompt_tokens.len() as u32;
+        prompt_tokens.extend(inferlet::chat::user(&model, &body));
+        let body_end = prompt_tokens.len() as u32;
+        full_ranges.push(Range::new(body_start, body_end));
+    }
+
+    prompt_tokens.extend(inferlet::chat::user(
+        &model,
+        "Answer the original request using the selected local chunk(s) and the \
+         global chunk summaries.",
+    ));
+    prompt_tokens.extend(inferlet::chat::cue(&model));
+
+    println!("--- hierarchical-attention-rust ---");
+    println!("chunks={}", chunks.len());
+    println!("selected_chunk={:?} (mode={})", selected, input.selection_mode);
+    println!("summary_ranges={}", fmt_ranges(&summary_ranges));
+    println!("full_ranges={}", fmt_ranges(&full_ranges));
+
+    let mut ctx = Context::new(&model)?;
+    let mut pending = prompt_tokens;
+    let mut generated: Vec<u32> = Vec::new();
+    let mut logged_mask = false;
+
+    for _ in 0..input.max_tokens {
+        if pending.is_empty() {
+            break;
+        }
+
+        let mut fwd = ctx.forward();
+        let total_seq_after = fwd.start_position() + pending.len() as u32;
+
+        // Assemble the keep-set for this step.
+        let mut keep: Vec<Range> = Vec::new();
+        // 1. Sink: the very beginning stays globally visible.
+        keep.push(Range::new(0, input.sink_tokens.min(total_seq_after)));
+        // 2. Summary/header tokens from every chunk.
+        keep.extend(summary_ranges.iter().copied());
+        // 3. The full body of each selected chunk.
+        for &idx in &selected {
+            if let Some(r) = full_ranges.get(idx) {
+                keep.push(*r);
+            }
+        }
+        // 4. Recent window over the committed + pending sequence.
+        let win_start = total_seq_after.saturating_sub(input.local_window_tokens);
+        keep.push(Range::new(win_start, total_seq_after));
+
+        let mask = build_brle_mask(total_seq_after, &keep);
+
+        // Log the first step's mask occupancy so the effect is visible without
+        // spamming one line per generated token.
+        if !logged_mask {
+            println!(
+                "mask_true_tokens={} / total={}",
+                mask_true_count(&mask),
+                total_seq_after
+            );
+            logged_mask = true;
+        }
+
+        fwd.input(&pending);
+        // One shared mask per query token in this pass (MVP simplification).
+        let masks: Vec<Vec<u32>> = (0..pending.len()).map(|_| mask.clone()).collect();
+        fwd.attention_mask(&masks);
+
+        let h = fwd.sample(&[(pending.len() - 1) as u32], Sampler::Argmax);
+        let out = fwd.execute().await?;
+        let token = match out.token(h) {
+            Some(t) => t,
+            None => break,
+        };
+        if stop_tokens.contains(&token) {
+            break;
+        }
+
+        generated.push(token);
+        pending = vec![token];
+    }
+
+    println!("generated_tokens={}", generated.len());
+    Ok(model.tokenizer().decode(&generated)?)
+}
+
+// =============================================================================
+// Pure helpers (unit-tested)
+// =============================================================================
+
+/// Split text into chunks of at most `chunk_words` whitespace-separated words.
+/// An empty prompt yields a single empty chunk so downstream range bookkeeping
+/// always has something to point at.
+fn split_words(text: &str, chunk_words: usize) -> Vec<String> {
+    let words: Vec<&str> = text.split_whitespace().collect();
+    if words.is_empty() {
+        return vec![String::new()];
+    }
+    let n = chunk_words.max(1);
+    words.chunks(n).map(|w| w.join(" ")).collect()
+}
+
+/// First `n` words of `text` — the stand-in "summary" for a chunk.
+fn summarize_words(text: &str, n: usize) -> String {
+    text.split_whitespace().take(n).collect::<Vec<_>>().join(" ")
+}
+
+/// Pick the `k` chunks with the highest lexical overlap with `query`.
+///
+/// Overlap = count of query words (longer than 3 chars, lowercased) that appear
+/// in the chunk. Ties break toward the earlier chunk. Always returns at least
+/// one index (chunk 0) so the keep-set is never empty.
+fn select_relevant_chunks(chunks: &[String], query: &str, k: usize) -> Vec<usize> {
+    if chunks.is_empty() {
+        return vec![];
+    }
+    let q: HashSet<String> = query
+        .split_whitespace()
+        .map(|w| w.to_lowercase())
+        .filter(|w| w.len() > 3)
+        .collect();
+
+    let mut scored: Vec<(usize, usize)> = chunks
+        .iter()
+        .enumerate()
+        .map(|(i, c)| {
+            let score = c
+                .split_whitespace()
+                .map(|w| w.to_lowercase())
+                .filter(|w| q.contains(w))
+                .count();
+            (i, score)
+        })
+        .collect();
+
+    // Sort by score desc, then index asc (stable tie-break toward earlier).
+    scored.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
+
+    let take = k.clamp(1, chunks.len());
+    let mut out: Vec<usize> = scored.into_iter().take(take).map(|(i, _)| i).collect();
+    out.sort_unstable(); // keep ranges in positional order
+    out
+}
+
+/// Clip ranges to `[0, total)`, drop empties, sort, and merge overlapping or
+/// touching ranges into a minimal disjoint set.
+fn merge_ranges(ranges: &[Range], total: u32) -> Vec<Range> {
+    let mut clipped: Vec<Range> = ranges
+        .iter()
+        .map(|r| Range::new(r.start.min(total), r.end.min(total)))
+        .filter(|r| r.start < r.end)
+        .collect();
+    clipped.sort_by_key(|r| r.start);
+
+    let mut merged: Vec<Range> = Vec::new();
+    for r in clipped {
+        match merged.last_mut() {
+            // `<=` merges touching ranges (e.g. [0,4) and [4,8) -> [0,8)).
+            Some(last) if r.start <= last.end => last.end = last.end.max(r.end),
+            _ => merged.push(r),
+        }
+    }
+    merged
+}
+
+/// Build a BRLE attention mask over `[0, total)` keeping `ranges`.
+///
+/// BRLE alternates run lengths starting with a **false** run:
+/// `[false, true, false, true, ...]`. `[0, total]` means "all true".
+///
+/// Contract enforced here:
+/// * ranges are clipped to `total` and merged (overlaps collapse, no crash on
+///   empty ranges),
+/// * an empty keep-set returns `[0, total]` (all-true / no restriction) rather
+///   than an all-false mask, which the runtime would reject as attending to
+///   nothing.
+fn build_brle_mask(total: u32, ranges: &[Range]) -> Vec<u32> {
+    let merged = merge_ranges(ranges, total);
+    if merged.is_empty() {
+        // No keep-ranges => impose no restriction (all visible). Never emit a
+        // pure all-false mask.
+        return vec![0, total];
+    }
+
+    let mut out: Vec<u32> = Vec::new();
+    let mut cursor = 0u32;
+    for r in merged {
+        out.push(r.start - cursor); // false run up to this range
+        out.push(r.end - r.start); // true run covering this range
+        cursor = r.end;
+    }
+    if cursor < total {
+        out.push(total - cursor); // trailing false run
+    }
+    out
+}
+
+/// Number of *attended* positions in a BRLE mask = sum of the true runs (the
+/// odd-indexed entries).
+fn mask_true_count(mask: &[u32]) -> u32 {
+    mask.iter().skip(1).step_by(2).sum()
+}
+
+fn fmt_ranges(ranges: &[Range]) -> String {
+    let parts: Vec<String> = ranges.iter().map(|r| format!("[{},{})", r.start, r.end)).collect();
+    format!("[{}]", parts.join(", "))
+}

--- a/inferlets/mcts-js/Pie.toml
+++ b/inferlets/mcts-js/Pie.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mcts-js"
+version = "0.1.0"
+description = "TypeScript Monte Carlo Tree Search reasoning (UCB selection, expansion, rollout, evaluation, backpropagation)"
+authors = ["Abraam Mankaruse"]
+
+[runtime]
+core = "^0.2.0"
+mcp = "^0.2.0"
+
+[parameters]
+prompt = {type = "string", optional = true, description = "Problem / question to reason about"}
+max_iterations = {type = "int", optional = true, description = "Number of MCTS simulations (default 16)"}
+max_depth = {type = "int", optional = true, description = "Maximum reasoning depth of the search tree (default 4)"}
+branch_factor = {type = "int", optional = true, description = "Children proposed per expansion (default 3)"}
+rollout_tokens = {type = "int", optional = true, description = "Max tokens for a rollout continuation (default 128)"}
+final_tokens = {type = "int", optional = true, description = "Max tokens for the final synthesized answer (default 256)"}
+exploration_constant = {type = "float", optional = true, description = "UCB1 exploration constant c (default 1.414)"}
+show_trace = {type = "bool", optional = true, description = "Include the best reasoning path and MCTS summary in the output (default true)"}

--- a/inferlets/mcts-js/index.ts
+++ b/inferlets/mcts-js/index.ts
@@ -1,0 +1,364 @@
+// MCTS-reasoning inferlet in TypeScript.
+//
+// Mirrors the canonical Rust version (`mcts-rust`). Monte Carlo Tree Search
+// budgets the model calls: each iteration walks the most promising path by UCB,
+// expands it, simulates a candidate answer, scores it, and backs the score up
+// the tree. Over many iterations visit counts concentrate on the branch that
+// keeps scoring well.
+//
+// Four phases per iteration:
+//   1. Selection       — descend from root by UCB to a not-fully-expanded node.
+//   2. Expansion       — ask the model for the next reasoning step; attach a child.
+//   3. Simulation      — from that child, generate a candidate final answer.
+//   4. Eval + backprop — score 0-100, normalize to [0,1], add to every node on
+//                        the path and bump visit counts.
+//
+// MVP scope: every phase runs in a fresh Context (clear control flow at the cost
+// of recomputing shared prefixes). The pure search helpers (`ucb`, `parseScore`,
+// `Tree`) are model-free.
+
+import { Context, Model, Sampler, runtime } from 'inferlet';
+
+interface Input {
+    prompt?: string;
+    max_iterations?: number;
+    max_depth?: number;
+    branch_factor?: number;
+    rollout_tokens?: number;
+    final_tokens?: number;
+    exploration_constant?: number;
+    show_trace?: boolean;
+}
+
+// =============================================================================
+// Pure helpers
+// =============================================================================
+
+// UCB1 score for one child:
+//   ucb = mean + c * sqrt( ln(parentVisits + 1) / (childVisits + 1) )
+// An unvisited child returns +Infinity so it is always tried before any sibling
+// is revisited.
+function ucb(mean: number, childVisits: number, parentVisits: number, c: number): number {
+    if (childVisits === 0) return Infinity;
+    const exploration = Math.sqrt(Math.log(parentVisits + 1) / (childVisits + 1));
+    return mean + c * exploration;
+}
+
+// Extract the first decimal number from arbitrary text, or undefined.
+function firstNumber(text: string): number | undefined {
+    let buf = '';
+    for (const ch of text) {
+        if ((ch >= '0' && ch <= '9') || (ch === '.' && !buf.includes('.'))) {
+            buf += ch;
+        } else if (buf) {
+            break;
+        }
+    }
+    if (!buf || buf === '.') return undefined;
+    const v = Number(buf);
+    return Number.isNaN(v) ? undefined : v;
+}
+
+// Normalize a model score string to [0,1]. Numbers > 1.0 are treated as a
+// 0-100 score (divided by 100); a bare fraction <= 1.0 is taken as already
+// normalized. Unparseable output falls back to a neutral 0.5.
+function parseScore(text: string): number {
+    const v = firstNumber(text);
+    if (v === undefined) return 0.5;
+    const normalized = v > 1.0 ? v / 100.0 : v;
+    return Math.max(0.0, Math.min(1.0, normalized));
+}
+
+// =============================================================================
+// Search tree (arena of node records)
+// =============================================================================
+
+interface Node {
+    parent: number | null;
+    children: number[];
+    depth: number;
+    action: string;
+    visits: number;
+    valueSum: number;
+    terminal: boolean;
+}
+
+class Tree {
+    nodes: Node[];
+
+    constructor() {
+        this.nodes = [
+            { parent: null, children: [], depth: 0, action: '', visits: 0, valueSum: 0, terminal: false },
+        ];
+    }
+
+    root(): number {
+        return 0;
+    }
+
+    meanValue(node: number): number {
+        const n = this.nodes[node];
+        return n.visits === 0 ? 0 : n.valueSum / n.visits;
+    }
+
+    addChild(parent: number, action: string, maxDepth: number): number {
+        const depth = this.nodes[parent].depth + 1;
+        const id = this.nodes.length;
+        this.nodes.push({
+            parent,
+            children: [],
+            depth,
+            action,
+            visits: 0,
+            valueSum: 0,
+            terminal: depth >= maxDepth,
+        });
+        this.nodes[parent].children.push(id);
+        return id;
+    }
+
+    isFullyExpanded(node: number, branchFactor: number): boolean {
+        return this.nodes[node].children.length >= branchFactor;
+    }
+
+    bestUcbChild(node: number, c: number): number | undefined {
+        const children = this.nodes[node].children;
+        if (children.length === 0) return undefined;
+        const parentVisits = this.nodes[node].visits;
+        let best = children[0];
+        let bestScore = -Infinity;
+        for (const ch of children) {
+            const s = ucb(this.meanValue(ch), this.nodes[ch].visits, parentVisits, c);
+            if (s > bestScore) {
+                bestScore = s;
+                best = ch;
+            }
+        }
+        return best;
+    }
+
+    // Selection: descend by UCB while fully expanded, non-terminal, has children.
+    select(node: number, c: number, branchFactor: number): number {
+        for (;;) {
+            if (this.nodes[node].terminal) return node;
+            if (!this.isFullyExpanded(node, branchFactor)) return node;
+            const child = this.bestUcbChild(node, c);
+            if (child === undefined) return node;
+            node = child;
+        }
+    }
+
+    // Backpropagation: add value to every node from `node` up to the root.
+    backpropagate(node: number, value: number): void {
+        let cur: number | null = node;
+        while (cur !== null) {
+            this.nodes[cur].visits += 1;
+            this.nodes[cur].valueSum += value;
+            cur = this.nodes[cur].parent;
+        }
+    }
+
+    mostVisitedChild(node: number): number | undefined {
+        const children = this.nodes[node].children;
+        if (children.length === 0) return undefined;
+        let best = children[0];
+        for (const ch of children) {
+            if (this.nodes[ch].visits > this.nodes[best].visits) best = ch;
+        }
+        return best;
+    }
+
+    pathActions(node: number): string[] {
+        const out: string[] = [];
+        let cur: number | null = node;
+        while (cur !== null) {
+            if (this.nodes[cur].action) out.push(this.nodes[cur].action);
+            cur = this.nodes[cur].parent;
+        }
+        out.reverse();
+        return out;
+    }
+
+    bestPath(): string[] {
+        let node = this.root();
+        for (;;) {
+            const child = this.mostVisitedChild(node);
+            if (child === undefined) break;
+            node = child;
+        }
+        return this.pathActions(node);
+    }
+}
+
+// =============================================================================
+// Model-backed phases
+// =============================================================================
+
+function pathBlock(path: string[]): string {
+    if (path.length === 0) return '(no steps yet)';
+    return path.map((s, i) => `${i + 1}. ${s.trim()}`).join('\n');
+}
+
+async function expandStep(
+    model: Model,
+    problem: string,
+    path: string[],
+    rolloutTokens: number,
+): Promise<string> {
+    const ctx = new Context(model);
+    ctx.system(
+        'You extend a chain of reasoning. Given a problem and the steps so far, ' +
+            'propose ONE concise next reasoning step. Output only that step.',
+    );
+    ctx.user(`Problem:\n${problem}\n\nReasoning so far:\n${pathBlock(path)}\n\nNext reasoning step:`);
+    ctx.cue();
+    const text = await ctx
+        .generate(Sampler.topP(0.8, 0.95), { maxTokens: Math.max(16, Math.min(64, rolloutTokens)) })
+        .collectText();
+    return text.trim();
+}
+
+async function rollout(
+    model: Model,
+    problem: string,
+    path: string[],
+    rolloutTokens: number,
+): Promise<string> {
+    const ctx = new Context(model);
+    ctx.system(
+        'You finish a partial chain of reasoning. Continue from the steps given ' +
+            'and produce a short, concrete candidate final answer.',
+    );
+    ctx.user(
+        `Problem:\n${problem}\n\nReasoning so far:\n${pathBlock(path)}\n\nCandidate final answer:`,
+    );
+    ctx.cue();
+    const text = await ctx
+        .generate(Sampler.topP(0.7, 0.95), { maxTokens: rolloutTokens })
+        .collectText();
+    return text.trim();
+}
+
+async function evaluate(model: Model, problem: string, candidate: string): Promise<number> {
+    const ctx = new Context(model);
+    ctx.system(
+        'You are a strict grader. Score the candidate answer from 0 to 100 for ' +
+            'correctness, completeness, and reasoning quality. Return ONLY the number.',
+    );
+    ctx.user(`Problem:\n${problem}\n\nCandidate answer:\n${candidate}\n\nScore (0-100):`);
+    ctx.cue();
+    const text = await ctx.generate(Sampler.argmax(), { maxTokens: 8 }).collectText();
+    return parseScore(text);
+}
+
+async function synthesize(
+    model: Model,
+    problem: string,
+    bestPath: string[],
+    finalTokens: number,
+): Promise<string> {
+    const ctx = new Context(model);
+    ctx.system(
+        'You write the final answer to a problem, guided by a vetted chain of ' +
+            'reasoning. Be clear and correct.',
+    );
+    ctx.user(`Problem:\n${problem}\n\nBest reasoning path:\n${pathBlock(bestPath)}\n\nFinal answer:`);
+    ctx.cue();
+    const text = await ctx.generate(Sampler.argmax(), { maxTokens: finalTokens }).collectText();
+    return text.trim();
+}
+
+// =============================================================================
+// Entry point
+// =============================================================================
+
+export async function main(input: Input): Promise<string> {
+    const model = Model.load(runtime.models()[0]);
+
+    const prompt =
+        input.prompt ?? 'A farmer has 17 sheep and all but 9 run away. How many are left?';
+    const maxIterations = Math.max(1, input.max_iterations ?? 16);
+    const maxDepth = Math.max(1, input.max_depth ?? 4);
+    const branchFactor = Math.max(1, input.branch_factor ?? 3);
+    const rolloutTokens = input.rollout_tokens ?? 128;
+    const finalTokens = input.final_tokens ?? 256;
+    const c = input.exploration_constant ?? 1.414;
+    const showTrace = input.show_trace ?? true;
+
+    console.log('--- mcts-js ---');
+    console.log(
+        `iterations=${maxIterations} max_depth=${maxDepth} branch_factor=${branchFactor} c=${c.toFixed(3)}`,
+    );
+
+    const tree = new Tree();
+    let bestScore = 0;
+    let bestCandidate = '';
+
+    for (let it = 0; it < maxIterations; ++it) {
+        // (a) Selection.
+        const selected = tree.select(tree.root(), c, branchFactor);
+
+        // (b) Expansion.
+        const canExpand =
+            !tree.nodes[selected].terminal &&
+            tree.nodes[selected].depth < maxDepth &&
+            !tree.isFullyExpanded(selected, branchFactor);
+
+        let simNode: number;
+        if (canExpand) {
+            const path = tree.pathActions(selected);
+            const action = await expandStep(model, prompt, path, rolloutTokens);
+            simNode = tree.addChild(selected, action, maxDepth);
+        } else {
+            simNode = selected;
+        }
+        const expandedChildren = tree.nodes[selected].children.length;
+
+        // (c) Simulation / rollout.
+        const simPath = tree.pathActions(simNode);
+        const candidate = await rollout(model, prompt, simPath, rolloutTokens);
+
+        // (d) Evaluation.
+        const value = await evaluate(model, prompt, candidate);
+
+        // (e) Backpropagation.
+        tree.backpropagate(simNode, value);
+
+        if (value >= bestScore) {
+            bestScore = value;
+            bestCandidate = candidate;
+        }
+
+        console.log(
+            `iteration=${it} selected_node=${selected} expanded_children=${expandedChildren} ` +
+                `rollout_score=${value.toFixed(3)} best_score=${bestScore.toFixed(3)}`,
+        );
+    }
+
+    const bestPath = tree.bestPath();
+    let finalAnswer: string;
+    if (bestPath.length === 0) {
+        finalAnswer = bestCandidate || (await rollout(model, prompt, [], finalTokens));
+    } else {
+        finalAnswer = await synthesize(model, prompt, bestPath, finalTokens);
+    }
+
+    if (!showTrace) {
+        return finalAnswer;
+    }
+
+    const lines = ['Final answer:', finalAnswer, '', 'Best reasoning path:'];
+    if (bestPath.length === 0) {
+        lines.push('(search produced no expanded steps)');
+    } else {
+        bestPath.forEach((step, i) => lines.push(`${i + 1}. ${step.trim()}`));
+    }
+    lines.push(
+        '',
+        'MCTS summary:',
+        `iterations=${maxIterations}`,
+        `nodes=${tree.nodes.length}`,
+        `best_score=${bestScore.toFixed(3)}`,
+    );
+    return lines.join('\n');
+}

--- a/inferlets/mcts-js/package.json
+++ b/inferlets/mcts-js/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "mcts-js",
+    "version": "0.1.0",
+    "type": "module",
+    "main": "index.ts"
+}

--- a/inferlets/mcts-python/Pie.toml
+++ b/inferlets/mcts-python/Pie.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mcts-python"
+version = "0.1.0"
+description = "Python Monte Carlo Tree Search reasoning (UCB selection, expansion, rollout, evaluation, backpropagation)"
+authors = ["Abraam Mankaruse"]
+
+[runtime]
+core = "^0.2.0"
+mcp = "^0.2.0"
+python-runtime = "^0.4.0"
+
+[parameters]
+prompt = {type = "string", optional = true, description = "Problem / question to reason about"}
+max_iterations = {type = "int", optional = true, description = "Number of MCTS simulations (default 16)"}
+max_depth = {type = "int", optional = true, description = "Maximum reasoning depth of the search tree (default 4)"}
+branch_factor = {type = "int", optional = true, description = "Children proposed per expansion (default 3)"}
+rollout_tokens = {type = "int", optional = true, description = "Max tokens for a rollout continuation (default 128)"}
+final_tokens = {type = "int", optional = true, description = "Max tokens for the final synthesized answer (default 256)"}
+exploration_constant = {type = "float", optional = true, description = "UCB1 exploration constant c (default 1.414)"}
+show_trace = {type = "bool", optional = true, description = "Include the best reasoning path and MCTS summary in the output (default true)"}

--- a/inferlets/mcts-python/main.py
+++ b/inferlets/mcts-python/main.py
@@ -1,0 +1,332 @@
+"""MCTS-reasoning inferlet in Python.
+
+Mirrors the canonical Rust version (`mcts-rust`). Monte Carlo Tree Search
+budgets the model calls: each iteration walks the most promising path by UCB,
+expands it, simulates a candidate answer, scores it, and backs the score up the
+tree. Over many iterations visit counts concentrate on the branch that keeps
+scoring well.
+
+Four phases per iteration:
+
+1. Selection      — descend from root by UCB to a not-fully-expanded node.
+2. Expansion      — ask the model for the next reasoning step; attach a child.
+3. Simulation     — from that child, generate a candidate final answer.
+4. Eval + backprop— score 0-100, normalize to [0,1], add to every node on the
+                    path and bump visit counts.
+
+MVP scope: every phase runs in a fresh Context (clear control flow at the cost
+of recomputing shared prefixes). The pure search helpers (`ucb`, `parse_score`,
+`Tree`) are model-free and unit-tested in `test_mcts.py`.
+"""
+
+import math
+
+from inferlet import Context, Model, Sampler, runtime
+
+
+# =============================================================================
+# Pure helpers (unit-tested)
+# =============================================================================
+
+
+def ucb(mean_value: float, child_visits: int, parent_visits: int, c: float) -> float:
+    """UCB1 score for one child::
+
+        ucb = mean_value + c * sqrt( ln(parent_visits + 1) / (child_visits + 1) )
+
+    An unvisited child returns +inf so it is always tried before any sibling is
+    revisited (the "expand every action at least once" rule).
+    """
+    if child_visits == 0:
+        return math.inf
+    exploration = math.sqrt(math.log(parent_visits + 1) / (child_visits + 1))
+    return mean_value + c * exploration
+
+
+def first_number(text: str):
+    """Extract the first decimal number from arbitrary text, or ``None``."""
+    buf = ""
+    for ch in text:
+        if ch.isdigit() or (ch == "." and "." not in buf):
+            buf += ch
+        elif buf:
+            break
+    if not buf or buf == ".":
+        return None
+    try:
+        return float(buf)
+    except ValueError:
+        return None
+
+
+def parse_score(text: str) -> float:
+    """Normalize a model score string into ``[0,1]``.
+
+    The evaluation prompt asks for 0-100, but models are inconsistent ("85",
+    "Score: 85/100", "0.85"). Grab the first number: ``> 1.0`` is treated as a
+    0-100 score (divided by 100); a bare fraction ``<= 1.0`` is taken as already
+    normalized. Unparseable output falls back to a neutral ``0.5``.
+    """
+    v = first_number(text)
+    if v is None:
+        return 0.5
+    normalized = v / 100.0 if v > 1.0 else v
+    return max(0.0, min(1.0, normalized))
+
+
+# =============================================================================
+# Search tree (arena of dict nodes)
+# =============================================================================
+
+
+class Tree:
+    """MCTS search tree. Holds the node arena and all *pure* search logic
+    (selection, UCB, expansion bookkeeping, backpropagation). Nothing here
+    touches the model, so it is unit-testable on the host."""
+
+    def __init__(self):
+        # Node fields: parent, children, depth, action, visits, value_sum, terminal.
+        self.nodes = [
+            {
+                "parent": None,
+                "children": [],
+                "depth": 0,
+                "action": "",
+                "visits": 0,
+                "value_sum": 0.0,
+                "terminal": False,
+            }
+        ]
+
+    def root(self) -> int:
+        return 0
+
+    def mean_value(self, node: int) -> float:
+        n = self.nodes[node]
+        return 0.0 if n["visits"] == 0 else n["value_sum"] / n["visits"]
+
+    def add_child(self, parent: int, action: str, max_depth: int) -> int:
+        depth = self.nodes[parent]["depth"] + 1
+        node_id = len(self.nodes)
+        self.nodes.append(
+            {
+                "parent": parent,
+                "children": [],
+                "depth": depth,
+                "action": action,
+                "visits": 0,
+                "value_sum": 0.0,
+                "terminal": depth >= max_depth,
+            }
+        )
+        self.nodes[parent]["children"].append(node_id)
+        return node_id
+
+    def is_fully_expanded(self, node: int, branch_factor: int) -> bool:
+        return len(self.nodes[node]["children"]) >= branch_factor
+
+    def best_ucb_child(self, node: int, c: float):
+        children = self.nodes[node]["children"]
+        if not children:
+            return None
+        parent_visits = self.nodes[node]["visits"]
+        return max(
+            children,
+            key=lambda ch: ucb(self.mean_value(ch), self.nodes[ch]["visits"], parent_visits, c),
+        )
+
+    def select(self, node: int, c: float, branch_factor: int) -> int:
+        """Descend by UCB while fully expanded, non-terminal, and has children."""
+        while True:
+            if self.nodes[node]["terminal"]:
+                return node
+            if not self.is_fully_expanded(node, branch_factor):
+                return node
+            child = self.best_ucb_child(node, c)
+            if child is None:
+                return node
+            node = child
+
+    def backpropagate(self, node: int, value: float) -> None:
+        """Add ``value`` to every node from ``node`` up to the root."""
+        cur = node
+        while cur is not None:
+            self.nodes[cur]["visits"] += 1
+            self.nodes[cur]["value_sum"] += value
+            cur = self.nodes[cur]["parent"]
+
+    def most_visited_child(self, node: int):
+        children = self.nodes[node]["children"]
+        if not children:
+            return None
+        return max(children, key=lambda ch: self.nodes[ch]["visits"])
+
+    def path_actions(self, node: int):
+        out = []
+        cur = node
+        while cur is not None:
+            action = self.nodes[cur]["action"]
+            if action:
+                out.append(action)
+            cur = self.nodes[cur]["parent"]
+        out.reverse()
+        return out
+
+    def best_path(self):
+        node = self.root()
+        while True:
+            child = self.most_visited_child(node)
+            if child is None:
+                break
+            node = child
+        return self.path_actions(node)
+
+
+# =============================================================================
+# Model-backed phases
+# =============================================================================
+
+
+def path_block(path) -> str:
+    if not path:
+        return "(no steps yet)"
+    return "\n".join(f"{i + 1}. {s.strip()}" for i, s in enumerate(path))
+
+
+async def expand_step(model, problem, path, rollout_tokens) -> str:
+    ctx = Context(model)
+    ctx.system(
+        "You extend a chain of reasoning. Given a problem and the steps so far, "
+        "propose ONE concise next reasoning step. Output only that step."
+    )
+    ctx.user(f"Problem:\n{problem}\n\nReasoning so far:\n{path_block(path)}\n\nNext reasoning step:")
+    ctx.cue()
+    text = await ctx.generate(
+        Sampler.top_p(0.8, 0.95), max_tokens=max(16, min(64, rollout_tokens))
+    ).collect_text()
+    return text.strip()
+
+
+async def rollout(model, problem, path, rollout_tokens) -> str:
+    ctx = Context(model)
+    ctx.system(
+        "You finish a partial chain of reasoning. Continue from the steps given "
+        "and produce a short, concrete candidate final answer."
+    )
+    ctx.user(
+        f"Problem:\n{problem}\n\nReasoning so far:\n{path_block(path)}\n\nCandidate final answer:"
+    )
+    ctx.cue()
+    text = await ctx.generate(Sampler.top_p(0.7, 0.95), max_tokens=rollout_tokens).collect_text()
+    return text.strip()
+
+
+async def evaluate(model, problem, candidate) -> float:
+    ctx = Context(model)
+    ctx.system(
+        "You are a strict grader. Score the candidate answer from 0 to 100 for "
+        "correctness, completeness, and reasoning quality. Return ONLY the number."
+    )
+    ctx.user(f"Problem:\n{problem}\n\nCandidate answer:\n{candidate}\n\nScore (0-100):")
+    ctx.cue()
+    text = await ctx.generate(Sampler.argmax(), max_tokens=8).collect_text()
+    return parse_score(text)
+
+
+async def synthesize(model, problem, best_path, final_tokens) -> str:
+    ctx = Context(model)
+    ctx.system(
+        "You write the final answer to a problem, guided by a vetted chain of "
+        "reasoning. Be clear and correct."
+    )
+    ctx.user(f"Problem:\n{problem}\n\nBest reasoning path:\n{path_block(best_path)}\n\nFinal answer:")
+    ctx.cue()
+    text = await ctx.generate(Sampler.argmax(), max_tokens=final_tokens).collect_text()
+    return text.strip()
+
+
+# =============================================================================
+# Entry point
+# =============================================================================
+
+
+async def main(input: dict) -> str:
+    model = Model.load(runtime.models()[0])
+
+    prompt = input.get(
+        "prompt", "A farmer has 17 sheep and all but 9 run away. How many are left?"
+    )
+    max_iterations = max(1, int(input.get("max_iterations", 16)))
+    max_depth = max(1, int(input.get("max_depth", 4)))
+    branch_factor = max(1, int(input.get("branch_factor", 3)))
+    rollout_tokens = int(input.get("rollout_tokens", 128))
+    final_tokens = int(input.get("final_tokens", 256))
+    c = float(input.get("exploration_constant", 1.414))
+    show_trace = bool(input.get("show_trace", True))
+
+    print("--- mcts-python ---")
+    print(f"iterations={max_iterations} max_depth={max_depth} branch_factor={branch_factor} c={c:.3f}")
+
+    tree = Tree()
+    best_score = 0.0
+    best_candidate = ""
+
+    for it in range(max_iterations):
+        # (a) Selection.
+        selected = tree.select(tree.root(), c, branch_factor)
+
+        # (b) Expansion.
+        can_expand = (
+            not tree.nodes[selected]["terminal"]
+            and tree.nodes[selected]["depth"] < max_depth
+            and not tree.is_fully_expanded(selected, branch_factor)
+        )
+        if can_expand:
+            path = tree.path_actions(selected)
+            action = await expand_step(model, prompt, path, rollout_tokens)
+            sim_node = tree.add_child(selected, action, max_depth)
+        else:
+            sim_node = selected
+        expanded_children = len(tree.nodes[selected]["children"])
+
+        # (c) Simulation / rollout.
+        sim_path = tree.path_actions(sim_node)
+        candidate = await rollout(model, prompt, sim_path, rollout_tokens)
+
+        # (d) Evaluation.
+        value = await evaluate(model, prompt, candidate)
+
+        # (e) Backpropagation.
+        tree.backpropagate(sim_node, value)
+
+        if value >= best_score:
+            best_score = value
+            best_candidate = candidate
+
+        print(
+            f"iteration={it} selected_node={selected} expanded_children={expanded_children} "
+            f"rollout_score={value:.3f} best_score={best_score:.3f}"
+        )
+
+    best_path = tree.best_path()
+    if not best_path:
+        final_answer = best_candidate or await rollout(model, prompt, [], final_tokens)
+    else:
+        final_answer = await synthesize(model, prompt, best_path, final_tokens)
+
+    if not show_trace:
+        return final_answer
+
+    lines = ["Final answer:", final_answer, "", "Best reasoning path:"]
+    if not best_path:
+        lines.append("(search produced no expanded steps)")
+    else:
+        lines.extend(f"{i + 1}. {step.strip()}" for i, step in enumerate(best_path))
+    lines += [
+        "",
+        "MCTS summary:",
+        f"iterations={max_iterations}",
+        f"nodes={len(tree.nodes)}",
+        f"best_score={best_score:.3f}",
+    ]
+    return "\n".join(lines)

--- a/inferlets/mcts-rust/Cargo.toml
+++ b/inferlets/mcts-rust/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mcts-rust"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+inferlet = { path = "../../sdk/rust/inferlet" }
+serde = { version = "1.0", features = ["derive"] }
+
+[profile.release]
+lto = true

--- a/inferlets/mcts-rust/Pie.toml
+++ b/inferlets/mcts-rust/Pie.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mcts-rust"
+version = "0.1.0"
+description = "Monte Carlo Tree Search reasoning (UCB selection, expansion, rollout, evaluation, backpropagation)"
+authors = ["Abraam Mankaruse"]
+
+[runtime]
+core = "^0.2.0"
+mcp = "^0.2.0"
+
+[parameters]
+prompt = {type = "string", optional = true, description = "Problem / question to reason about"}
+max_iterations = {type = "int", optional = true, description = "Number of MCTS simulations (default 16)"}
+max_depth = {type = "int", optional = true, description = "Maximum reasoning depth of the search tree (default 4)"}
+branch_factor = {type = "int", optional = true, description = "Children proposed per expansion (default 3)"}
+rollout_tokens = {type = "int", optional = true, description = "Max tokens for a rollout continuation (default 128)"}
+final_tokens = {type = "int", optional = true, description = "Max tokens for the final synthesized answer (default 256)"}
+exploration_constant = {type = "float", optional = true, description = "UCB1 exploration constant c (default 1.414)"}
+show_trace = {type = "bool", optional = true, description = "Include the best reasoning path and MCTS summary in the output (default true)"}

--- a/inferlets/mcts-rust/src/lib.rs
+++ b/inferlets/mcts-rust/src/lib.rs
@@ -1,0 +1,507 @@
+//! MCTS-reasoning inferlet.
+//!
+//! A standalone example of **Monte Carlo Tree Search (MCTS) reasoning** for
+//! LLM problem solving. Instead of generating a fixed breadth-first tree of
+//! thoughts and pruning (that is `tree-of-thought`), MCTS *budgets* its model
+//! calls: it repeatedly walks the most promising path, expands it, simulates a
+//! candidate answer, scores it, and feeds that score back up the tree. Over
+//! many iterations the visit counts concentrate on the branch that keeps
+//! scoring well.
+//!
+//! The classic four-phase loop, once per iteration:
+//!
+//! 1. **Selection** — from the root, descend by Upper Confidence Bound (UCB)
+//!    until reaching a node that is not fully expanded (or is terminal).
+//! 2. **Expansion** — ask the model for `branch_factor` candidate next
+//!    reasoning steps and attach them as children.
+//! 3. **Simulation / rollout** — from one new child, generate a candidate
+//!    final answer.
+//! 4. **Evaluation + backpropagation** — score the candidate 0–100, normalize
+//!    to `[0,1]`, and add it to every node on the path while bumping visits.
+//!
+//! After the budget is spent we follow the most-visited child at each level to
+//! recover the best reasoning path, then synthesize a final answer from it.
+//!
+//! Why UCB? It trades **exploitation** (a node's average score so far) against
+//! **exploration** (a bonus for nodes visited few times relative to their
+//! parent), so the search neither fixates on an early lucky branch nor wastes
+//! the whole budget sampling uniformly. Unvisited children get an infinite
+//! score, so every child is tried at least once before any is revisited.
+//!
+//! MVP scope: each phase uses a fresh short [`Context`] (expand / rollout /
+//! evaluate / synthesize). That keeps the control flow obviously correct at
+//! the cost of recomputing shared prompt prefixes — see the README for the
+//! `Context::fork()` optimization left as future work. This is a *correctness
+//! / demonstration* inferlet, not a tuned reasoning benchmark.
+
+use inferlet::{Context, Result, model::Model, runtime, sample::Sampler};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+struct Input {
+    #[serde(default = "default_prompt")]
+    prompt: String,
+    #[serde(default = "default_max_iterations")]
+    max_iterations: usize,
+    #[serde(default = "default_max_depth")]
+    max_depth: usize,
+    #[serde(default = "default_branch_factor")]
+    branch_factor: usize,
+    #[serde(default = "default_rollout_tokens")]
+    rollout_tokens: usize,
+    #[serde(default = "default_final_tokens")]
+    final_tokens: usize,
+    #[serde(default = "default_exploration_constant")]
+    exploration_constant: f32,
+    #[serde(default = "default_show_trace")]
+    show_trace: bool,
+}
+
+fn default_prompt() -> String {
+    "A farmer has 17 sheep and all but 9 run away. How many are left?".to_string()
+}
+fn default_max_iterations() -> usize { 16 }
+fn default_max_depth() -> usize { 4 }
+fn default_branch_factor() -> usize { 3 }
+fn default_rollout_tokens() -> usize { 128 }
+fn default_final_tokens() -> usize { 256 }
+fn default_exploration_constant() -> f32 { 1.414 }
+fn default_show_trace() -> bool { true }
+
+// =============================================================================
+// Search tree (arena-allocated)
+// =============================================================================
+//
+// Nodes are stored in a flat `Vec` and referenced by index. An arena avoids
+// the `Rc<RefCell<Node>>` dance you'd otherwise need for a tree with parent
+// pointers, and makes the pure search logic trivially unit-testable.
+
+/// One node in the search tree — a partial reasoning state.
+#[derive(Debug, Clone)]
+struct Node {
+    /// Index of the parent node, or `None` for the root.
+    parent: Option<usize>,
+    /// Indices of attached children.
+    children: Vec<usize>,
+    /// Distance from the root (root = 0).
+    depth: usize,
+    /// The reasoning step (action) that produced this node. Empty at the root.
+    action: String,
+    /// How many simulations have passed through this node.
+    visits: u32,
+    /// Sum of normalized rollout values backed up through this node.
+    value_sum: f32,
+    /// Terminal nodes are never expanded (they sit at `max_depth`).
+    terminal: bool,
+}
+
+impl Node {
+    fn mean_value(&self) -> f32 {
+        if self.visits == 0 { 0.0 } else { self.value_sum / self.visits as f32 }
+    }
+}
+
+/// The MCTS search tree. Holds the node arena and all *pure* search logic
+/// (selection, UCB, expansion bookkeeping, backpropagation). Nothing here
+/// touches the model, so the whole module is unit-testable on the host.
+struct Tree {
+    nodes: Vec<Node>,
+}
+
+impl Tree {
+    /// Create a tree containing only the root (depth 0, no action).
+    fn new() -> Self {
+        Tree {
+            nodes: vec![Node {
+                parent: None,
+                children: Vec::new(),
+                depth: 0,
+                action: String::new(),
+                visits: 0,
+                value_sum: 0.0,
+                terminal: false,
+            }],
+        }
+    }
+
+    fn root(&self) -> usize { 0 }
+
+    /// Attach a child carrying `action` under `parent`. The child is marked
+    /// terminal when it reaches `max_depth` (it can never be expanded further).
+    fn add_child(&mut self, parent: usize, action: String, max_depth: usize) -> usize {
+        let depth = self.nodes[parent].depth + 1;
+        let id = self.nodes.len();
+        self.nodes.push(Node {
+            parent: Some(parent),
+            children: Vec::new(),
+            depth,
+            action,
+            visits: 0,
+            value_sum: 0.0,
+            terminal: depth >= max_depth,
+        });
+        self.nodes[parent].children.push(id);
+        id
+    }
+
+    /// A node is fully expanded once it has `branch_factor` children.
+    fn is_fully_expanded(&self, node: usize, branch_factor: usize) -> bool {
+        self.nodes[node].children.len() >= branch_factor
+    }
+
+    /// The child of `node` with the highest UCB score, or `None` if it has no
+    /// children. Unvisited children win automatically (UCB returns +∞).
+    fn best_ucb_child(&self, node: usize, c: f32) -> Option<usize> {
+        let parent_visits = self.nodes[node].visits;
+        self.nodes[node]
+            .children
+            .iter()
+            .copied()
+            .max_by(|&a, &b| {
+                let sa = ucb(self.nodes[a].mean_value(), self.nodes[a].visits, parent_visits, c);
+                let sb = ucb(self.nodes[b].mean_value(), self.nodes[b].visits, parent_visits, c);
+                sa.partial_cmp(&sb).unwrap_or(std::cmp::Ordering::Equal)
+            })
+    }
+
+    /// **Selection**: descend from `node` by UCB while the current node is
+    /// fully expanded, non-terminal, and has children. Stops at the first node
+    /// that can still grow a child (or at a terminal/leaf node).
+    fn select(&self, mut node: usize, c: f32, branch_factor: usize) -> usize {
+        loop {
+            if self.nodes[node].terminal {
+                return node;
+            }
+            if !self.is_fully_expanded(node, branch_factor) {
+                return node;
+            }
+            match self.best_ucb_child(node, c) {
+                Some(child) => node = child,
+                None => return node, // fully expanded but childless (branch_factor==0)
+            }
+        }
+    }
+
+    /// **Backpropagation**: add `value` to every node from `node` up to the
+    /// root, incrementing each one's visit count.
+    fn backpropagate(&mut self, node: usize, value: f32) {
+        let mut cur = Some(node);
+        while let Some(i) = cur {
+            self.nodes[i].visits += 1;
+            self.nodes[i].value_sum += value;
+            cur = self.nodes[i].parent;
+        }
+    }
+
+    /// The most-visited child of `node` — the *robust* choice used to read off
+    /// the final path (visit count is a steadier signal than mean value).
+    fn most_visited_child(&self, node: usize) -> Option<usize> {
+        self.nodes[node]
+            .children
+            .iter()
+            .copied()
+            .max_by_key(|&c| self.nodes[c].visits)
+    }
+
+    /// Actions from the root down to `node`, in order (root's empty action is
+    /// skipped).
+    fn path_actions(&self, node: usize) -> Vec<String> {
+        let mut out = Vec::new();
+        let mut cur = Some(node);
+        while let Some(i) = cur {
+            if !self.nodes[i].action.is_empty() {
+                out.push(self.nodes[i].action.clone());
+            }
+            cur = self.nodes[i].parent;
+        }
+        out.reverse();
+        out
+    }
+
+    /// Follow `most_visited_child` from the root to a leaf and return the
+    /// actions along that best path.
+    fn best_path(&self) -> Vec<String> {
+        let mut node = self.root();
+        while let Some(child) = self.most_visited_child(node) {
+            node = child;
+        }
+        self.path_actions(node)
+    }
+}
+
+// =============================================================================
+// Pure helpers (unit-tested)
+// =============================================================================
+
+/// UCB1 score for one child.
+///
+/// ```text
+/// ucb = mean_value + c * sqrt( ln(parent_visits + 1) / (child_visits + 1) )
+/// ```
+///
+/// An unvisited child returns `+∞` so it is always tried before any sibling is
+/// revisited — the standard "expand every action at least once" rule.
+fn ucb(mean_value: f32, child_visits: u32, parent_visits: u32, c: f32) -> f32 {
+    if child_visits == 0 {
+        return f32::INFINITY;
+    }
+    let exploration = ((parent_visits as f32 + 1.0).ln() / (child_visits as f32 + 1.0)).sqrt();
+    mean_value + c * exploration
+}
+
+/// Parse a model-produced score into a normalized value in `[0,1]`.
+///
+/// The evaluation prompt asks for a number 0–100, but models are inconsistent
+/// ("85", "Score: 85/100", "0.85"). We grab the first numeric token and
+/// normalize: anything `> 1.0` is treated as a 0–100 score and divided by 100;
+/// a bare fraction `<= 1.0` is taken as already normalized. Unparseable output
+/// falls back to a neutral `0.5` so a flaky evaluator never crashes the search.
+fn parse_score(text: &str) -> f32 {
+    match first_number(text) {
+        Some(v) => {
+            let normalized = if v > 1.0 { v / 100.0 } else { v };
+            normalized.clamp(0.0, 1.0)
+        }
+        None => 0.5,
+    }
+}
+
+/// Extract the first decimal number from arbitrary text, or `None`.
+fn first_number(text: &str) -> Option<f32> {
+    let mut buf = String::new();
+    for ch in text.chars() {
+        if ch.is_ascii_digit() || (ch == '.' && !buf.contains('.')) {
+            buf.push(ch);
+        } else if !buf.is_empty() {
+            break;
+        }
+    }
+    // Reject a lone "." that no digit followed.
+    if buf.is_empty() || buf == "." {
+        None
+    } else {
+        buf.parse::<f32>().ok()
+    }
+}
+
+// =============================================================================
+// Model-backed phases
+// =============================================================================
+//
+// Each helper runs one isolated generation in a fresh Context. Splitting the
+// phases keeps the prompts small and the control flow readable; the trade-off
+// is recomputing the shared problem prefix every call (see README).
+
+fn path_block(path: &[String]) -> String {
+    if path.is_empty() {
+        "(no steps yet)".to_string()
+    } else {
+        path.iter()
+            .enumerate()
+            .map(|(i, s)| format!("{}. {}", i + 1, s.trim()))
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+/// **Expansion** — propose one diverse next reasoning step given the path so
+/// far. We sample `branch_factor` separate short completions (rather than
+/// parsing one numbered list) so each child is a clean, independent step.
+async fn expand_step(
+    model: &Model,
+    problem: &str,
+    path: &[String],
+    rollout_tokens: usize,
+) -> Result<String> {
+    let mut ctx = Context::new(model)?;
+    ctx.system(
+        "You extend a chain of reasoning. Given a problem and the steps so far, \
+         propose ONE concise next reasoning step. Output only that step.",
+    );
+    ctx.user(&format!(
+        "Problem:\n{problem}\n\nReasoning so far:\n{}\n\nNext reasoning step:",
+        path_block(path)
+    ));
+    ctx.cue();
+    let text = ctx
+        .generate(Sampler::TopP { temperature: 0.8, p: 0.95 })
+        .max_tokens(rollout_tokens.min(64).max(16))
+        .collect_text()
+        .await?;
+    Ok(text.trim().to_string())
+}
+
+/// **Simulation / rollout** — from the current path, produce a candidate final
+/// answer in one short generation.
+async fn rollout(
+    model: &Model,
+    problem: &str,
+    path: &[String],
+    rollout_tokens: usize,
+) -> Result<String> {
+    let mut ctx = Context::new(model)?;
+    ctx.system(
+        "You finish a partial chain of reasoning. Continue from the steps given \
+         and produce a short, concrete candidate final answer.",
+    );
+    ctx.user(&format!(
+        "Problem:\n{problem}\n\nReasoning so far:\n{}\n\nCandidate final answer:",
+        path_block(path)
+    ));
+    ctx.cue();
+    let text = ctx
+        .generate(Sampler::TopP { temperature: 0.7, p: 0.95 })
+        .max_tokens(rollout_tokens)
+        .collect_text()
+        .await?;
+    Ok(text.trim().to_string())
+}
+
+/// **Evaluation** — score a candidate answer 0–100. Returns the normalized
+/// value in `[0,1]` (with the `0.5` fallback baked into [`parse_score`]).
+async fn evaluate(model: &Model, problem: &str, candidate: &str) -> Result<f32> {
+    let mut ctx = Context::new(model)?;
+    ctx.system(
+        "You are a strict grader. Score the candidate answer from 0 to 100 for \
+         correctness, completeness, and reasoning quality. Return ONLY the number.",
+    );
+    ctx.user(&format!(
+        "Problem:\n{problem}\n\nCandidate answer:\n{candidate}\n\nScore (0-100):"
+    ));
+    ctx.cue();
+    let text = ctx
+        .generate(Sampler::Argmax)
+        .max_tokens(8)
+        .collect_text()
+        .await?;
+    Ok(parse_score(&text))
+}
+
+/// **Final synthesis** — write the answer the inferlet returns, conditioned on
+/// the best reasoning path MCTS found.
+async fn synthesize(
+    model: &Model,
+    problem: &str,
+    best_path: &[String],
+    final_tokens: usize,
+) -> Result<String> {
+    let mut ctx = Context::new(model)?;
+    ctx.system(
+        "You write the final answer to a problem, guided by a vetted chain of \
+         reasoning. Be clear and correct.",
+    );
+    ctx.user(&format!(
+        "Problem:\n{problem}\n\nBest reasoning path:\n{}\n\nFinal answer:",
+        path_block(best_path)
+    ));
+    ctx.cue();
+    let text = ctx
+        .generate(Sampler::Argmax)
+        .max_tokens(final_tokens)
+        .collect_text()
+        .await?;
+    Ok(text.trim().to_string())
+}
+
+// =============================================================================
+// Entry point
+// =============================================================================
+
+#[inferlet::main]
+async fn main(input: Input) -> Result<String> {
+    let model = Model::load(runtime::models().first().ok_or("No models available")?)?;
+
+    // Clamp pathological inputs so the control flow always terminates sensibly.
+    let max_iterations = input.max_iterations.max(1);
+    let max_depth = input.max_depth.max(1);
+    let branch_factor = input.branch_factor.max(1);
+    let c = input.exploration_constant;
+
+    println!("--- mcts-rust ---");
+    println!(
+        "iterations={} max_depth={} branch_factor={} c={:.3}",
+        max_iterations, max_depth, branch_factor, c
+    );
+
+    let mut tree = Tree::new();
+    let mut best_score = 0.0f32;
+    let mut best_candidate = String::new();
+
+    for iter in 0..max_iterations {
+        // (a) Selection.
+        let selected = tree.select(tree.root(), c, branch_factor);
+
+        // (b) Expansion: grow one child unless the node is terminal or full.
+        let can_expand = !tree.nodes[selected].terminal
+            && tree.nodes[selected].depth < max_depth
+            && !tree.is_fully_expanded(selected, branch_factor);
+
+        let (sim_node, expanded_children) = if can_expand {
+            let path = tree.path_actions(selected);
+            let action = expand_step(&model, &input.prompt, &path, input.rollout_tokens).await?;
+            let child = tree.add_child(selected, action, max_depth);
+            (child, tree.nodes[selected].children.len())
+        } else {
+            // Re-simulate the selected node (e.g. a terminal leaf or, with
+            // branch_factor==1, an already-expanded path).
+            (selected, tree.nodes[selected].children.len())
+        };
+
+        // (c) Simulation / rollout from the node we will score.
+        let sim_path = tree.path_actions(sim_node);
+        let candidate = rollout(&model, &input.prompt, &sim_path, input.rollout_tokens).await?;
+
+        // (d) Evaluation.
+        let value = evaluate(&model, &input.prompt, &candidate).await?;
+
+        // (e) Backpropagation.
+        tree.backpropagate(sim_node, value);
+
+        if value >= best_score {
+            best_score = value;
+            best_candidate = candidate;
+        }
+
+        println!(
+            "iteration={} selected_node={} expanded_children={} rollout_score={:.3} best_score={:.3}",
+            iter, selected, expanded_children, value, best_score
+        );
+    }
+
+    // Read off the best path (most-visited child at each level) and synthesize.
+    let best_path = tree.best_path();
+    let final_answer = if best_path.is_empty() {
+        // No expansion happened (e.g. max_iterations far below branch_factor):
+        // fall back to the best rollout candidate we saw.
+        if best_candidate.is_empty() {
+            rollout(&model, &input.prompt, &[], input.final_tokens).await?
+        } else {
+            best_candidate.clone()
+        }
+    } else {
+        synthesize(&model, &input.prompt, &best_path, input.final_tokens).await?
+    };
+
+    if !input.show_trace {
+        return Ok(final_answer);
+    }
+
+    let mut out = String::new();
+    out.push_str("Final answer:\n");
+    out.push_str(&final_answer);
+    out.push_str("\n\nBest reasoning path:\n");
+    if best_path.is_empty() {
+        out.push_str("(search produced no expanded steps)\n");
+    } else {
+        for (i, step) in best_path.iter().enumerate() {
+            out.push_str(&format!("{}. {}\n", i + 1, step.trim()));
+        }
+    }
+    out.push_str(&format!(
+        "\nMCTS summary:\niterations={}\nnodes={}\nbest_score={:.3}\n",
+        max_iterations,
+        tree.nodes.len(),
+        best_score
+    ));
+    Ok(out)
+}

--- a/inferlets/modular-cache-js/Pie.toml
+++ b/inferlets/modular-cache-js/Pie.toml
@@ -1,0 +1,17 @@
+[package]
+name = "modular-cache-js"
+version = "0.1.0"
+description = "TypeScript module-aware prompt prefix caching using named KV snapshots"
+authors = ["Abraam Mankaruse"]
+
+[runtime]
+core = "^0.2.0"
+mcp = "^0.2.0"
+
+[parameters]
+prompt = {type = "string", optional = true, description = "User prompt"}
+max_tokens = {type = "int", optional = true, description = "Maximum number of output tokens"}
+
+use_cache = {type = "bool", optional = true, description = "Try to reuse saved module-prefix snapshots"}
+save_cache = {type = "bool", optional = true, description = "Save module-prefix snapshots as they are built"}
+

--- a/inferlets/modular-cache-js/index.ts
+++ b/inferlets/modular-cache-js/index.ts
@@ -1,0 +1,160 @@
+// Modular-cache inferlet in TypeScript.
+//
+// This mirrors the Rust/Python versions:
+// - Split prompt into reusable modules.
+// - Sort by dependency.
+// - Open longest saved prefix snapshot.
+// - Append only missing modules.
+// - Save each new prefix snapshot.
+
+import { Context, Model, Sampler, runtime } from 'inferlet';
+
+interface ModuleInput {
+    id: string;
+    role?: 'system' | 'user';
+    text: string;
+    deps?: string[];
+}
+
+interface Input {
+    prompt?: string;
+    max_tokens?: number;
+    use_cache?: boolean;
+    save_cache?: boolean;
+    modules?: ModuleInput[];
+}
+
+function defaultModules(prompt: string): ModuleInput[] {
+    return [
+        {
+            id: 'system/base',
+            role: 'system',
+            deps: [],
+            text: 'You are a concise technical assistant.',
+        },
+        {
+            id: 'style/simple',
+            role: 'user',
+            deps: ['system/base'],
+            text: 'Explain simply first, then give implementation details.',
+        },
+        {
+            id: 'context/pie',
+            role: 'user',
+            deps: ['style/simple'],
+            text: 'Pie inferlets can control forward passes, KV cache snapshots, and generation loops.',
+        },
+        {
+            id: 'task/current',
+            role: 'user',
+            deps: ['context/pie'],
+            text: prompt,
+        },
+    ];
+}
+
+function stableHash(text: string): bigint {
+    // FNV-1a 64-bit. Deterministic across runs.
+    let h = 1469598103934665603n;
+    for (const ch of new TextEncoder().encode(text)) {
+        h ^= BigInt(ch);
+        h = (h * 1099511628211n) & 0xffffffffffffffffn;
+    }
+    return h;
+}
+
+function prefixKey(modules: ModuleInput[]): string {
+    const parts: string[] = ['modular-cache-v1'];
+    for (const m of modules) {
+        parts.push(m.id);
+        parts.push(m.role ?? 'user');
+        parts.push(m.text);
+        for (const d of m.deps ?? []) parts.push(d);
+    }
+    return `modular-cache-js/${stableHash(parts.join('|')).toString(16).padStart(16, '0')}`;
+}
+
+function topoSort(modules: ModuleInput[]): ModuleInput[] {
+    const byId = new Map<string, ModuleInput>();
+    for (const m of modules) byId.set(m.id, m);
+
+    const visiting = new Set<string>();
+    const visited = new Set<string>();
+    const ordered: ModuleInput[] = [];
+
+    function visit(id: string) {
+        if (visited.has(id)) return;
+        if (visiting.has(id)) throw new Error(`cycle detected at module ${id}`);
+
+        const m = byId.get(id);
+        if (!m) throw new Error(`missing module ${id}`);
+
+        visiting.add(id);
+        for (const dep of m.deps ?? []) visit(dep);
+        visiting.delete(id);
+
+        visited.add(id);
+        ordered.push(m);
+    }
+
+    for (const id of Array.from(byId.keys()).sort()) visit(id);
+    return ordered;
+}
+
+function openLongestPrefix(model: Model, modules: ModuleInput[]): [Context | undefined, number] {
+    for (let len = modules.length; len >= 1; --len) {
+        const ctx = Context.open(model, prefixKey(modules.slice(0, len)));
+        if (ctx) return [ctx, len];
+    }
+    return [undefined, 0];
+}
+
+export async function main(input: Input): Promise<string> {
+    const model = Model.load(runtime.models()[0]);
+
+    const prompt =
+        input.prompt ?? 'Explain modular KV caching for LLM serving in simple terms.';
+    const maxTokens = input.max_tokens ?? 256;
+    const useCache = input.use_cache ?? true;
+    const saveCache = input.save_cache ?? true;
+
+    const modules = topoSort(input.modules ?? defaultModules(prompt));
+
+    let ctx: Context;
+    let resumeIndex = 0;
+
+    if (useCache) {
+        const [cached, len] = openLongestPrefix(model, modules);
+        if (cached) {
+            console.log(`cache_hit_modules=${len}`);
+            ctx = cached.fork();
+            resumeIndex = len;
+        } else {
+            console.log('cache_miss');
+            ctx = new Context(model);
+        }
+    } else {
+        ctx = new Context(model);
+    }
+
+    for (let i = resumeIndex; i < modules.length; ++i) {
+        const m = modules[i];
+
+        if ((m.role ?? 'user') === 'system') ctx.system(m.text);
+        else ctx.user(m.text);
+
+        await ctx.flush();
+
+        if (saveCache) {
+            const name = prefixKey(modules.slice(0, i + 1));
+            ctx.save(name);
+            console.log(`saved=${name}`);
+        }
+    }
+
+    ctx.cue();
+
+    return await ctx
+        .generate(Sampler.argmax(), { maxTokens })
+        .collectText();
+}

--- a/inferlets/modular-cache-js/index.ts
+++ b/inferlets/modular-cache-js/index.ts
@@ -2,16 +2,32 @@
 //
 // This mirrors the Rust/Python versions:
 // - Split prompt into reusable modules.
-// - Sort by dependency.
-// - Open longest saved prefix snapshot.
+// - Sort by dependency (rejecting dup ids, missing deps, cycles).
+// - Open the longest saved prefix snapshot.
 // - Append only missing modules.
-// - Save each new prefix snapshot.
+// - Save each new prefix snapshot so any stable prefix can be reused.
+//
+// Behavior:
+//   first run               -> cache_miss
+//   identical re-run        -> cache_hit_modules=N (full reuse)
+//   only final task changed -> reuse the stable earlier prefix
+//   use_cache=false         -> never open a saved snapshot
+//   save_cache=false        -> never save new snapshots
 
 import { Context, Model, Sampler, runtime } from 'inferlet';
 
+// Bump when the snapshot layout / key meaning changes.
+const CACHE_SCHEMA = 'modular-cache-v1';
+// Snapshot namespace — keeps JS snapshots distinct from the Rust / Python ports.
+const CACHE_NS = 'modular-cache-js';
+// Key field separator (ASCII unit separator — won't show up in prompt text).
+const SEP = '\x1f';
+
+type Role = 'system' | 'user';
+
 interface ModuleInput {
     id: string;
-    role?: 'system' | 'user';
+    role?: Role;
     text: string;
     deps?: string[];
 }
@@ -53,30 +69,43 @@ function defaultModules(prompt: string): ModuleInput[] {
     ];
 }
 
+// FNV-1a 64-bit. Deterministic across runs. Same algorithm as the Rust/Python ports.
 function stableHash(text: string): bigint {
-    // FNV-1a 64-bit. Deterministic across runs.
-    let h = 1469598103934665603n;
+    let h = 0xcbf29ce484222325n;
     for (const ch of new TextEncoder().encode(text)) {
         h ^= BigInt(ch);
-        h = (h * 1099511628211n) & 0xffffffffffffffffn;
+        h = (h * 0x100000001b3n) & 0xffffffffffffffffn;
     }
     return h;
 }
 
+// Deterministic snapshot name for a module prefix. Folds in the schema version
+// plus every module's id, role, text, and deps, so any change anywhere in the
+// prefix changes the key (invalidation).
 function prefixKey(modules: ModuleInput[]): string {
-    const parts: string[] = ['modular-cache-v1'];
+    const parts: string[] = [CACHE_SCHEMA];
     for (const m of modules) {
         parts.push(m.id);
         parts.push(m.role ?? 'user');
         parts.push(m.text);
         for (const d of m.deps ?? []) parts.push(d);
     }
-    return `modular-cache-js/${stableHash(parts.join('|')).toString(16).padStart(16, '0')}`;
+    return `${CACHE_NS}/${stableHash(parts.join(SEP)).toString(16).padStart(16, '0')}`;
 }
 
+// Dependency-order modules so deps come first. Rejects duplicate ids, missing
+// deps, and cycles with clean errors.
 function topoSort(modules: ModuleInput[]): ModuleInput[] {
     const byId = new Map<string, ModuleInput>();
-    for (const m of modules) byId.set(m.id, m);
+    for (const m of modules) {
+        if (!m.id || !m.id.trim()) throw new Error('module id must not be empty');
+        const role = m.role ?? 'user';
+        if (role !== 'system' && role !== 'user') {
+            throw new Error(`unsupported role '${role}' on module ${m.id}`);
+        }
+        if (byId.has(m.id)) throw new Error(`duplicate module id: ${m.id}`);
+        byId.set(m.id, m);
+    }
 
     const visiting = new Set<string>();
     const visited = new Set<string>();
@@ -84,7 +113,7 @@ function topoSort(modules: ModuleInput[]): ModuleInput[] {
 
     function visit(id: string) {
         if (visited.has(id)) return;
-        if (visiting.has(id)) throw new Error(`cycle detected at module ${id}`);
+        if (visiting.has(id)) throw new Error(`dependency cycle at module ${id}`);
 
         const m = byId.get(id);
         if (!m) throw new Error(`missing module ${id}`);
@@ -97,13 +126,22 @@ function topoSort(modules: ModuleInput[]): ModuleInput[] {
         ordered.push(m);
     }
 
+    // Sorted start ids => deterministic order independent of input order.
     for (const id of Array.from(byId.keys()).sort()) visit(id);
     return ordered;
 }
 
+// open() forks the snapshot (it stays immutable), so the context it returns is
+// ours to append to. It *throws* on a missing snapshot rather than returning
+// undefined, so a failed open just means a miss at that length.
 function openLongestPrefix(model: Model, modules: ModuleInput[]): [Context | undefined, number] {
     for (let len = modules.length; len >= 1; --len) {
-        const ctx = Context.open(model, prefixKey(modules.slice(0, len)));
+        let ctx: Context | undefined;
+        try {
+            ctx = Context.open(model, prefixKey(modules.slice(0, len)));
+        } catch {
+            ctx = undefined;
+        }
         if (ctx) return [ctx, len];
     }
     return [undefined, 0];
@@ -120,6 +158,11 @@ export async function main(input: Input): Promise<string> {
 
     const modules = topoSort(input.modules ?? defaultModules(prompt));
 
+    console.log('--- modular-cache-js ---');
+    console.log(`modules=${modules.length}`);
+    console.log('order=' + modules.map((m) => m.id).join(' -> '));
+    console.log(`use_cache=${useCache} save_cache=${saveCache}`);
+
     let ctx: Context;
     let resumeIndex = 0;
 
@@ -127,13 +170,14 @@ export async function main(input: Input): Promise<string> {
         const [cached, len] = openLongestPrefix(model, modules);
         if (cached) {
             console.log(`cache_hit_modules=${len}`);
-            ctx = cached.fork();
+            ctx = cached;
             resumeIndex = len;
         } else {
             console.log('cache_miss');
             ctx = new Context(model);
         }
     } else {
+        console.log('cache_miss (use_cache=false)');
         ctx = new Context(model);
     }
 
@@ -147,8 +191,14 @@ export async function main(input: Input): Promise<string> {
 
         if (saveCache) {
             const name = prefixKey(modules.slice(0, i + 1));
-            ctx.save(name);
-            console.log(`saved=${name}`);
+            // best-effort: save() throws if an earlier run already saved this
+            // exact prefix; a cache miss shouldn't abort generation.
+            try {
+                ctx.save(name);
+                console.log(`saved=${name}`);
+            } catch (e) {
+                console.log(`save_skipped=${name} (${e})`);
+            }
         }
     }
 

--- a/inferlets/modular-cache-js/package.json
+++ b/inferlets/modular-cache-js/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "modular-cache-js",
+    "version": "0.1.0",
+    "type": "module",
+    "main": "index.ts"
+}

--- a/inferlets/modular-cache-python/Pie.toml
+++ b/inferlets/modular-cache-python/Pie.toml
@@ -1,0 +1,18 @@
+[package]
+name = "modular-cache-python"
+version = "0.1.0"
+description = "Python module-aware prompt prefix caching using named KV snapshots"
+authors = ["Abraam Mankaruse"]
+
+[runtime]
+core = "^0.2.0"
+mcp = "^0.2.0"
+python-runtime = "^0.4.0"
+
+[parameters]
+prompt = {type = "string", optional = true, description = "User prompt"}
+max_tokens = {type = "int", optional = true, description = "Maximum number of output tokens"}
+
+use_cache = {type = "bool", optional = true, description = "Try to reuse saved module-prefix snapshots"}
+save_cache = {type = "bool", optional = true, description = "Save module-prefix snapshots as they are built"}
+

--- a/inferlets/modular-cache-python/main.py
+++ b/inferlets/modular-cache-python/main.py
@@ -1,13 +1,27 @@
 """Modular-cache inferlet in Python.
 
 This mirrors the Rust version:
-- Build a dependency-ordered module list.
+- Build a dependency-ordered module list (rejecting dup ids, missing deps, cycles).
 - Open the longest saved module-prefix context snapshot.
 - Append only modules that were not cached.
-- Save snapshots after every new module.
+- Save snapshots after every new module so any stable prefix can be reused.
+
+Behavior:
+  * first run with a module chain -> ``cache_miss``
+  * identical re-run              -> ``cache_hit_modules=N`` (full reuse)
+  * only the final task changed   -> reuse the stable earlier prefix
+  * use_cache=false               -> never open a saved snapshot
+  * save_cache=false              -> never save new snapshots
 """
 
 from inferlet import Context, Model, Sampler, runtime
+
+# Bump when the snapshot layout / key meaning changes.
+CACHE_SCHEMA = "modular-cache-v1"
+# Snapshot namespace — keeps Python snapshots distinct from the Rust / JS ports.
+CACHE_NS = "modular-cache-python"
+# Key field separator (ASCII unit separator — won't show up in prompt text).
+SEP = "\x1f"
 
 
 def default_modules(prompt: str):
@@ -40,32 +54,49 @@ def default_modules(prompt: str):
 
 
 def stable_hash(text: str) -> int:
-    """Small deterministic FNV-1a hash.
+    """FNV-1a 64-bit. Deterministic across runs and processes.
 
-    Python's built-in hash() is randomized between processes, so do not use it
-    for persistent cache keys.
+    Python's built-in ``hash()`` is randomized per-process (PYTHONHASHSEED),
+    so it must never be used for persistent cache keys. The Rust and JS ports
+    use the identical algorithm.
     """
-    h = 1469598103934665603
+    h = 0xCBF29CE484222325
     for b in text.encode("utf-8"):
         h ^= b
-        h = (h * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+        h = (h * 0x100000001B3) & 0xFFFFFFFFFFFFFFFF
     return h
 
 
-def prefix_key(modules):
-    """Build the persistent snapshot name for a module prefix."""
-    parts = ["modular-cache-v1"]
+def prefix_key(modules) -> str:
+    """Deterministic snapshot name for a module prefix.
+
+    Folds in the schema version plus every module's id, role, text, and deps,
+    so any change anywhere in the prefix changes the key (invalidation)."""
+    parts = [CACHE_SCHEMA]
     for m in modules:
         parts.append(m["id"])
         parts.append(m.get("role", "user"))
         parts.append(m["text"])
         parts.extend(m.get("deps", []))
-    return f"modular-cache-python/{stable_hash('|'.join(parts)):016x}"
+    return f"{CACHE_NS}/{stable_hash(SEP.join(parts)):016x}"
 
 
 def topo_sort(modules):
-    """Dependency-order modules so deps come first."""
-    by_id = {m["id"]: m for m in modules}
+    """Dependency-order modules so deps come first.
+
+    Rejects duplicate ids, missing deps, and cycles with clean errors."""
+    by_id = {}
+    for m in modules:
+        mid = m.get("id", "")
+        if not str(mid).strip():
+            raise ValueError("module id must not be empty")
+        role = m.get("role", "user")
+        if role not in ("system", "user"):
+            raise ValueError(f"unsupported role '{role}' on module {mid}")
+        if mid in by_id:
+            raise ValueError(f"duplicate module id: {mid}")
+        by_id[mid] = m
+
     visiting = set()
     visited = set()
     ordered = []
@@ -74,9 +105,9 @@ def topo_sort(modules):
         if mid in visited:
             return
         if mid in visiting:
-            raise RuntimeError(f"cycle detected at module {mid}")
+            raise ValueError(f"dependency cycle at module {mid}")
         if mid not in by_id:
-            raise RuntimeError(f"missing module {mid}")
+            raise ValueError(f"missing module {mid}")
 
         visiting.add(mid)
         for dep in by_id[mid].get("deps", []):
@@ -86,6 +117,7 @@ def topo_sort(modules):
         visited.add(mid)
         ordered.append(by_id[mid])
 
+    # Sorted start ids => deterministic order independent of input order.
     for mid in sorted(by_id.keys()):
         visit(mid)
 
@@ -93,10 +125,18 @@ def topo_sort(modules):
 
 
 def open_longest_prefix(model, modules):
-    """Return (ctx, prefix_len) for the longest saved prefix, or (None, 0)."""
+    """Longest saved prefix as (ctx, prefix_len), or (None, 0).
+
+    open() forks the snapshot (it stays immutable), so the context it returns is
+    ours to append to. It *raises* on a missing snapshot rather than returning
+    None, so a failed open just means a miss at that length.
+    """
     for length in range(len(modules), 0, -1):
         name = prefix_key(modules[:length])
-        ctx = Context.open(model, name)
+        try:
+            ctx = Context.open(model, name)
+        except Exception:
+            ctx = None
         if ctx is not None:
             return ctx, length
     return None, 0
@@ -116,18 +156,24 @@ async def main(input: dict) -> str:
     modules = input.get("modules") or default_modules(prompt)
     modules = topo_sort(modules)
 
+    print("--- modular-cache-python ---")
+    print(f"modules={len(modules)}")
+    print("order=" + " -> ".join(m["id"] for m in modules))
+    print(f"use_cache={use_cache} save_cache={save_cache}")
+
+    resume_index = 0
     if use_cache:
         cached, resume_index = open_longest_prefix(model, modules)
         if cached is not None:
             print(f"cache_hit_modules={resume_index}")
-            ctx = cached.fork()
+            ctx = cached
         else:
             print("cache_miss")
             ctx = Context(model)
             resume_index = 0
     else:
+        print("cache_miss (use_cache=false)")
         ctx = Context(model)
-        resume_index = 0
 
     for i in range(resume_index, len(modules)):
         m = modules[i]
@@ -141,8 +187,13 @@ async def main(input: dict) -> str:
 
         if save_cache:
             name = prefix_key(modules[: i + 1])
-            ctx.save(name)
-            print(f"saved={name}")
+            # best-effort: save() raises if an earlier run already saved this
+            # exact prefix; a cache miss shouldn't abort generation.
+            try:
+                ctx.save(name)
+                print(f"saved={name}")
+            except Exception as e:
+                print(f"save_skipped={name} ({e})")
 
     ctx.cue()
     return await ctx.generate(Sampler.argmax(), max_tokens=max_tokens).collect_text()

--- a/inferlets/modular-cache-python/main.py
+++ b/inferlets/modular-cache-python/main.py
@@ -1,0 +1,148 @@
+"""Modular-cache inferlet in Python.
+
+This mirrors the Rust version:
+- Build a dependency-ordered module list.
+- Open the longest saved module-prefix context snapshot.
+- Append only modules that were not cached.
+- Save snapshots after every new module.
+"""
+
+from inferlet import Context, Model, Sampler, runtime
+
+
+def default_modules(prompt: str):
+    return [
+        {
+            "id": "system/base",
+            "role": "system",
+            "deps": [],
+            "text": "You are a concise technical assistant.",
+        },
+        {
+            "id": "style/simple",
+            "role": "user",
+            "deps": ["system/base"],
+            "text": "Explain simply first, then give implementation details.",
+        },
+        {
+            "id": "context/pie",
+            "role": "user",
+            "deps": ["style/simple"],
+            "text": "Pie inferlets can control forward passes, KV cache snapshots, and generation loops.",
+        },
+        {
+            "id": "task/current",
+            "role": "user",
+            "deps": ["context/pie"],
+            "text": prompt,
+        },
+    ]
+
+
+def stable_hash(text: str) -> int:
+    """Small deterministic FNV-1a hash.
+
+    Python's built-in hash() is randomized between processes, so do not use it
+    for persistent cache keys.
+    """
+    h = 1469598103934665603
+    for b in text.encode("utf-8"):
+        h ^= b
+        h = (h * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+    return h
+
+
+def prefix_key(modules):
+    """Build the persistent snapshot name for a module prefix."""
+    parts = ["modular-cache-v1"]
+    for m in modules:
+        parts.append(m["id"])
+        parts.append(m.get("role", "user"))
+        parts.append(m["text"])
+        parts.extend(m.get("deps", []))
+    return f"modular-cache-python/{stable_hash('|'.join(parts)):016x}"
+
+
+def topo_sort(modules):
+    """Dependency-order modules so deps come first."""
+    by_id = {m["id"]: m for m in modules}
+    visiting = set()
+    visited = set()
+    ordered = []
+
+    def visit(mid):
+        if mid in visited:
+            return
+        if mid in visiting:
+            raise RuntimeError(f"cycle detected at module {mid}")
+        if mid not in by_id:
+            raise RuntimeError(f"missing module {mid}")
+
+        visiting.add(mid)
+        for dep in by_id[mid].get("deps", []):
+            visit(dep)
+        visiting.remove(mid)
+
+        visited.add(mid)
+        ordered.append(by_id[mid])
+
+    for mid in sorted(by_id.keys()):
+        visit(mid)
+
+    return ordered
+
+
+def open_longest_prefix(model, modules):
+    """Return (ctx, prefix_len) for the longest saved prefix, or (None, 0)."""
+    for length in range(len(modules), 0, -1):
+        name = prefix_key(modules[:length])
+        ctx = Context.open(model, name)
+        if ctx is not None:
+            return ctx, length
+    return None, 0
+
+
+async def main(input: dict) -> str:
+    model = Model.load(runtime.models()[0])
+
+    prompt = input.get(
+        "prompt",
+        "Explain modular KV caching for LLM serving in simple terms.",
+    )
+    max_tokens = int(input.get("max_tokens", 256))
+    use_cache = bool(input.get("use_cache", True))
+    save_cache = bool(input.get("save_cache", True))
+
+    modules = input.get("modules") or default_modules(prompt)
+    modules = topo_sort(modules)
+
+    if use_cache:
+        cached, resume_index = open_longest_prefix(model, modules)
+        if cached is not None:
+            print(f"cache_hit_modules={resume_index}")
+            ctx = cached.fork()
+        else:
+            print("cache_miss")
+            ctx = Context(model)
+            resume_index = 0
+    else:
+        ctx = Context(model)
+        resume_index = 0
+
+    for i in range(resume_index, len(modules)):
+        m = modules[i]
+
+        if m.get("role", "user") == "system":
+            ctx.system(m["text"])
+        else:
+            ctx.user(m["text"])
+
+        await ctx.flush()
+
+        if save_cache:
+            name = prefix_key(modules[: i + 1])
+            ctx.save(name)
+            print(f"saved={name}")
+
+    ctx.cue()
+    return await ctx.generate(Sampler.argmax(), max_tokens=max_tokens).collect_text()

--- a/inferlets/modular-cache-rust/Cargo.toml
+++ b/inferlets/modular-cache-rust/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "modular-cache-rust"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+inferlet = { path = "../../sdk/rust/inferlet" }
+serde = { version = "1.0", features = ["derive"] }
+
+[profile.release]
+lto = true

--- a/inferlets/modular-cache-rust/Pie.toml
+++ b/inferlets/modular-cache-rust/Pie.toml
@@ -1,0 +1,17 @@
+[package]
+name = "modular-cache-rust"
+version = "0.1.0"
+description = "Module-aware prompt prefix caching using named KV context snapshots"
+authors = ["Abraam Mankaruse"]
+
+[runtime]
+core = "^0.2.0"
+mcp = "^0.2.0"
+
+[parameters]
+prompt = {type = "string", optional = true, description = "User prompt"}
+max_tokens = {type = "int", optional = true, description = "Maximum number of output tokens"}
+
+use_cache = {type = "bool", optional = true, description = "Try to reuse saved module-prefix snapshots"}
+save_cache = {type = "bool", optional = true, description = "Save module-prefix snapshots as they are built"}
+

--- a/inferlets/modular-cache-rust/src/lib.rs
+++ b/inferlets/modular-cache-rust/src/lib.rs
@@ -8,13 +8,27 @@
 //!   system/base -> style/policy -> project/context -> task/current
 //!
 //! If only task/current changes, system/style/context KV pages can be reused.
-//! If project/context changes, task/current cache keys change too.
+//! If project/context changes, task/current cache keys change too (because the
+//! cache key for each prefix folds in every earlier module's content).
+//!
+//! Behavior:
+//!   * first run with a given module chain  -> `cache_miss`
+//!   * identical re-run                     -> `cache_hit_modules=N` (full reuse)
+//!   * only the final task changed          -> reuse the stable earlier prefix
+//!   * `use_cache=false`                    -> never open a saved snapshot
+//!   * `save_cache=false`                   -> never save new snapshots
 
 use inferlet::{Context, Result, model::Model, runtime, sample::Sampler};
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
+
+/// Bump this when the on-disk snapshot layout / key meaning changes so old
+/// snapshots can never be confused with new ones.
+const CACHE_SCHEMA: &str = "modular-cache-v1";
+
+/// Snapshot-name namespace. Keeps Rust snapshots from colliding with the
+/// Python / JS ports, which use their own namespaces.
+const CACHE_NS: &str = "modular-cache-rust";
 
 #[derive(Debug, Clone, Deserialize)]
 struct Input {
@@ -48,7 +62,7 @@ struct Module {
     deps: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 enum Role {
     System,
     User,
@@ -66,7 +80,7 @@ fn default_role() -> String { "user".to_string() }
 async fn main(input: Input) -> Result<String> {
     let model = Model::load(runtime::models().first().ok_or("No models available")?)?;
 
-    // If the caller did not provide a custom module graph, create a useful default.
+    // If the caller did not provide a custom module graph, build a useful default.
     let modules = if input.modules.is_empty() {
         default_modules(&input.prompt)
     } else {
@@ -74,53 +88,60 @@ async fn main(input: Input) -> Result<String> {
     };
 
     // Dependency-order modules so every dependency is appended before its user.
+    // This also rejects duplicate ids, missing deps, and cycles.
     let ordered = topo_sort(modules)?;
 
     println!("--- modular-cache-rust ---");
     println!("modules={}", ordered.len());
+    println!("order={}", ordered.iter().map(|m| m.id.as_str()).collect::<Vec<_>>().join(" -> "));
     println!("use_cache={} save_cache={}", input.use_cache, input.save_cache);
 
-    // Resume from the longest saved prefix if possible.
+    // Resume from the longest saved prefix. open() already forks (the snapshot
+    // stays immutable), so the context it hands back is ours to append to.
     let mut resume_index = 0usize;
     let mut ctx = if input.use_cache {
         match open_longest_prefix(&model, &ordered) {
-            Ok(Some((cached, len))) => {
+            Some((cached, len)) => {
                 println!("cache_hit_modules={}", len);
                 resume_index = len;
-                cached.fork()?
+                cached
             }
-            _ => {
+            None => {
                 println!("cache_miss");
                 Context::new(&model)?
             }
         }
     } else {
+        println!("cache_miss (use_cache=false)");
         Context::new(&model)?
     };
 
-    // Append only the missing modules.
+    // Append only the modules that were not already cached.
     for i in resume_index..ordered.len() {
         let module = &ordered[i];
 
-        // System modules become system messages; everything else becomes user context.
+        // System modules become system messages; everything else is user context.
         match module.role {
             Role::System => { ctx.system(&module.text); }
             Role::User => { ctx.user(&module.text); }
         }
 
-        // Flush materializes KV pages for this module.
+        // flush() materializes this module's KV pages.
         ctx.flush().await?;
 
-        // Save prefix snapshot after every module.
-        // That means a later run can resume from any stable prefix.
+        // Snapshot every prefix so a later run can resume from any stable one.
+        // Best-effort: save() errors if an earlier run already saved this exact
+        // prefix (names are content-addressed) — a miss shouldn't kill the run.
         if input.save_cache {
             let name = prefix_key(&ordered[..=i]);
-            ctx.save(&name)?;
-            println!("saved={}", name);
+            match ctx.save(&name) {
+                Ok(()) => println!("saved={}", name),
+                Err(e) => println!("save_skipped={} ({})", name, e),
+            }
         }
     }
 
-    // Cue tells the chat template that assistant generation starts here.
+    // Mark assistant turn start for the chat template, then generate.
     ctx.cue();
 
     let text = ctx.generate(Sampler::Argmax)
@@ -161,55 +182,83 @@ fn default_modules(prompt: &str) -> Vec<Module> {
 }
 
 fn parse_modules(inputs: Vec<ModuleInput>) -> Result<Vec<Module>> {
-    let mut out = Vec::new();
+    let mut out = Vec::with_capacity(inputs.len());
     for m in inputs {
+        if m.id.trim().is_empty() {
+            return Err("module id must not be empty".to_string());
+        }
         let role = match m.role.to_lowercase().as_str() {
             "system" => Role::System,
             "user" => Role::User,
-            other => return Err(format!("unsupported role: {}", other)),
+            other => return Err(format!("unsupported role '{}' on module {}", other, m.id)),
         };
         out.push(Module { id: m.id, role, text: m.text, deps: m.deps });
     }
     Ok(out)
 }
 
-fn role_str(role: &Role) -> &'static str {
+fn role_str(role: Role) -> &'static str {
     match role {
         Role::System => "system",
         Role::User => "user",
     }
 }
 
-fn prefix_key(modules: &[Module]) -> String {
-    let mut h = DefaultHasher::new();
-    "modular-cache-v1".hash(&mut h);
-    for m in modules {
-        m.id.hash(&mut h);
-        role_str(&m.role).hash(&mut h);
-        m.text.hash(&mut h);
-        for d in &m.deps { d.hash(&mut h); }
+/// FNV-1a 64-bit. A fixed hash keeps keys stable across runs and matches the
+/// Python/JS ports; `DefaultHasher` (SipHash) isn't stable across Rust versions.
+fn fnv1a(s: &str) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in s.as_bytes() {
+        h ^= *b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
     }
-    format!("modular-cache/{:016x}", h.finish())
+    h
 }
 
-fn open_longest_prefix(model: &Model, modules: &[Module]) -> Result<Option<(Context, usize)>> {
+/// Deterministic snapshot name for a module prefix. Folds in the schema
+/// version plus every module's id, role, text, and dependency list so any
+/// change anywhere in the prefix produces a different key (invalidation).
+fn prefix_key(modules: &[Module]) -> String {
+    let mut parts: Vec<&str> = vec![CACHE_SCHEMA];
+    for m in modules {
+        parts.push(&m.id);
+        parts.push(role_str(m.role));
+        parts.push(&m.text);
+        for d in &m.deps {
+            parts.push(d);
+        }
+    }
+    format!("{}/{:016x}", CACHE_NS, fnv1a(&parts.join("\u{1f}")))
+}
+
+/// Open the longest saved prefix snapshot, returning the forked context and
+/// the number of modules it covers. Returns `None` if nothing is cached.
+fn open_longest_prefix(model: &Model, modules: &[Module]) -> Option<(Context, usize)> {
+    // Longest first; open() is Err when that prefix isn't cached, so fall through.
     for len in (1..=modules.len()).rev() {
         let name = prefix_key(&modules[..len]);
         if let Ok(ctx) = Context::open(model, &name) {
-            return Ok(Some((ctx, len)));
+            return Some((ctx, len));
         }
     }
-    Ok(None)
+    None
 }
 
 fn topo_sort(modules: Vec<Module>) -> Result<Vec<Module>> {
-    let by_id: HashMap<String, Module> =
-        modules.into_iter().map(|m| (m.id.clone(), m)).collect();
+    // Index by id, rejecting duplicates (a silent overwrite would drop a module).
+    let mut by_id: HashMap<String, Module> = HashMap::with_capacity(modules.len());
+    for m in modules {
+        if by_id.contains_key(&m.id) {
+            return Err(format!("duplicate module id: {}", m.id));
+        }
+        by_id.insert(m.id.clone(), m);
+    }
 
     let mut visiting = HashSet::new();
     let mut visited = HashSet::new();
     let mut ordered = Vec::new();
 
+    // Sort start ids for a deterministic order independent of input order.
     let mut ids: Vec<_> = by_id.keys().cloned().collect();
     ids.sort();
 
@@ -228,7 +277,7 @@ fn visit(
     ordered: &mut Vec<Module>,
 ) -> Result<()> {
     if visited.contains(id) { return Ok(()); }
-    if visiting.contains(id) { return Err(format!("cycle at module {}", id)); }
+    if visiting.contains(id) { return Err(format!("dependency cycle at module {}", id)); }
 
     let m = by_id.get(id).ok_or_else(|| format!("missing module {}", id))?;
     visiting.insert(id.to_string());

--- a/inferlets/modular-cache-rust/src/lib.rs
+++ b/inferlets/modular-cache-rust/src/lib.rs
@@ -1,0 +1,247 @@
+//! Modular-cache inferlet.
+//!
+//! This is a standalone example of "modular caching":
+//! instead of caching one giant prompt prefix, we split the prompt into
+//! reusable semantic modules and cache every stable module-prefix.
+//!
+//! Example module chain:
+//!   system/base -> style/policy -> project/context -> task/current
+//!
+//! If only task/current changes, system/style/context KV pages can be reused.
+//! If project/context changes, task/current cache keys change too.
+
+use inferlet::{Context, Result, model::Model, runtime, sample::Sampler};
+use serde::Deserialize;
+use std::collections::{HashMap, HashSet};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+#[derive(Debug, Clone, Deserialize)]
+struct Input {
+    #[serde(default = "default_prompt")]
+    prompt: String,
+    #[serde(default = "default_max_tokens")]
+    max_tokens: usize,
+    #[serde(default = "default_use_cache")]
+    use_cache: bool,
+    #[serde(default = "default_save_cache")]
+    save_cache: bool,
+    #[serde(default)]
+    modules: Vec<ModuleInput>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct ModuleInput {
+    id: String,
+    #[serde(default = "default_role")]
+    role: String,
+    text: String,
+    #[serde(default)]
+    deps: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct Module {
+    id: String,
+    role: Role,
+    text: String,
+    deps: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+enum Role {
+    System,
+    User,
+}
+
+fn default_prompt() -> String {
+    "Explain modular KV caching for LLM serving in simple terms.".to_string()
+}
+fn default_max_tokens() -> usize { 256 }
+fn default_use_cache() -> bool { true }
+fn default_save_cache() -> bool { true }
+fn default_role() -> String { "user".to_string() }
+
+#[inferlet::main]
+async fn main(input: Input) -> Result<String> {
+    let model = Model::load(runtime::models().first().ok_or("No models available")?)?;
+
+    // If the caller did not provide a custom module graph, create a useful default.
+    let modules = if input.modules.is_empty() {
+        default_modules(&input.prompt)
+    } else {
+        parse_modules(input.modules)?
+    };
+
+    // Dependency-order modules so every dependency is appended before its user.
+    let ordered = topo_sort(modules)?;
+
+    println!("--- modular-cache-rust ---");
+    println!("modules={}", ordered.len());
+    println!("use_cache={} save_cache={}", input.use_cache, input.save_cache);
+
+    // Resume from the longest saved prefix if possible.
+    let mut resume_index = 0usize;
+    let mut ctx = if input.use_cache {
+        match open_longest_prefix(&model, &ordered) {
+            Ok(Some((cached, len))) => {
+                println!("cache_hit_modules={}", len);
+                resume_index = len;
+                cached.fork()?
+            }
+            _ => {
+                println!("cache_miss");
+                Context::new(&model)?
+            }
+        }
+    } else {
+        Context::new(&model)?
+    };
+
+    // Append only the missing modules.
+    for i in resume_index..ordered.len() {
+        let module = &ordered[i];
+
+        // System modules become system messages; everything else becomes user context.
+        match module.role {
+            Role::System => { ctx.system(&module.text); }
+            Role::User => { ctx.user(&module.text); }
+        }
+
+        // Flush materializes KV pages for this module.
+        ctx.flush().await?;
+
+        // Save prefix snapshot after every module.
+        // That means a later run can resume from any stable prefix.
+        if input.save_cache {
+            let name = prefix_key(&ordered[..=i]);
+            ctx.save(&name)?;
+            println!("saved={}", name);
+        }
+    }
+
+    // Cue tells the chat template that assistant generation starts here.
+    ctx.cue();
+
+    let text = ctx.generate(Sampler::Argmax)
+        .max_tokens(input.max_tokens)
+        .collect_text()
+        .await?;
+
+    Ok(text)
+}
+
+fn default_modules(prompt: &str) -> Vec<Module> {
+    vec![
+        Module {
+            id: "system/base".into(),
+            role: Role::System,
+            deps: vec![],
+            text: "You are a concise technical assistant.".into(),
+        },
+        Module {
+            id: "style/simple".into(),
+            role: Role::User,
+            deps: vec!["system/base".into()],
+            text: "Explain simply first, then give implementation details.".into(),
+        },
+        Module {
+            id: "context/pie".into(),
+            role: Role::User,
+            deps: vec!["style/simple".into()],
+            text: "Pie inferlets can control forward passes, KV cache snapshots, and generation loops.".into(),
+        },
+        Module {
+            id: "task/current".into(),
+            role: Role::User,
+            deps: vec!["context/pie".into()],
+            text: prompt.into(),
+        },
+    ]
+}
+
+fn parse_modules(inputs: Vec<ModuleInput>) -> Result<Vec<Module>> {
+    let mut out = Vec::new();
+    for m in inputs {
+        let role = match m.role.to_lowercase().as_str() {
+            "system" => Role::System,
+            "user" => Role::User,
+            other => return Err(format!("unsupported role: {}", other)),
+        };
+        out.push(Module { id: m.id, role, text: m.text, deps: m.deps });
+    }
+    Ok(out)
+}
+
+fn role_str(role: &Role) -> &'static str {
+    match role {
+        Role::System => "system",
+        Role::User => "user",
+    }
+}
+
+fn prefix_key(modules: &[Module]) -> String {
+    let mut h = DefaultHasher::new();
+    "modular-cache-v1".hash(&mut h);
+    for m in modules {
+        m.id.hash(&mut h);
+        role_str(&m.role).hash(&mut h);
+        m.text.hash(&mut h);
+        for d in &m.deps { d.hash(&mut h); }
+    }
+    format!("modular-cache/{:016x}", h.finish())
+}
+
+fn open_longest_prefix(model: &Model, modules: &[Module]) -> Result<Option<(Context, usize)>> {
+    for len in (1..=modules.len()).rev() {
+        let name = prefix_key(&modules[..len]);
+        if let Ok(ctx) = Context::open(model, &name) {
+            return Ok(Some((ctx, len)));
+        }
+    }
+    Ok(None)
+}
+
+fn topo_sort(modules: Vec<Module>) -> Result<Vec<Module>> {
+    let by_id: HashMap<String, Module> =
+        modules.into_iter().map(|m| (m.id.clone(), m)).collect();
+
+    let mut visiting = HashSet::new();
+    let mut visited = HashSet::new();
+    let mut ordered = Vec::new();
+
+    let mut ids: Vec<_> = by_id.keys().cloned().collect();
+    ids.sort();
+
+    for id in ids {
+        visit(&id, &by_id, &mut visiting, &mut visited, &mut ordered)?;
+    }
+
+    Ok(ordered)
+}
+
+fn visit(
+    id: &str,
+    by_id: &HashMap<String, Module>,
+    visiting: &mut HashSet<String>,
+    visited: &mut HashSet<String>,
+    ordered: &mut Vec<Module>,
+) -> Result<()> {
+    if visited.contains(id) { return Ok(()); }
+    if visiting.contains(id) { return Err(format!("cycle at module {}", id)); }
+
+    let m = by_id.get(id).ok_or_else(|| format!("missing module {}", id))?;
+    visiting.insert(id.to_string());
+
+    for dep in &m.deps {
+        if !by_id.contains_key(dep) {
+            return Err(format!("module {} depends on missing module {}", id, dep));
+        }
+        visit(dep, by_id, visiting, visited, ordered)?;
+    }
+
+    visiting.remove(id);
+    visited.insert(id.to_string());
+    ordered.push(m.clone());
+    Ok(())
+}


### PR DESCRIPTION
### Summary

This PR adds three new Pie example inferlet families: modular-cache, hierarchical-attention and MCTS reasoning.

The goal is to show a few more of the programmable-serving patterns described in the Pie paper, using small examples that are easy to build, run, and inspect. Each example is implemented across Rust, Python, and JavaScript so the same idea can be compared across SDKs.

The MCTS example demonstrates an iterative reasoning loop. It uses selection, expansion, rollout, evaluation and backpropagation to build a small reasoning tree before synthesizing a final answer.

The modular-cache example demonstrates application-controlled KV cache reuse. It breaks a prompt into dependency-ordered modules, saves snapshots after stable module prefixes and reuses the longest matching prefix when later launches share the same persistent `pie serve` engine.

The hierarchical-attention example demonstrates structured attention control. It chunks a prompt, keeps global instructions and chunk summaries visible, selects the most relevant chunk by lexical overlap and applies a BRLE attention mask during manual forward passes.


### Tests

I added host-side pure-logic tests for the parts that do not need a running Pie engine, including modular-cache ordering/keying, hierarchical-attention chunking and masks, and MCTS scoring/tree logic.

I also added E2E-style runners that launch the inferlets against the dummy driver and assert on structured control-flow output. These tests check that the examples run correctly and emit the expected traces, rather than trying to judge model quality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added hierarchical-attention inferlets for efficient prompt processing using hierarchical attention masks.
  * Added Monte Carlo Tree Search (MCTS) inferlets for reasoning-based generation tasks.
  * Added modular-cache inferlets for KV cache snapshots and reuse across inference runs.
  * All new inferlets available in JavaScript, Python, and Rust implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->