### PR TITLE
fix(inferlets): correct naming/metadata inconsistencies across the collection

### DIFF
--- a/inferlets/agent-codeact/Pie.toml
+++ b/inferlets/agent-codeact/Pie.toml
@@ -9,5 +9,6 @@ core = "^0.2.0"
 mcp = "^0.2.0"
 
 [parameters]
-num_function_calls = {type = "int", optional = true, description = "Number of sequential code execution cycles (default: 5)"}
-tokens_between_calls = {type = "int", optional = true, description = "Max tokens for each generation step (default: 512)"}
+max_steps = {type = "int", optional = true, description = "Number of sequential code execution cycles (default: 5)"}
+max_tokens = {type = "int", optional = true, description = "Max tokens for each generation step (default: 384)"}
+task = {type = "string", optional = true, description = "The task to solve (default: 'Compute 25 squared, then add 17 to it.')"}

--- a/inferlets/agent-react/Pie.toml
+++ b/inferlets/agent-react/Pie.toml
@@ -9,5 +9,6 @@ core = "^0.2.0"
 mcp = "^0.2.0"
 
 [parameters]
-num_function_calls = {type = "int", optional = true, description = "Number of sequential Thought/Action/Observation cycles (default: 5)"}
-tokens_between_calls = {type = "int", optional = true, description = "Max tokens for each Thought/Action step (default: 512)"}
+max_steps = {type = "int", optional = true, description = "Number of sequential Thought/Action/Observation cycles (default: 5)"}
+max_tokens = {type = "int", optional = true, description = "Max tokens for each Thought/Action step (default: 256)"}
+question = {type = "string", optional = true, description = "The question to answer (default: 'What is 17 multiplied by 24, plus 13?')"}

--- a/inferlets/attention-sink/Pie.toml
+++ b/inferlets/attention-sink/Pie.toml
@@ -9,7 +9,7 @@ core = "^0.2.0"
 mcp = "^0.2.0"
 
 [parameters]
-prompt = {type = "string", optional = true, description = "The prompt to send to the model (default: 'Explain LLM decoding process in ELI5.')"}
+prompt = {type = "string", optional = true, description = "The prompt to send to the model (default: 'Tell me a long story about a cat.')"}
 max_tokens = {type = "int", optional = true, description = "Maximum number of new tokens to generate (default: 512)"}
-sink_size = {type = "int", optional = true, description = "Initial size of the attention sink (default: 64)"}
-window_size = {type = "int", optional = true, description = "Sliding window size for the attention sink (default: 32)"}
+sink_size = {type = "int", optional = true, description = "Initial size of the attention sink (default: 4)"}
+window_size = {type = "int", optional = true, description = "Sliding window size for the attention sink (default: 64)"}

--- a/inferlets/constrained-decoding/Pie.toml
+++ b/inferlets/constrained-decoding/Pie.toml
@@ -1,7 +1,7 @@
 [package]
 name = "constrained-decoding"
 version = "0.1.0"
-description = "Grammar-constrained decoding using Lark grammar for structured outputs"
+description = "Grammar-constrained decoding using an EBNF grammar for structured outputs"
 authors = ["Pie Team"]
 
 [runtime]

--- a/inferlets/demo-custom-spec/src/lib.rs
+++ b/inferlets/demo-custom-spec/src/lib.rs
@@ -244,7 +244,7 @@ async fn run_speculated(model: &Model, model_name: &str, input: &Input) -> Resul
     // numerical differences between "prefill alone" and "prefill +
     // multi-position samplers" kernel shapes, and on cuda 0.1.0 the
     // fused shape produces logits that drift off the greedy trajectory.
-    // The split-pass pattern matches inferlets/cacheback-decoding.
+    // The split-pass pattern matches inferlets/draft-model-decoding.
     ctx.flush().await?;
 
     let tokenizer = model.tokenizer();

--- a/inferlets/draft-model-decoding/Cargo.toml
+++ b/inferlets/draft-model-decoding/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cacheback-decoding"
+name = "draft-model-decoding"
 version = "0.1.0"
 edition = "2024"
 

