### PR TITLE
Never serve a masked decode from a staged speculation fire

### DIFF
--- a/driver/dummy/src/lib.rs
+++ b/driver/dummy/src/lib.rs
@@ -182,9 +182,17 @@ fn run_impl(
                     ArchivedRequestPayload::Health => {
                         let _ = lease.commit_status(0);
                     }
-                    _ => {
-                        eprintln!("[pie-driver-dummy] unsupported payload variant");
-                        let _ = lease.commit_status(-1);
+                    // The dummy has no real KV/recurrent state and no adapter
+                    // weights, so a page Copy or adapter Load has nothing to
+                    // move — and since token generation is random (independent
+                    // of cache contents), acking these as vacuous no-ops is the
+                    // faithful no-compute behavior. The runtime forks contexts
+                    // via Copy for prefix sharing / grammar-constrained
+                    // sub-generation; erroring here would break those paths and
+                    // silently drop the logit-mask constraint.
+                    ArchivedRequestPayload::Copy(_)
+                    | ArchivedRequestPayload::Adapter(_) => {
+                        let _ = lease.commit_status(0);
                     }
                 }
             }

--- a/runtime/src/inference/speculator.rs
+++ b/runtime/src/inference/speculator.rs
@@ -93,6 +93,25 @@ pub(crate) fn entry_matches_request(
     if request.token_ids.len() != 1 {
         return false;
     }
+    // The chain extender stages every fire with an EMPTY constraint
+    // surface: `build_next_request` emits `logit_masks = []` (the next
+    // position's grammar mask isn't known until the inferlet's matcher
+    // advances on the just-sampled token) and `masks = []` /
+    // `has_user_mask = false` (it can't know the inferlet's next custom
+    // attention mask either). A request that carries EITHER a logit mask
+    // (grammar / JSON-schema / forced-tool constrained decode) OR a custom
+    // attention mask (windowed / sink / hierarchical attention) must
+    // therefore NEVER be served from a staged fire — the unconstrained,
+    // fully-causal staged token would silently ignore the constraint. This
+    // mirrors the producer-side skip set in `evaluate_request_shape`
+    // (which refuses to stage from either kind of masked request); the two
+    // sites must stay symmetric or the constraint is dropped at exactly the
+    // unconstrained→constrained transition. Force such a request onto the
+    // cold path (the `try_hit` miss branch clears the stale chain) so the
+    // mask is actually applied.
+    if !request.logit_masks.is_empty() || request.has_user_mask {
+        return false;
+    }
     let base = Some(entry.anchor_token) == request.token_ids.first().copied()
         && Some(entry.anchor_pos) == request.position_ids.first().copied()
         && entry.spec_token_ids == request.spec_token_ids
@@ -842,6 +861,78 @@ mod tests {
         assert_eq!(next.output_spec_flags, vec![true]);
         assert_eq!(next.rs_slot_ids, vec![7]);
         assert_eq!(next.rs_slot_flags, vec![0]);
+    }
+
+    fn staged_entry(anchor_token: u32, anchor_pos: u32) -> StagedEntry {
+        let (_tx, rx) = oneshot::channel();
+        StagedEntry {
+            anchor_token,
+            anchor_pos,
+            spec_token_ids: Vec::new(),
+            spec_position_ids: Vec::new(),
+            output_spec_flags: vec![false],
+            uses_rs_cache: false,
+            allow_extend: Arc::new(AtomicBool::new(true)),
+            output_rx: rx,
+        }
+    }
+
+    /// A staged fire is always pre-fired WITHOUT a logit mask, so a
+    /// constrained decode request (grammar / JSON-schema / forced-tool)
+    /// must miss the staged entry and fall through to the cold path where
+    /// the mask is applied. Without this guard the unconstrained staged
+    /// token is served verbatim and the constraint is silently dropped —
+    /// the bug that turned dummy-driver JSON output into garbage while a
+    /// real model masked it by naturally emitting valid JSON.
+    #[test]
+    fn entry_match_rejects_logit_masked_request() {
+        // Same single-token anchor the extender would have staged.
+        let mut req = req_with(vec![11], vec![0], vec![argmax()]);
+        req.token_ids = vec![42];
+        let entry = staged_entry(42, 11);
+
+        // Unconstrained decode at this anchor: a hit is correct.
+        assert!(entry_matches_request(&entry, &req));
+
+        // Attach a non-empty logit mask (BRLE: forbid id 0, allow the
+        // rest). Now the same anchor must NOT match — the staged fire
+        // never saw this constraint.
+        req.logit_masks = vec![pie_bridge::Brle::from_vec(vec![1, u32::MAX])];
+        req.logit_mask_indptr = vec![0, 1];
+        assert!(
+            !entry_matches_request(&entry, &req),
+            "constrained request must not be served from an unconstrained staged fire"
+        );
+    }
+
+    /// The twin of the logit-mask guard for custom *attention* masks. A
+    /// staged fire is always pre-fired fully-causal (`has_user_mask =
+    /// false`), so a single-token decode that supplies a custom attention
+    /// mask (windowed / sink / hierarchical attention) must miss the staged
+    /// entry and fall through to the cold path. Without the
+    /// `has_user_mask` clause the unconstrained, fully-causal staged token
+    /// is served verbatim and the window mask is silently dropped — the
+    /// token then attends to positions the inferlet meant to exclude.
+    #[test]
+    fn entry_match_rejects_user_masked_request() {
+        // Same single-token anchor the extender would have staged.
+        let mut req = req_with(vec![11], vec![0], vec![argmax()]);
+        req.token_ids = vec![42];
+        let entry = staged_entry(42, 11);
+
+        // Unconstrained, fully-causal decode at this anchor: a hit is
+        // correct.
+        assert!(entry_matches_request(&entry, &req));
+
+        // Supply a custom attention mask (as windowed-attention does once
+        // the sequence exceeds the window). The same anchor must NOT match —
+        // the staged fire was computed fully-causal.
+        req.masks = vec![pie_bridge::Brle::from_vec(vec![0, u32::MAX])];
+        req.has_user_mask = true;
+        assert!(
+            !entry_matches_request(&entry, &req),
+            "attention-masked request must not be served from a fully-causal staged fire"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Pass-level speculation pre-fires each context's next decode step before the inferlet has set up that step's constraints, so every staged fire is built with an **empty constraint surface**: no logit mask (`build_next_request` emits `logit_masks = []`) and no custom attention mask (`masks = []`, `has_user_mask = false`). The staged-hit check `entry_matches_request` compared anchor token/position and the spec arrays but **neither mask** — so a request carrying one was served the unconstrained, fully-causal staged token verbatim, silently dropping the constraint at the unconstrained→constrained transition.

Two reachable variants, both **default-on** (`speculation_depth = 1`):

- **Logit mask** — `json_object` / `json_schema` / forced tool-call grammar decode ignored the grammar. A real model hides this (asked for JSON it naturally emits a leading `{`); the dummy driver (uniform-random within the mask) exposes it as fully unconstrained output that never begins with `{`.
- **Attention mask** — single-token `windowed-attention` / `attention-sink` / `hierarchical-attention` decode (these decode one token at a time and call `attention_mask()` once the sequence exceeds the window) was served a token computed with full causal attention, so it attended to positions the inferlet meant to exclude.

## Fix

Reject a staged hit whenever the incoming request carries **either** mask, forcing it onto the cold path where the mask is applied (the `try_hit` miss branch clears the now-stale chain). This mirrors the producer-side skip set in `evaluate_request_shape`, which already refuses to stage from either kind of masked request — the two sites must stay symmetric or the drop reappears.

A regression test per variant proves a masked request misses an otherwise-matching staged entry (both mutation-proven: each fails if its mask clause is reverted).

Also teaches the dummy driver to ack `Copy`/`Adapter` as no-ops (status 0) instead of the catch-all `-1` error: a no-compute driver has no KV pages to copy and no adapter weights to load, and token generation is independent of cache contents, so a vacuous success is faithful. The previous `-1` broke the context-fork path used for prefix sharing.

## Provenance

Integration bug surfaced by the reconcile: this branch's `runtime/src/inference/speculator.rs` (pass-level speculation) and the pie-bridge `logit_masks`/`masks` schema were developed on separate upstream branches and were not wired together until the reconcile merged them onto one tree. Neither source branch exercised both halves, so the staged-fire-vs-masked-request interaction was never tested until now.

## Verification

| Tier | Result |
|---|---|
| `inference::speculator::tests` (10) | green — incl. `entry_match_rejects_logit_masked_request` + `entry_match_rejects_user_masked_request`, both mutation-proven |
| HTTP chat E2E | **202 passed, 1 skipped** (#200 pre-existing); `json_object`/`json_schema` output begins with `{` |
| Real Metal | `json_schema` → 200 with `{"name": ...}`; forced tool → 200 with `tool_calls`; S3 coherence green |
| pie lib / weight-loader | 444 / 14 |