### PR TITLE
Key uniform-sample reshape on slot count, not request count (deep-ToT speculation crash)

### DIFF
--- a/driver/portable/src/graph_common.hpp
+++ b/driver/portable/src/graph_common.hpp
@@ -94,7 +94,7 @@ struct GraphInputs {
     ggml_tensor*              tok_input;   // I32 [total_n_tokens]
     ggml_tensor*              pos_input;   // I32 [total_n_tokens]
     ggml_tensor*              kv_idxs;     // I64 [total_n_tokens] (write idxs)
-    ggml_tensor*              out_idx;     // I32 [n_request]
+    ggml_tensor*              out_idx;     // I32 [n_sample_slots] (>= n_request under spec decode)
     // Slow path (per-request): one mask + gather tensor per request.
     std::vector<ggml_tensor*> masks;       // F16 [n_kv_r, n_tokens_pad_r]
     // Phi-3-small only: per-request blocksparse-clipped mask used by

--- a/driver/portable/src/graph_gemma4.cpp
+++ b/driver/portable/src/graph_gemma4.cpp
@@ -522,9 +522,12 @@ GraphResult build_gemma4_graph(ggml_context* ctx,
         ggml_tensor* probs = ggml_soft_max_ext(ctx, logits, /*mask=*/nullptr,
                                                 /*scale=*/inv_t, /*max_bias=*/0.0f);
         top_k_idx = ggml_top_k(ctx, probs, plan.uniform_top_k);
-        ggml_tensor* probs_3d = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_req);
+        // n_slots (sampled rows), not n_req: speculation samples >1 slot
+        // per request, so n_slots >= n_req.
+        const std::int64_t n_slots = probs->ne[1];
+        ggml_tensor* probs_3d = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_slots);
         ggml_tensor* gathered = ggml_get_rows(ctx, probs_3d, top_k_idx);
-        top_k_probs = ggml_reshape_2d(ctx, gathered, plan.uniform_top_k, n_req);
+        top_k_probs = ggml_reshape_2d(ctx, gathered, plan.uniform_top_k, n_slots);
         ggml_set_name(top_k_idx,   "top_k_idx");
         ggml_set_name(top_k_probs, "top_k_probs");
         ggml_set_output(top_k_idx);

--- a/driver/portable/src/graph_phi3_5moe.cpp
+++ b/driver/portable/src/graph_phi3_5moe.cpp
@@ -193,10 +193,13 @@ GraphResult build_phi3_5moe_graph(ggml_context* ctx,
         auto* probs = ggml_soft_max_ext(ctx, logits, /*mask=*/nullptr,
                                         /*scale=*/inv_t, /*max_bias=*/0.0f);
         auto* top_k_idx = ggml_top_k(ctx, probs, plan.uniform_top_k);
-        auto* probs_3d  = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_req);
+        // n_slots (sampled rows), not n_req: speculation samples >1 slot
+        // per request, so n_slots >= n_req.
+        const std::int64_t n_slots = probs->ne[1];
+        auto* probs_3d  = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_slots);
         auto* gathered  = ggml_get_rows(ctx, probs_3d, top_k_idx);
         auto* top_k_probs = ggml_reshape_2d(
-            ctx, gathered, plan.uniform_top_k, n_req);
+            ctx, gathered, plan.uniform_top_k, n_slots);
         ggml_set_name(top_k_idx, "top_k_idx");
         ggml_set_name(top_k_probs, "top_k_probs");
         ggml_set_output(top_k_idx);

--- a/driver/portable/src/graph_phi3small.cpp
+++ b/driver/portable/src/graph_phi3small.cpp
@@ -219,10 +219,13 @@ GraphResult build_phi3small_graph(ggml_context* ctx,
         auto* probs = ggml_soft_max_ext(ctx, logits, /*mask=*/nullptr,
                                         /*scale=*/inv_t, /*max_bias=*/0.0f);
         auto* top_k_idx = ggml_top_k(ctx, probs, plan.uniform_top_k);
-        auto* probs_3d  = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_req);
+        // n_slots (sampled rows), not n_req: speculation samples >1 slot
+        // per request, so n_slots >= n_req.
+        const std::int64_t n_slots = probs->ne[1];
+        auto* probs_3d  = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_slots);
         auto* gathered  = ggml_get_rows(ctx, probs_3d, top_k_idx);
         auto* top_k_probs = ggml_reshape_2d(
-            ctx, gathered, plan.uniform_top_k, n_req);
+            ctx, gathered, plan.uniform_top_k, n_slots);
         ggml_set_name(top_k_idx, "top_k_idx");
         ggml_set_name(top_k_probs, "top_k_probs");
         ggml_set_output(top_k_idx);