--- a/inferlets/draft-model-decoding/Pie.toml
+++ b/inferlets/draft-model-decoding/Pie.toml
@@ -1,7 +1,7 @@
 [package]
-name = "cacheback-decoding"
+name = "draft-model-decoding"
 version = "0.1.0"
-description = "Speculative decoding with cache-based drafter using n-gram matching"
+description = "Draft-model speculative decoding: a separate greedy draft model proposes tokens, the target model verifies them in one forward pass"
 authors = ["Pie Team"]
 
 [runtime]
@@ -9,6 +9,6 @@ core = "^0.2.0"
 mcp = "^0.2.0"
 
 [parameters]
-prompt = {type = "string", optional = true, description = "The prompt to send to the model (default: 'Keep printing hello, world! 100 times.')"}
+prompt = {type = "string", optional = true, description = "The prompt to send to the model (default: 'Explain quantum computing.')"}
 max_tokens = {type = "int", optional = true, description = "Maximum number of new tokens to generate (default: 256)"}
 draft_length = {type = "int", optional = true, description = "Number of draft tokens to propose per step (default: 4)"}

--- a/inferlets/draft-model-decoding/src/lib.rs
+++ b/inferlets/draft-model-decoding/src/lib.rs
@@ -1,5 +1,5 @@
-//! Demonstrates CacheBack speculative decoding — a manual loop with a
-//! cached draft model.
+//! Demonstrates draft-model speculative decoding — a manual loop with a
+//! separate greedy draft model.
 //!
 //! A separate "drafter" context generates candidate tokens; the main
 //! context verifies them in a single forward pass. Accepted tokens commit;
