### PR TITLE
bring #409, #410 into v1-base-shmem

### DIFF
--- a/driver/cuda/src/ops/attention_flashinfer.cu
+++ b/driver/cuda/src/ops/attention_flashinfer.cu
@@ -1,5 +1,6 @@
 #include "ops/attention_flashinfer.hpp"
 
+#include <algorithm>
 #include <type_traits>
 
 #include <cmath>
@@ -92,6 +93,27 @@ struct DecodeWorkEstimator {
         if constexpr (!head_dim_supports_cascade_merge(HEAD_DIM)) {
             split_kv = false;
             new_batch_size = batch_size;
+
+            // With split_kv forced false, DecodePlan sets padded_batch_size =
+            // batch_size, but DecodeSplitKVIndptr still tiles each request's
+            // KV pages into ceil_div(pages_i, max_num_pages_per_batch) work
+            // items using the chunk size the (split-kv) estimator chose
+            // above. If any request has more pages than that chunk size,
+            // DecodeSplitKVIndptr emits more than `batch_size` (request,
+            // tile) entries, overflowing the request_indices/kv_tile_indices/
+            // o_indptr buffers (sized for padded_batch_size = batch_size) and
+            // mapping multiple grid blocks onto the same request — clobbering
+            // other requests' output rows. Bump the chunk size to the largest
+            // per-request page count so every request maps to exactly one
+            // tile, keeping request_indices_vec.size() == batch_size ==
+            // padded_batch_size. (kv_chunk_size_ptr is otherwise unused when
+            // partition_kv == false.)
+            uint32_t max_pages_per_req = 1;
+            for (uint32_t i = 0; i < batch_size; ++i) {
+                uint32_t pages_i = static_cast<uint32_t>(kv_indptr_h[i + 1] - kv_indptr_h[i]);
+                max_pages_per_req = std::max(max_pages_per_req, pages_i);
+            }
+            max_num_pages_per_batch = std::max(max_num_pages_per_batch, max_pages_per_req);
         }
         return rc;
     }
@@ -210,7 +232,7 @@ void plan_attention_flashinfer_decode_bf16(
             throw std::runtime_error(
                 "flashinfer decode: unsupported head_dim " +
                 std::to_string(head_dim) +
-                " (instantiated: 64, 128, 256, 512)");
+                " (instantiated: 64, 96, 128, 256, 512)");
     }
     CUDA_CHECK(status);
 
