### PR TITLE
fix(driver-portable): guard GGUF tensor bounds to surface truncation instead of SIGBUS

### DIFF
--- a/driver/portable/src/gguf_archive.cpp
+++ b/driver/portable/src/gguf_archive.cpp
@@ -227,6 +227,28 @@ GGUFArchive::GGUFArchive(const std::filesystem::path& gguf_file) {
     const std::int64_t n_tensors = gguf_get_n_tensors(gctx_);
     raw_names_.reserve(static_cast<std::size_t>(n_tensors));
 
+    // gguf_init_from_file (no_alloc=true) validates only the header, so a
+    // tensor extent past EOF passes init then SIGBUSes on first read.
+    for (std::int64_t i = 0; i < n_tensors; ++i) {
+        const std::size_t local_offset = gguf_get_tensor_offset(gctx_, i);
+        const std::size_t nbytes       = gguf_get_tensor_size(gctx_, i);
+        // Overflow-safe form of: data_offset + local_offset + nbytes > mmap_size_
+        if (data_offset > mmap_size_ ||
+            local_offset > mmap_size_ - data_offset ||
+            nbytes > mmap_size_ - data_offset - local_offset) {
+            const std::string nm = gguf_get_tensor_name(gctx_, i);
+            close_mmap_();
+            gguf_free(gctx_); gctx_ = nullptr;
+            throw std::runtime_error(
+                "gguf: tensor '" + nm + "' (data_offset=" +
+                std::to_string(data_offset) + " + offset=" +
+                std::to_string(local_offset) + " + size=" +
+                std::to_string(nbytes) + ") extends past mapped file size " +
+                std::to_string(mmap_size_) +
+                " — GGUF is truncated or corrupt: " + gguf_file.string());
+        }
+    }
+
     // We need tensor shapes (ne[]) and the public gguf API doesn't
     // expose them directly (only type, offset, size). Workaround: pass
     // ctx=&meta_ggml_ctx to gguf_init_from_file with no_alloc=true and


### PR DESCRIPTION
## Problem

When the embedded portable driver loads a truncated or corrupt GGUF, the driver thread dies with a SIGBUS and the process exits with no surfaced cause.

`GGUFArchive` maps the whole model file with `mmap` and hands out tensor pointers as `mmap_base + data_offset + tensor_offset`. `gguf_init_from_file` runs with `no_alloc=true`, so it validates only the metadata header and never touches the tensor-data section. A GGUF whose declared tensor region runs past the on-disk size therefore passes init and then SIGBUSes on the first tensor access — an `mmap` read beyond the file's last mapped page (for example, the `token_embd` dequant reads at load time).

Because the embedded driver runs as a thread inside the engine process with `install_signal_handlers=0`, that SIGBUS kills the whole process. It bypasses the C++ `run_inproc` `try/catch` (which only catches `std::exception`) and the host's startup-exit detection (which only catches clean nonzero returns, not signals). The result is an opaque signal death with the real cause unsurfaced.

Note: this is unrelated to `python_snapshot` / the Python WASM runtime — that path is guarded separately and is never reached on a missing runtime.

## Fix

Add a bounds check in the `GGUFArchive` constructor, before any tensor is read: for each tensor, assert `data_offset + tensor_offset + nbytes <= mapped size` (overflow-safe), otherwise throw a `std::runtime_error` naming the offending tensor and the sizes.

The throw propagates through the driver's `run_inproc` catch, which prints `[pie-driver-portable] fatal: <reason>` to stderr and returns nonzero, so the cause now reaches the host instead of an opaque signal death. Covers single-file and sharded loads (each shard runs through the same constructor).

Existence, magic, and header validation are already handled by `gguf_init_from_file`; this closes the remaining truncation/bounds gap.

## Test

Adds `portable_gguf_archive`: writes a valid one-tensor GGUF, truncates it into the data section, and asserts the constructor throws a "truncated or corrupt" error, while the intact file opens cleanly.

## Verification

- `portable_gguf_archive` C++ test: PASS, and mutation-proven (removing the guard makes the test fail rather than SIGBUS).
- `cargo build -p pie-server --release` with `PIE_PORTABLE_METAL=1`: PASS — the guard compiles in the real portable build and the engine binary links.
- Downstream app lint + unit suite (828 tests, 9 skipped): PASS.
- HTTP E2E was blocked only by an orthogonal chat-apc prebuilt-wasm freshness gate (the consuming tree sits on this base while the committed prebuilt is stamped against an older pin); it trips on the bare base too and is independent of this change.