--- a/driver/portable/src/graph_qwen3.cpp
+++ b/driver/portable/src/graph_qwen3.cpp
@@ -850,10 +850,13 @@ GraphResult build_qwen3_graph(ggml_context* ctx,
         // the get_rows trick used by the MoE router (build_moe_ffn).
         // probs reshaped to [1, vocab, n_slots]; get_rows along ne[1]
         // with index [K, n_slots] yields [1, K, n_slots] → reshape.
+        // n_slots (sampled rows), not n_req: speculation samples >1 slot
+        // per request, so n_slots >= n_req.
+        const std::int64_t n_slots = probs->ne[1];
         ggml_tensor* probs_3d = ggml_reshape_3d(
-            ctx, probs, 1, h.vocab_size, n_req);
+            ctx, probs, 1, h.vocab_size, n_slots);
         ggml_tensor* gathered = ggml_get_rows(ctx, probs_3d, top_k_idx);
-        top_k_probs = ggml_reshape_2d(ctx, gathered, plan.uniform_top_k, n_req);
+        top_k_probs = ggml_reshape_2d(ctx, gathered, plan.uniform_top_k, n_slots);
 
         ggml_set_name(top_k_idx, "top_k_idx");
         ggml_set_name(top_k_probs, "top_k_probs");

--- a/driver/portable/src/graph_qwen3_5.cpp
+++ b/driver/portable/src/graph_qwen3_5.cpp
@@ -571,9 +571,12 @@ GraphResult build_qwen3_5_graph(ggml_context* ctx,
         ggml_tensor* probs = ggml_soft_max_ext(ctx, logits, /*mask=*/nullptr,
                                                 /*scale=*/inv_t, /*max_bias=*/0.0f);
         top_k_idx = ggml_top_k(ctx, probs, plan.uniform_top_k);
-        ggml_tensor* probs_3d = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_req);
+        // n_slots (sampled rows), not n_req: speculation samples >1 slot
+        // per request, so n_slots >= n_req.
+        const std::int64_t n_slots = probs->ne[1];
+        ggml_tensor* probs_3d = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_slots);
         ggml_tensor* gathered = ggml_get_rows(ctx, probs_3d, top_k_idx);
-        top_k_probs = ggml_reshape_2d(ctx, gathered, plan.uniform_top_k, n_req);
+        top_k_probs = ggml_reshape_2d(ctx, gathered, plan.uniform_top_k, n_slots);
         ggml_set_name(top_k_idx,   "top_k_idx");
         ggml_set_name(top_k_probs, "top_k_probs");
         ggml_set_output(top_k_idx);


### PR DESCRIPTION
Sibling PRs for this ticket:
- pie-project/pie#419 — https://github.com/pie-project/pie/pull/419
- pie-project/pie#420 — https://github.com/pie-project/pie/pull/420
- shsym/RatioThink#259 — https://github.com/shsym/RatioThink/pull/259

## Problem

The portable driver's non-greedy **uniform top-k sampling** fast path reshaped the per-slot probability tensor using the **request count** (`n_req`) as its trailing dimension, but `probs` has one row per sampling **slot**. Pass-level / system speculation verifies several draft slots per request, so `n_slots > n_req`; `ggml_reshape` then aborted with `GGML_ASSERT(ggml_nelements(a) == ne0*ne1*ne2)` and the driver **died mid-stream**. The greedy path (`ggml_argmax`) is per-slot and was unaffected — the crash only surfaced with non-greedy sampling (tree-of-thought at temperature > 0) once speculation produced a multi-slot batch (deep search: a staged single-token decode co-batched with a prefill).

## Provenance — reconcile-introduced

Pass-level speculation (`runtime/src/inference/speculator.rs`), the only producer of multi-slot-per-request sampling, is **absent on the pre-reconcile fork tip `7c52551`**; it was added by the driver/bridge reconcile and is default-on. With `scheduler.speculation_depth = 0` deep ToT runs clean. So the sampler fast path's latent single-slot assumption only became reachable via the reconcile.

## Fix

Key both reshapes on the actual slot count (`probs->ne[1]`). When a request samples one slot, `n_slots == n_req`, so non-speculative decoding is unchanged. Applied to all five arch graph builders that share the fast path: **qwen3, qwen3.5, gemma4, phi3-small, phi3.5-moe**.

## Verification

- Warm-sequence real-Metal repro (Qwen3-0.6B, depth-2 then depth-3 ToT, one boot): ~100% crash before, **8/8 clean after**, zero `GGML_ASSERT`.
- Profile audit on the fixed engine: chat, repeat-boost (greedy + speculation engaged), json-think, tree-of-thought (depth 2 and 3) all pass.

> NOTE: the first commit (`fix(inference): never serve a masked decode…`) belongs to the open mask-fix PR this is stacked on; review only the `fix(portable): key uniform-sample reshape…` commit here. After the mask-fix PR merges, rebase drops the overlap.