@@ -181,7 +181,7 @@ async fn main(input: Input) -> Result<String> {
 
     let text = tokenizer.decode(&all_generated)?;
     println!(
-        "--- CacheBack Decoding (draft_length={}, steps={}) ---",
+        "--- Draft-Model Decoding (draft_length={}, steps={}) ---",
         draft_length, total_steps
     );
     println!("Generated in {:?}", start.elapsed());

--- a/inferlets/http-server/src/lib.rs
+++ b/inferlets/http-server/src/lib.rs
@@ -11,6 +11,7 @@
 //! - `/echo` - Echoes back the request body
 //! - `/echo-headers` - Echoes back the request headers
 //! - `/info` - Returns server and request information as JSON
+//! - `/sse` - Streams a few Server-Sent Events (text/event-stream)
 //!
 //! ## Running
 //!
@@ -59,7 +60,8 @@ async fn home(_req: Request<IncomingBody>, res: Responder) -> Finished {
                   /wait   - Async sleep demo (sleeps for 1 second)\n\
                   /echo   - Echo back the request body\n\
                   /echo-headers - Echo back request headers\n\
-                  /info   - Server and request information\n"
+                  /info   - Server and request information\n\
+                  /sse    - Stream Server-Sent Events\n"
         .into_body();
 
     res.respond(Response::new(body)).await

--- a/inferlets/jacobi-decoding/Pie.toml
+++ b/inferlets/jacobi-decoding/Pie.toml
@@ -9,6 +9,6 @@ core = "^0.2.0"
 mcp = "^0.2.0"
 
 [parameters]
-max_tokens = {type = "int", optional = true, description = "Maximum number of tokens to generate (default: 512)"}
+max_tokens = {type = "int", optional = true, description = "Maximum number of tokens to generate (default: 256)"}
 window_size = {type = "int", optional = true, description = "Number of tokens to speculate in parallel (default: 5)"}
-prompt = {type = "string", optional = true, description = "Prompt to generate (default: 'Explain the LLM decoding process ELI5.')"}
+prompt = {type = "string", optional = true, description = "Prompt to generate (default: 'Write a poem about the ocean.')"}

--- a/inferlets/prefix-tree/Pie.toml
+++ b/inferlets/prefix-tree/Pie.toml
@@ -1,7 +1,7 @@
 [package]
 name = "prefix-tree"
 version = "0.1.0"
-description = "Prefix tree caching with concurrent generation from shared context"
+description = "Prefix tree caching with sequential generation from a shared context"
 authors = ["Pie Team"]
 
 [runtime]

--- a/inferlets/recursion-of-thought/Pie.toml
+++ b/inferlets/recursion-of-thought/Pie.toml
@@ -9,7 +9,7 @@ core = "^0.2.0"
 mcp = "^0.2.0"
 
 [parameters]
-question = {type = "string", optional = true, description = "The initial question to solve (default: 'Please calculate the expression (42 + 3) * 5 / 15.')"}
-max_depth = {type = "int", optional = true, description = "Maximum recursion depth (default: 5)"}
-max_tokens = {type = "int", optional = true, description = "Max tokens to generate at each step (default: 128)"}
+question = {type = "string", optional = true, description = "The initial question to solve (default: 'Compute the sum 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8.')"}
+max_depth = {type = "int", optional = true, description = "Maximum recursion depth (default: 2)"}
+max_tokens = {type = "int", optional = true, description = "Max tokens to generate at each step (default: 256)"}
 verbose = {type = "bool", optional = true, description = "Print intermediate messages during recursion"}

--- a/inferlets/tool-test/Pie.toml
+++ b/inferlets/tool-test/Pie.toml
@@ -9,4 +9,4 @@ core = "^0.2.0"
 mcp = "^0.2.0"
 
 [parameters]
-prompt = {type = "string", description = "User prompt"}
+prompt = {type = "string", optional = true, description = "Unused — the smoke test drives a fixed tool-call prompt"}

--- a/inferlets/tree-of-thought/Pie.toml
+++ b/inferlets/tree-of-thought/Pie.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-of-thought"
 version = "0.1.0"
-description = "Tree-of-Thought for multi-branch reasoning (Propose, Execute, Reflect)"
+description = "Tree-of-Thought as level-wise beam search: generate candidates per frontier item, score them, keep the global top-k, expand only survivors"
 authors = ["Pie Team"]
 
 [runtime]
@@ -10,5 +10,8 @@ mcp = "^0.2.0"
 
 [parameters]
 question = {type = "string", optional = true, description = "The question to solve (default: 'Calculate (42 + 3) * 5 / 15.')"}
-num_branches = {type = "int", optional = true, description = "Number of branches at each level of the tree (default: 2)"}
-max_tokens = {type = "int", optional = true, description = "Max new tokens to generate at each step (default: 512)"}
+breadth = {type = "int", optional = true, description = "Candidates generated per frontier item at each level (default: 3)"}
+beam_width = {type = "int", optional = true, description = "Global top-k survivors kept and expanded at each level (default: 2)"}
+levels = {type = "int", optional = true, description = "Number of search levels (default: 2)"}
+max_tokens = {type = "int", optional = true, description = "Max new tokens to generate at each step (default: 384)"}
+show_search = {type = "bool", optional = true, description = "Emit per-level search debug output (default: false)"}

--- a/inferlets/watermarking/src/lib.rs
+++ b/inferlets/watermarking/src/lib.rs
@@ -150,8 +150,11 @@ async fn main(input: Input) -> Result<String> {
         pass.input(&pending);
         let last_idx = (pending.len() - 1) as u32;
         // `k = 0` returns the full vocabulary so the watermark can bias
-        // every token, not just the top-k.
-        let h = pass.probe(last_idx, Distribution { temperature: 0.0, k: 0 });
+        // every token, not just the top-k. `temperature = 1.0` keeps the
+        // model's natural softmax — `0.0` would collapse the host
+        // distribution to a one-hot argmax, leaving the green-list bias
+        // nothing to reweight (the watermark would be a no-op).
+        let h = pass.probe(last_idx, Distribution { temperature: 1.0, k: 0 });
         let out = pass.execute().await?;
 
         let (ids, probs) = match out.distribution(h) {

--- a/inferlets/windowed-attention/Pie.toml
+++ b/inferlets/windowed-attention/Pie.toml
@@ -9,6 +9,6 @@ core = "^0.2.0"
 mcp = "^0.2.0"
 
 [parameters]
-prompt = {type = "string", optional = true, description = "The prompt to send to the model (default: 'Explain LLM decoding process in ELI5.')"}
+prompt = {type = "string", optional = true, description = "The prompt to send to the model (default: 'Tell me a long story about a cat.')"}
 max_tokens = {type = "int", optional = true, description = "Maximum number of new tokens to generate (default: 512)"}
-window_size = {type = "int", optional = true, description = "Sliding window size for KV cache (default: 32)"}
+window_size = {type = "int", optional = true, description = "Sliding window size for KV cache (default: 64)"}

--- a/tests/inferlets/run_all.py
+++ b/tests/inferlets/run_all.py
@@ -24,7 +24,7 @@ from test_constrained_decoding import test_constrained_decoding
 from test_watermarking import test_watermarking
 from test_windowed_attention import test_windowed_attention
 from test_attention_sink import test_attention_sink
-from test_cacheback_decoding import test_cacheback_decoding
+from test_draft_model_decoding import test_draft_model_decoding
 from test_jacobi_decoding import test_jacobi_decoding
 from test_best_of_n import test_best_of_n
 from test_json_schema_validation import test_json_schema_validation
@@ -65,7 +65,7 @@ ALL_TESTS = [
     test_watermarking,
     test_windowed_attention,
     test_attention_sink,
-    test_cacheback_decoding,
+    test_draft_model_decoding,
     # Tier 4: JS/Python SDK
     test_js_example,
     test_js_concurrency,

--- a/tests/inferlets/test_draft_model_decoding.py
+++ b/tests/inferlets/test_draft_model_decoding.py
@@ -1,12 +1,12 @@
-"""E2E test for cacheback-decoding inferlet."""
+"""E2E test for draft-model-decoding inferlet."""
 import re
 
 from conftest import run_inferlet, run_tests
 
 
-async def test_cacheback_decoding(client, args):
+async def test_draft_model_decoding(client, args):
     output = await run_inferlet(
-        client, "cacheback-decoding",
+        client, "draft-model-decoding",
         {"max_tokens": 64},
         timeout=args.timeout,
     )
@@ -18,4 +18,4 @@ async def test_cacheback_decoding(client, args):
 
 
 if __name__ == "__main__":
-    run_tests([test_cacheback_decoding])
+    run_tests([test_draft_model_decoding])

--- a/website/docs/guide/examples/speculation.mdx
+++ b/website/docs/guide/examples/speculation.mdx
@@ -15,7 +15,7 @@ The dummy driver samples a fresh random token for every slot, so every draft is 
 | Inferlet | What it shows |
 |---|---|
 | [`jacobi-decoding`](https://github.com/pie-project/pie/tree/main/inferlets/jacobi-decoding) | Parallel Jacobi decoding (custom drafter). |
-| [`cacheback-decoding`](https://github.com/pie-project/pie/tree/main/inferlets/cacheback-decoding) | Cache-based drafter via n-gram matching. |
+| [`draft-model-decoding`](https://github.com/pie-project/pie/tree/main/inferlets/draft-model-decoding) | Separate greedy draft model proposes; the target model verifies. |
 
 ## Related guide
 

--- a/website/docs/guide/forward/speculation.mdx
+++ b/website/docs/guide/forward/speculation.mdx
@@ -136,7 +136,7 @@ let text = ctx
     .await?;
 ```
 
-The [`cacheback-decoding`](https://github.com/pie-project/pie/tree/main/inferlets/cacheback-decoding) and [`jacobi-decoding`](https://github.com/pie-project/pie/tree/main/inferlets/jacobi-decoding) inferlets show two more drafting strategies in full.
+The [`draft-model-decoding`](https://github.com/pie-project/pie/tree/main/inferlets/draft-model-decoding) and [`jacobi-decoding`](https://github.com/pie-project/pie/tree/main/inferlets/jacobi-decoding) inferlets show two more drafting strategies in full.
 
 ## How verification works
 

--- a/website/docs/overview/key-features.mdx
+++ b/website/docs/overview/key-features.mdx
@@ -23,7 +23,7 @@ let out = fwd.execute().await?;
 A primitive at this level is enough to express decoding strategies that other serving systems either hardcode or do not support at all. Each of the following is a library on top of `forward()`, not an engine feature:
 
 - **Constrained decoding.** Mask logits against a grammar or JSON schema before sampling. See [Structured generation](../guide/forward/constrained).
-- **Speculative decoding.** Run a drafter, verify with the target model, accept or reject. Pie ships an n-gram speculator and a Jacobi decoder, and you can write your own. See the `text-completion-spec`, `cacheback-decoding`, and `jacobi-decoding` inferlets.
+- **Speculative decoding.** Run a drafter, verify with the target model, accept or reject. Pie ships an n-gram speculator, a draft-model speculator, and a Jacobi decoder, and you can write your own. See the `text-completion-spec`, `draft-model-decoding`, and `jacobi-decoding` inferlets.
 - **Custom samplers and raw logits.** Score candidate strings, compute entropy, or pull the full distribution back into your inferlet. See the `sampler-suite` and `output-validation` inferlets.
 - **Custom attention masks.** Sliding window, attention sink, hierarchical masks, anything that can be expressed as a per-token mask. See [Customize generation](../guide/forward/overview).
 - **LoRA adapters.** Attach an adapter for a single forward pass or for every step of a generation loop.


### PR DESCRIPTION
Audit of the pie inferlet collection (part of pie-mac ticket #639) surfaced several name-vs-implementation mismatches and drifted manifest metadata. This fixes the upstream-pie side; pie-mac bumps the submodule pin separately.

## Fixes
- **Rename `cacheback-decoding` → `draft-model-decoding`.** The crate runs a separate greedy draft model (`GreedyDrafter`, own `Context`) verified in one forward pass — classic *draft-model* speculative decoding, **not** CacheBack. Real CacheBack is the n-gram leader→follower drafter shipped in the app. Renaming frees the "cacheback" name to label only the n-gram technique. Updates header, `Pie.toml`, e2e test, `run_all` registry, website docs (3), and the `demo-custom-spec` cross-reference.
- **watermarking: probe with `temperature: 1.0` not `0.0`.** A `0.0` temperature collapses the host distribution to a one-hot argmax, leaving the green-list bias nothing to reweight — the watermark was a **no-op**. The sibling `demo-watermark` already uses `1.0` with the same rationale.
- **tree-of-thought `Pie.toml`:** describe the actual level-wise beam search (`breadth`/`beam_width`/`levels`/`show_search`) instead of "(Propose, Execute, Reflect)" with stale `num_branches`.
- **constrained-decoding `Pie.toml`:** grammar is EBNF, not Lark.
- **Sync drifted `Pie.toml` `[parameters]`** (names/defaults/prompt text) to the actual `Input` structs: agent-codeact, agent-react, recursion-of-thought, attention-sink, jacobi-decoding, windowed-attention.
- **prefix-tree `Pie.toml`:** generation is sequential, not concurrent.
- **tool-test `Pie.toml`:** mark the unused `prompt` parameter optional.
- **http-server:** document the `/sse` route in the header + home page.

## Verification
`draft-model-decoding` and `watermarking` both build clean for `wasm32-wasip2`. Changes are metadata/doc/string plus the single watermarking temperature literal — no logic changes.

## Follow-ups (separate tickets)
- Consolidate `draft-model-decoding` + `demo-custom-spec` (n-gram) into one spec-decode inferlet with a selectable drafter.
- `raw-completion` and `tool-test` have no e2e test.
- `marketing-tab3-lora-spec` fetches an `example.com` placeholder LoRA URL.