@@ -348,6 +370,10 @@ void dispatch_attention_flashinfer_decode_bf16(
     switch (cache.head_dim) {
         case 64:
             status = dispatch_decode_for_head_dim<64>(cache, q, k_pages, v_pages, o,
+                kv_page_indices_d, kv_page_indptr_d, kv_last_page_lens_d, workspace, stream, window_left, logits_soft_cap, sm_scale, lse_out);
+            break;
+        case 96:
+            status = dispatch_decode_for_head_dim<96>(cache, q, k_pages, v_pages, o,
                 kv_page_indices_d, kv_page_indptr_d, kv_last_page_lens_d, workspace, stream, window_left, logits_soft_cap, sm_scale, lse_out);
             break;
         case 128:

--- a/driver/portable/src/forward.cpp
+++ b/driver/portable/src/forward.cpp
@@ -54,6 +54,14 @@ struct ForwardEngine::GraphCache {
     // n_request + max_n_kv).
     std::vector<std::int32_t> n_tokens_pad_per_req;
     std::vector<std::int32_t> n_kv_per_req;
+    // Pure-decode paged-attn only: total KV pages across the batch. The
+    // `page_indices` tensor is allocated to this exact size, but unlike
+    // page_indptr/last_page_lens (sized purely from n_request) it can
+    // change between batches that otherwise share the same signature
+    // (e.g. a request's KV usage crosses a page boundary without moving
+    // max_n_kv). Must invalidate the cache on change, else upload_graph_inputs
+    // writes a larger plan.page_indices_i32 into the smaller cached tensor.
+    std::int32_t total_pages_in_batch = 0;
     // State-bearing archs (Qwen 3.5) bake the per-request state_slot
     // offset into the graph view. The cache must invalidate when slots
     // change, even if everything else matches.
@@ -74,6 +82,10 @@ struct ForwardEngine::GraphCache {
         if (uniform_top_sample != plan.uniform_top_sample) return false;
         if (uniform_top_k != plan.uniform_top_k) return false;
         if (adapter != plan.active_adapter) return false;
+        if (plan.pure_decode) {
+            if (total_pages_in_batch !=
+                static_cast<std::int32_t>(plan.page_indices_i32.size())) return false;
+        }
         if (!plan.pure_decode) {
             // Slow path: per-request shapes must match exactly.
             if (n_tokens_pad_per_req.size() != plan.reqs.size()) return false;
@@ -106,6 +118,7 @@ struct ForwardEngine::GraphCache {
         if (plan.pure_decode) {
             n_tokens_pad_per_req.clear();
             n_kv_per_req.clear();
+            total_pages_in_batch = static_cast<std::int32_t>(plan.page_indices_i32.size());
         } else {
             n_tokens_pad_per_req.resize(plan.reqs.size());
             n_kv_per_req.resize(plan.reqs.size());

--- a/driver/portable/src/paged_attn_cuda.cu
+++ b/driver/portable/src/paged_attn_cuda.cu
@@ -17,6 +17,7 @@
 // total_pages*page_size]` matches FlashInfer's `kNHD` byte-for-byte
 // (offset formula coincides), so K/V can be wrapped without copies.
 
+#include <algorithm>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -200,6 +201,27 @@ struct DecodeWorkEstimator {
             batch_size, kv_indptr_h, num_qo_heads, page_size, enable_cuda_graph, stream);
         split_kv       = false;
         new_batch_size = batch_size;
+
+        // With split_kv forced false, DecodePlan sets padded_batch_size =
+        // batch_size, but DecodeSplitKVIndptr still tiles each request's KV
+        // pages into ceil_div(pages_i, max_num_pages_per_batch) work items
+        // using the chunk size the (split-kv) estimator chose above. If any
+        // request has more pages than that chunk size, DecodeSplitKVIndptr
+        // emits more than `batch_size` (request,tile) entries, overflowing
+        // the request_indices/kv_tile_indices/o_indptr buffers (sized for
+        // padded_batch_size = batch_size) and producing a corrupted,
+        // truncated request_indices that maps multiple grid blocks onto the
+        // same request — clobbering other requests' output rows.
+        //
+        // Bump the chunk size to the largest per-request page count so every
+        // request maps to exactly one tile, keeping
+        // request_indices_vec.size() == batch_size == padded_batch_size.
+        uint32_t max_pages_per_req = 1;
+        for (uint32_t i = 0; i < batch_size; ++i) {
+            uint32_t pages_i = static_cast<uint32_t>(kv_indptr_h[i + 1] - kv_indptr_h[i]);
+            max_pages_per_req = std::max(max_pages_per_req, pages_i);
+        }
+        max_num_pages_per_batch = std::max(max_num_pages_per_batch, max_pages_per_req);
         return rc;
     }
 };

--- a/runtime/src/context/sched.rs
+++ b/runtime/src/context/sched.rs
@@ -750,9 +750,19 @@ impl ContextManager {
 
     /// Peek at the highest-bid context in the restore queue.
     /// Returns None if the queue is empty.
-    /// O(1) with BinaryHeap vs previous O(N) scan.
-    pub(crate) fn highest_bid_in_restore_queue(&self) -> Option<ContextId> {
-        self.restore_queue.peek().map(|e| e.ctx_id)
+    /// Applies the same lazy-deletion convention as `drain_queues`: entries
+    /// whose owning context was already removed from `self.contexts` (e.g.
+    /// its process unregistered before the entry was popped/restored) are
+    /// stale and are popped/skipped here, so the caller never indexes
+    /// `self.contexts` with a dangling `ContextId`.
+    pub(crate) fn highest_bid_in_restore_queue(&mut self) -> Option<ContextId> {
+        while let Some(entry) = self.restore_queue.peek() {
+            if self.contexts.contains_key(&entry.ctx_id) {
+                return Some(entry.ctx_id);
+            }
+            self.restore_queue.pop();
+        }
+        None
     }
 
     // =========================================================================


### PR DESCRIPTION
Fixes the engine concurrency issues found in chat-apc. Brings the fixes that were already applied in main.