### PR TITLE
fix: invalidate graph cache on page-index growth; lazy-delete stale restore-queue entries

### DIFF
--- a/driver/portable/src/forward.cpp
+++ b/driver/portable/src/forward.cpp
@@ -54,6 +54,14 @@ struct ForwardEngine::GraphCache {
     // n_request + max_n_kv).
     std::vector<std::int32_t> n_tokens_pad_per_req;
     std::vector<std::int32_t> n_kv_per_req;
+    // Pure-decode paged-attn only: total KV pages across the batch. The
+    // `page_indices` tensor is allocated to this exact size, but unlike
+    // page_indptr/last_page_lens (sized purely from n_request) it can
+    // change between batches that otherwise share the same signature
+    // (e.g. a request's KV usage crosses a page boundary without moving
+    // max_n_kv). Must invalidate the cache on change, else upload_graph_inputs
+    // writes a larger plan.page_indices_i32 into the smaller cached tensor.
+    std::int32_t total_pages_in_batch = 0;
     // State-bearing archs (Qwen 3.5) bake the per-request state_slot
     // offset into the graph view. The cache must invalidate when slots
     // change, even if everything else matches.
@@ -74,6 +82,10 @@ struct ForwardEngine::GraphCache {
         if (uniform_top_sample != plan.uniform_top_sample) return false;
         if (uniform_top_k != plan.uniform_top_k) return false;
         if (adapter != plan.active_adapter) return false;
+        if (plan.pure_decode) {
+            if (total_pages_in_batch !=
+                static_cast<std::int32_t>(plan.page_indices_i32.size())) return false;
+        }
         if (!plan.pure_decode) {
             // Slow path: per-request shapes must match exactly.
             if (n_tokens_pad_per_req.size() != plan.reqs.size()) return false;
@@ -106,6 +118,7 @@ struct ForwardEngine::GraphCache {
         if (plan.pure_decode) {
             n_tokens_pad_per_req.clear();
             n_kv_per_req.clear();
+            total_pages_in_batch = static_cast<std::int32_t>(plan.page_indices_i32.size());
         } else {
             n_tokens_pad_per_req.resize(plan.reqs.size());
             n_kv_per_req.resize(plan.reqs.size());

--- a/runtime/src/context/sched.rs
+++ b/runtime/src/context/sched.rs
@@ -749,9 +749,19 @@ impl ContextManager {
 
     /// Peek at the highest-bid context in the restore queue.
     /// Returns None if the queue is empty.
-    /// O(1) with BinaryHeap vs previous O(N) scan.
-    pub(crate) fn highest_bid_in_restore_queue(&self) -> Option<ContextId> {
-        self.restore_queue.peek().map(|e| e.ctx_id)
+    /// Applies the same lazy-deletion convention as `drain_queues`: entries
+    /// whose owning context was already removed from `self.contexts` (e.g.
+    /// its process unregistered before the entry was popped/restored) are
+    /// stale and are popped/skipped here, so the caller never indexes
+    /// `self.contexts` with a dangling `ContextId`.
+    pub(crate) fn highest_bid_in_restore_queue(&mut self) -> Option<ContextId> {
+        while let Some(entry) = self.restore_queue.peek() {
+            if self.contexts.contains_key(&entry.ctx_id) {
+                return Some(entry.ctx_id);
+            }
+            self.restore_queue.pop();
+        }
+        None
     }
 
     // =========================================================================


### PR DESCRIPTION
The portable driver's GraphCache reuses graph topology/tensor allocations across batches whose signature (n_request, total_n_tokens, max_n_kv, ...) matches. On the pure-decode paged-attention fast path, the `page_indices` tensor is sized to total_pages_in_batch at allocation time, but that quantity wasn't part of the cache signature -- so a cache hit could reuse a smaller page_indices tensor while uploading a larger plan.page_indices_i32, tripping GGML_ASSERT(offset + size <= ggml_nbytes(tensor)) ("tensor write out of bounds") and crashing the engine. Reproduced reliably under concurrent OpenClaw-replay load (n_req>=4). Now total_pages_in_batch is part of the cache signature, forcing a rebuild when it changes.

Separately, highest_bid_in_restore_queue could return a ContextId for an entry whose owning context had already been removed from self.contexts (process unregistered before the entry was popped/restored), causing when_allocated to panic with "no entry found for key" and leaving the scheduler permanently returning instantiate-failed. Apply the same lazy-deletion convention drain_queues already uses: pop and skip stale entries until a live one is found. Amortized O(log N) instead of O(1) but follows lazy-deletion-on-pop convention from drain_queues.

Resolves #408 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved cache validation for inference graphs to prevent tensor size mismatches during batch processing
* Enhanced cleanup of stale context references to improve scheduling robustness and prevent invalid context restoration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->