### PR TITLE
Fix GGUF portable driver build failure

### DIFF
--- a/driver/portable/src/gguf_archive.cpp
+++ b/driver/portable/src/gguf_archive.cpp
@@ -1,6 +1,7 @@
 #include "gguf_archive.hpp"
 
 #include <fstream>
+#include <iostream>
 #include <stdexcept>
 #ifndef _WIN32
 #include <fcntl.h>
@@ -341,8 +342,6 @@ const StTensor& GGUFArchive::at(const std::string& name) const {
     return *t;
 }
 
-}  // namespace pie_portable_driver
-
 // ---------------------------------------------------------------------------
 // GGUFArchive::open_sharded — multi-file / split GGUF loader
 // ---------------------------------------------------------------------------
@@ -485,3 +484,5 @@ GGUFArchive::open_sharded(const std::filesystem::path& first_shard) {
 
     return primary;
 }
+
+}  // namespace pie_portable_driver


### PR DESCRIPTION
This PR only addresses the gguf_archive.cpp build failure reported in #403 

The fix:
- adds the missing <iostream> include
- moves the namespace closing brace after open_sharded()

No functional behavior changes are intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading GGUF file archives distributed across multiple sharded files. The system automatically discovers and integrates related shards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->