### PR TITLE
feat(portable): surface cause of any fatal driver-thread signal (#691)

### DIFF
--- a/driver/portable/src/entry.cpp
+++ b/driver/portable/src/entry.cpp
@@ -33,6 +33,7 @@
 #include "host_swap_pool.hpp"
 #include "config.hpp"
 #include "executor/executor.hpp"
+#include "fatal_backstop.hpp"
 #include "gguf_tokenizer.hpp"
 #include "hf_config.hpp"
 #include <pie_bridge/inproc_server.hpp>
@@ -267,6 +268,15 @@ int run_impl(int argc,
     if (!cfg.runtime.verbose) {
         ggml_log_set(quiet_ggml_log, nullptr);
     }
+
+    // Install the fatal-signal backstop before any model work so an
+    // uncatchable native fault during load (e.g. a wild read past a
+    // truncated mmap — the #688 SIGBUS) surfaces its cause to stderr
+    // instead of killing the host process silently. Marking this thread
+    // is per-thread; installing the handlers is process-once. See
+    // fatal_backstop.hpp for the wasmtime-coexistence reasoning.
+    pie_driver_backstop::mark_driver_thread();
+    pie_driver_backstop::install("portable", cfg.model.hf_path.c_str());
 
     // Informational logs go to stderr — stdout is reserved for the READY
     // handshake line consumed by the host process.

--- a/driver/portable/src/fatal_backstop.hpp
+++ b/driver/portable/src/fatal_backstop.hpp
@@ -23,24 +23,34 @@
 // driver thread. So a fatal signal delivered while executing *on the
 // driver thread* is always a real native driver fault, never a wasm trap.
 //
-// We therefore gate the diagnostic on a thread-local "this is a driver
-// thread" marker:
-//   * On a driver thread  -> emit the cause, then chain to the previously
-//     installed disposition so the process still dies with the right
-//     signal status.
-//   * On any other thread -> emit nothing and chain straight through to
-//     wasmtime's handler, so guard-page recovery (Linux) is byte-for-byte
-//     untouched.
+// We therefore gate the *diagnostic* (never the chain) on whether the
+// faulting thread could plausibly be carrying an expected wasm trap:
 //
-// Platform notes (both handled by the single mechanism above):
-//   * macOS: wasmtime uses Mach exception ports for guard pages, so a
-//     POSIX sigaction handler never even sees an expected wasm trap; the
-//     saved previous disposition for SIGSEGV/SIGBUS is just SIG_DFL.
-//   * Linux: wasmtime installs POSIX handlers. We save them and, when
-//     chaining, invoke `prev.sa_sigaction(sig, info, ctx)` with the *same*
-//     `ucontext` the kernel will use for `sigreturn`, so wasmtime's
-//     in-handler recovery (it rewrites `ctx` to resume) takes effect when
-//     our handler returns.
+//   * macOS: wasmtime uses Mach exception ports for guard pages, so an
+//     expected wasm trap is intercepted and recovered out-of-band and
+//     NEVER delivered as a BSD signal to a sigaction handler. Hence *any*
+//     signal that reaches this handler is already a genuine fatal fault —
+//     on the main driver thread, a ggml compute worker, or a Metal
+//     completion thread. We emit for all of them (the saved previous
+//     disposition is just SIG_DFL, so we restore it and re-raise to die).
+//     This is what surfaces an inference-time fault on a ggml worker
+//     thread that entry.cpp never marked.
+//   * Linux: wasmtime installs POSIX SIGSEGV/SIGBUS handlers, so an
+//     expected wasm guard-page trap DOES reach a sigaction handler on a
+//     host worker thread. There we must stay silent on any thread we did
+//     not explicitly mark, and chain straight through to wasmtime's saved
+//     handler — invoking `prev.sa_sigaction(sig, info, ctx)` with the
+//     *same* `ucontext` the kernel will `sigreturn` into, so wasmtime's
+//     in-handler recovery takes effect when we return. On Linux only the
+//     thread that called `mark_driver_thread()` emits; ggml compute
+//     workers are spawned inside ggml's default pthread pool (no pie-owned
+//     init hook), so surfacing their faults there needs a ggml
+//     worker-entry hook — deferred with the cuda/Linux follow-up.
+//
+// So the emit gate is: `t_on_driver_thread || !wasm traps can reach here`.
+// `g_wasm_traps_reach_sigaction` defaults to the platform value above and
+// is overridable so the hermetic test can exercise both regimes on one
+// host.
 //
 // Everything that runs inside the signal handler is async-signal-safe:
 // only `write(2)` of pre-sized buffers, `sigaction`, and `raise`. The
@@ -85,6 +95,20 @@ inline std::size_t g_model_len = 0;
 // load, no __tls_get_addr call).
 inline thread_local bool t_on_driver_thread = false;
 
+// Whether an expected wasm guard-page trap can be delivered to this POSIX
+// sigaction handler. False on Apple (wasmtime uses Mach exception ports),
+// so any signal reaching us is a genuine fault on any thread — including
+// unmarked ggml compute workers. True on Linux, where we must stay silent
+// on unmarked threads to avoid emitting on recoverable wasm traps. A plain
+// bool read in the handler is async-signal-safe; the test overrides it to
+// exercise both regimes on one host.
+#if defined(__APPLE__)
+inline constexpr bool kWasmTrapsReachSigactionDefault = false;
+#else
+inline constexpr bool kWasmTrapsReachSigactionDefault = true;
+#endif
+inline bool g_wasm_traps_reach_sigaction = kWasmTrapsReachSigactionDefault;
+
 // Write a string literal without strlen (async-signal-safe, length known
 // at compile time). `s` must be a char array literal.
 #define PIE_BACKSTOP_WLIT(s)                                        \
@@ -119,7 +143,10 @@ inline int fatal_index(int sig) {
 }
 
 inline void fatal_handler(int sig, siginfo_t* info, void* ctx) {
-    if (t_on_driver_thread) {
+    // Emit on a marked driver thread, or — where wasm traps cannot reach a
+    // sigaction handler (macOS Mach ports) — on any thread, since the
+    // signal is then necessarily a genuine fault (e.g. a ggml worker).
+    if (t_on_driver_thread || !g_wasm_traps_reach_sigaction) {
         // Format: "[pie-driver-<flavor>] fatal: caught <SIG> (model=<path>)"
         PIE_BACKSTOP_WLIT("[pie-driver-");
         write_buf(g_flavor, g_flavor_len);

--- a/driver/portable/src/fatal_backstop.hpp
+++ b/driver/portable/src/fatal_backstop.hpp
@@ -1,0 +1,229 @@
+// Process-level fatal-signal backstop for the embedded native driver.
+//
+// Why this exists
+// ---------------
+// The native driver runs as a *thread* inside the host process (the Rust
+// server, which also hosts wasmtime). The C++ run wrappers only catch
+// `std::exception`, the host's startup-exit detection only sees a clean
+// nonzero return, and the driver is launched with
+// `install_signal_handlers=0`. So an uncatchable native fault on the
+// driver thread (a wild read past a truncated mmap, a bad kernel, a
+// failed assert) kills the *whole* process with no surfaced cause — the
+// app sees only a bare `crashed on signal=N`. #688 added a bounds guard
+// for the one known trigger (a truncated GGUF); this is the general
+// backstop for every other native fault.
+//
+// The wasmtime coexistence problem
+// --------------------------------
+// wasmtime owns SIGSEGV/SIGBUS (and SIGILL/SIGFPE) to implement wasm
+// linear-memory guard pages and trap instructions. A naive fatal handler
+// would fire on every *expected* guard-page fault and clobber wasm's
+// recovery. The escape hatch is an invariant of this architecture:
+// wasmtime executes wasm only on the host's worker threads, NEVER on the
+// driver thread. So a fatal signal delivered while executing *on the
+// driver thread* is always a real native driver fault, never a wasm trap.
+//
+// We therefore gate the diagnostic on a thread-local "this is a driver
+// thread" marker:
+//   * On a driver thread  -> emit the cause, then chain to the previously
+//     installed disposition so the process still dies with the right
+//     signal status.
+//   * On any other thread -> emit nothing and chain straight through to
+//     wasmtime's handler, so guard-page recovery (Linux) is byte-for-byte
+//     untouched.
+//
+// Platform notes (both handled by the single mechanism above):
+//   * macOS: wasmtime uses Mach exception ports for guard pages, so a
+//     POSIX sigaction handler never even sees an expected wasm trap; the
+//     saved previous disposition for SIGSEGV/SIGBUS is just SIG_DFL.
+//   * Linux: wasmtime installs POSIX handlers. We save them and, when
+//     chaining, invoke `prev.sa_sigaction(sig, info, ctx)` with the *same*
+//     `ucontext` the kernel will use for `sigreturn`, so wasmtime's
+//     in-handler recovery (it rewrites `ctx` to resume) takes effect when
+//     our handler returns.
+//
+// Everything that runs inside the signal handler is async-signal-safe:
+// only `write(2)` of pre-sized buffers, `sigaction`, and `raise`. The
+// flavor/model strings are snprintf'd into fixed buffers at install time
+// (normal context), never inside the handler.
+
+#pragma once
+
+#include <atomic>
+#include <csignal>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+
+#include <pthread.h>
+#include <unistd.h>
+
+namespace pie_driver_backstop {
+
+inline constexpr int kFatalSignals[] = {SIGSEGV, SIGBUS, SIGILL, SIGFPE, SIGABRT};
+inline constexpr int kNumFatal =
+    static_cast<int>(sizeof(kFatalSignals) / sizeof(kFatalSignals[0]));
+
+// Previous dispositions (wasmtime's handler on Linux, SIG_DFL otherwise),
+// one per entry in kFatalSignals. Populated once by install().
+inline struct sigaction g_prev[kNumFatal];
+
+// install() runs at most once per process; mark_driver_thread() runs once
+// per driver thread.
+inline std::atomic<bool> g_installed{false};
+
+// Diagnostic context, fixed at install time so the handler only reads it.
+inline char        g_flavor[32] = {0};
+inline std::size_t g_flavor_len = 0;
+inline char        g_model[1024] = {0};
+inline std::size_t g_model_len = 0;
+
+// Per-thread marker. Default-false on every thread; set true only on
+// driver threads (see mark_driver_thread). Reading a thread_local in the
+// handler is safe here: the driver links as a static lib into the host
+// binary, so this resolves to local-exec TLS (a direct register+offset
+// load, no __tls_get_addr call).
+inline thread_local bool t_on_driver_thread = false;
+
+// Write a string literal without strlen (async-signal-safe, length known
+// at compile time). `s` must be a char array literal.
+#define PIE_BACKSTOP_WLIT(s)                                        \
+    do {                                                            \
+        ssize_t pie_backstop_n_ =                                   \
+            ::write(STDERR_FILENO, (s), sizeof(s) - 1);            \
+        (void)pie_backstop_n_;                                      \
+    } while (0)
+
+inline void write_buf(const char* buf, std::size_t len) {
+    if (len == 0) return;
+    ssize_t n = ::write(STDERR_FILENO, buf, len);
+    (void)n;
+}
+
+inline void write_signal_name(int sig) {
+    switch (sig) {
+        case SIGSEGV: PIE_BACKSTOP_WLIT("SIGSEGV"); break;
+        case SIGBUS:  PIE_BACKSTOP_WLIT("SIGBUS");  break;
+        case SIGILL:  PIE_BACKSTOP_WLIT("SIGILL");  break;
+        case SIGFPE:  PIE_BACKSTOP_WLIT("SIGFPE");  break;
+        case SIGABRT: PIE_BACKSTOP_WLIT("SIGABRT"); break;
+        default:      PIE_BACKSTOP_WLIT("signal");  break;
+    }
+}
+
+inline int fatal_index(int sig) {
+    for (int i = 0; i < kNumFatal; ++i) {
+        if (kFatalSignals[i] == sig) return i;
+    }
+    return -1;
+}
+
+inline void fatal_handler(int sig, siginfo_t* info, void* ctx) {
+    if (t_on_driver_thread) {
+        // Format: "[pie-driver-<flavor>] fatal: caught <SIG> (model=<path>)"
+        PIE_BACKSTOP_WLIT("[pie-driver-");
+        write_buf(g_flavor, g_flavor_len);
+        PIE_BACKSTOP_WLIT("] fatal: caught ");
+        write_signal_name(sig);
+        if (g_model_len > 0) {
+            PIE_BACKSTOP_WLIT(" (model=");
+            write_buf(g_model, g_model_len);
+            PIE_BACKSTOP_WLIT(")");
+        }
+        PIE_BACKSTOP_WLIT("\n");
+    }
+
+    // Chain to the previous disposition. On a non-driver thread this is the
+    // *only* thing we do, so wasm guard-page recovery is preserved exactly.
+    const int idx = fatal_index(sig);
+    if (idx >= 0) {
+        const struct sigaction& prev = g_prev[idx];
+        if (prev.sa_flags & SA_SIGINFO) {
+            if (prev.sa_sigaction != nullptr) {
+                // wasmtime's handler: it may rewrite `ctx` to recover. We
+                // hand it the same ctx the kernel will sigreturn into, then
+                // return so that recovery (or its own chain-to-default)
+                // takes effect.
+                prev.sa_sigaction(sig, info, ctx);
+                return;
+            }
+        } else {
+            if (prev.sa_handler == SIG_IGN) {
+                return;  // previously ignored — honor that
+            }
+            if (prev.sa_handler != SIG_DFL && prev.sa_handler != nullptr) {
+                prev.sa_handler(sig);
+                return;
+            }
+        }
+    }
+
+    // Previous was SIG_DFL (or we somehow lost it): restore the default
+    // disposition and re-raise so the process terminates with the correct
+    // signal status (e.g. WTERMSIG == sig for the host to report).
+    ::signal(sig, SIG_DFL);
+    ::raise(sig);
+}
+
+// Mark the calling thread as a driver thread. Call once at the top of each
+// driver thread's run path, before any work that could fault. Idempotent
+// and async-signal-safe.
+inline void mark_driver_thread() { t_on_driver_thread = true; }
+
+// Install the fatal-signal backstop process-wide. Safe to call from every
+// driver thread; only the first call installs the handlers and records the
+// diagnostic context. `flavor` is the driver flavor name (e.g. "portable");
+// `model_path` may be null.
+//
+// Ordering note: drivers boot before the runtime creates wasmtime (see
+// server::serve — drivers hand back caps, then bootstrap runs), so this
+// installs *before* wasmtime registers its trap handlers. That is fine in
+// either direction:
+//   * wasmtime, installing after us, saves our handler as its chain target
+//     and calls it for any fault it does not recognize as a wasm trap. A
+//     driver-thread fault therefore still reaches us (we emit, then chain
+//     to the default disposition we saved here and die with the right
+//     status), and an expected wasm guard-page fault is handled and
+//     recovered entirely inside wasmtime — it never reaches us.
+//   * If the order were ever reversed, we are the first responder and chain
+//     to wasmtime's saved handler, which recovers wasm faults and dies on
+//     native ones.
+// Either way the thread-local gate guarantees we only emit a diagnostic for
+// faults on a driver thread, and wasm guard-page recovery is untouched.
+inline void install(const char* flavor, const char* model_path) {
+    bool expected = false;
+    if (!g_installed.compare_exchange_strong(expected, true)) {
+        return;  // already installed by an earlier driver thread
+    }
+
+    std::snprintf(g_flavor, sizeof(g_flavor), "%s", flavor ? flavor : "?");
+    g_flavor_len = std::strlen(g_flavor);
+    if (model_path != nullptr && model_path[0] != '\0') {
+        std::snprintf(g_model, sizeof(g_model), "%s", model_path);
+        g_model_len = std::strlen(g_model);
+    }
+
+    struct sigaction sa;
+    std::memset(&sa, 0, sizeof(sa));
+    sa.sa_sigaction = fatal_handler;
+    sa.sa_flags = SA_SIGINFO;
+    sigemptyset(&sa.sa_mask);
+    for (int i = 0; i < kNumFatal; ++i) {
+        std::memset(&g_prev[i], 0, sizeof(g_prev[i]));
+        ::sigaction(kFatalSignals[i], &sa, &g_prev[i]);
+    }
+}
+
+// Map a signal name ("SIGSEGV", "SIGBUS", ...) to its number, or -1.
+// Provided for tests that inject a named fault.
+inline int signal_from_name(const char* name) {
+    if (name == nullptr) return -1;
+    if (std::strcmp(name, "SIGSEGV") == 0) return SIGSEGV;
+    if (std::strcmp(name, "SIGBUS") == 0) return SIGBUS;
+    if (std::strcmp(name, "SIGILL") == 0) return SIGILL;
+    if (std::strcmp(name, "SIGFPE") == 0) return SIGFPE;
+    if (std::strcmp(name, "SIGABRT") == 0) return SIGABRT;
+    return -1;
+}
+
+}  // namespace pie_driver_backstop

--- a/driver/portable/tests/fatal_backstop_test.cpp
+++ b/driver/portable/tests/fatal_backstop_test.cpp
@@ -21,7 +21,9 @@
 #include <csetjmp>
 #include <csignal>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <thread>
 
 static sigjmp_buf g_jmp;
 static volatile sig_atomic_t g_prev_ran = 0;
@@ -56,9 +58,29 @@ int main(int argc, char** argv) {
         return 64;
     }
 
+    // Force the platform regime so both can be exercised on one host:
+    //   PIE_BACKSTOP_FORCE_WASM_TRAPS=1 -> Linux semantics (wasm traps
+    //     reach the sigaction handler; unmarked threads stay silent).
+    //   PIE_BACKSTOP_FORCE_WASM_TRAPS=0 -> Apple/Mach semantics (any signal
+    //     here is a genuine fault; emit on any thread).
+    if (const char* f = std::getenv("PIE_BACKSTOP_FORCE_WASM_TRAPS")) {
+        pie_driver_backstop::g_wasm_traps_reach_sigaction = (f[0] == '1');
+    }
+
     if (std::strcmp(mode, "signum") == 0) {
         std::printf("%d\n", sig);
         return 0;
+    }
+
+    if (std::strcmp(mode, "worker") == 0) {
+        // Model an inference-time fault on a ggml compute worker: a thread
+        // that never called mark_driver_thread(). Under Apple/Mach
+        // semantics (FORCE=0) the backstop must still emit and die by the
+        // signal — the coverage F2 is about.
+        pie_driver_backstop::install("portable", "/test/model.gguf");
+        std::thread([sig] { ::raise(sig); }).join();
+        std::fprintf(stderr, "ERROR: survived raise() on worker thread\n");
+        return 1;  // unreachable: the chain to SIG_DFL must terminate us
     }
 
     if (std::strcmp(mode, "marked") == 0) {

--- a/driver/portable/tests/fatal_backstop_test.cpp
+++ b/driver/portable/tests/fatal_backstop_test.cpp
@@ -1,0 +1,101 @@
+// Hermetic test harness for fatal_backstop.hpp.
+//
+// Self-contained: includes only the header under test plus libc, so it
+// compiles and runs anywhere with a C++20 compiler — no pie/ggml/Metal
+// build required. The driver thread's fatal-signal contract is exercised
+// directly here; the in-app path is the same install()/handler code wired
+// into driver/portable/src/entry.cpp.
+//
+// Modes (driven by run-fatal-backstop-test.sh):
+//   signum <SIG>         print the OS signal number for <SIG>, exit 0.
+//   marked <SIG>         mark this as a driver thread, install, raise <SIG>.
+//                        Expect: diagnostic on stderr + death by <SIG>.
+//   unmarked <SIG>       install a recovering "prev" handler, then install
+//                        the backstop WITHOUT marking the thread, raise.
+//                        Expect: NO diagnostic + chain to prev recovers.
+//   marked_recover <SIG> recovering prev + marked + install, raise.
+//                        Expect: diagnostic AND chain to prev recovers.
+
+#include "../src/fatal_backstop.hpp"
+
+#include <csetjmp>
+#include <csignal>
+#include <cstdio>
+#include <cstring>
+
+static sigjmp_buf g_jmp;
+static volatile sig_atomic_t g_prev_ran = 0;
+
+// Stands in for wasmtime's guard-page handler: records that it ran and
+// "recovers" by jumping back to the sigsetjmp point (savesigs=1 restores
+// the signal mask), exactly the recover-and-continue shape our chain must
+// preserve for non-driver-thread faults on Linux.
+static void recovering_prev(int /*sig*/, siginfo_t* /*info*/, void* /*ctx*/) {
+    g_prev_ran = 1;
+    siglongjmp(g_jmp, 1);
+}
+
+static void install_recovering_prev(int sig) {
+    struct sigaction sa;
+    std::memset(&sa, 0, sizeof(sa));
+    sa.sa_sigaction = recovering_prev;
+    sa.sa_flags = SA_SIGINFO;
+    sigemptyset(&sa.sa_mask);
+    ::sigaction(sig, &sa, nullptr);
+}
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        std::fprintf(stderr, "usage: %s <mode> <SIG>\n", argv[0]);
+        return 64;
+    }
+    const char* mode = argv[1];
+    const int sig = pie_driver_backstop::signal_from_name(argv[2]);
+    if (sig <= 0) {
+        std::fprintf(stderr, "bad signal: %s\n", argv[2]);
+        return 64;
+    }
+
+    if (std::strcmp(mode, "signum") == 0) {
+        std::printf("%d\n", sig);
+        return 0;
+    }
+
+    if (std::strcmp(mode, "marked") == 0) {
+        pie_driver_backstop::mark_driver_thread();
+        pie_driver_backstop::install("portable", "/test/model.gguf");
+        ::raise(sig);
+        std::fprintf(stderr, "ERROR: survived raise() in marked mode\n");
+        return 1;  // unreachable: the chain to SIG_DFL must terminate us
+    }
+
+    if (std::strcmp(mode, "unmarked") == 0) {
+        install_recovering_prev(sig);
+        // Deliberately do NOT mark this thread.
+        pie_driver_backstop::install("portable", "/test/model.gguf");
+        if (sigsetjmp(g_jmp, 1) == 0) {
+            ::raise(sig);
+            std::fprintf(stderr, "ERROR: raise() returned without recovery\n");
+            return 1;
+        }
+        std::printf("RECOVERED prev_ran=%d\n", static_cast<int>(g_prev_ran));
+        return 0;
+    }
+
+    if (std::strcmp(mode, "marked_recover") == 0) {
+        install_recovering_prev(sig);
+        pie_driver_backstop::mark_driver_thread();
+        pie_driver_backstop::install("portable", "/test/model.gguf");
+        if (sigsetjmp(g_jmp, 1) == 0) {
+            ::raise(sig);
+            std::fprintf(stderr, "ERROR: raise() returned without recovery\n");
+            return 1;
+        }
+        std::printf("RECOVERED-MARKED prev_ran=%d\n",
+                    static_cast<int>(g_prev_ran));
+        return 0;
+    }
+
+    std::fprintf(stderr, "unknown mode: %s\n", mode);
+    return 64;
+}

--- a/driver/portable/tests/run-fatal-backstop-test.sh
+++ b/driver/portable/tests/run-fatal-backstop-test.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Hermetic test for the embedded-driver fatal-signal backstop.
+#
+# Compiles fatal_backstop_test.cpp (which includes the real
+# driver/portable/src/fatal_backstop.hpp) and asserts the contract across
+# all five fatal signals:
+#   * marked driver thread        -> diagnostic emitted + dies by the signal
+#   * unmarked thread             -> NO diagnostic + chains to prev (recovers)
+#   * marked + recovering prev    -> diagnostic AND chains to prev (recovers)
+#
+# No pie/ggml/Metal build needed; runs on macOS and Linux.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+src="$here/fatal_backstop_test.cpp"
+bin="$(mktemp -t fatal_backstop_test.XXXXXX)"
+trap 'rm -f "$bin"' EXIT
+
+cxx="${CXX:-c++}"
+echo "== compiling fatal_backstop_test ($cxx, c++20) =="
+"$cxx" -std=c++20 -Wall -Wextra -O0 -g "$src" -o "$bin" -lpthread
+
+pass=0
+fail=0
+note() { printf '  %s\n' "$*"; }
+ok()   { pass=$((pass + 1)); printf 'PASS: %s\n' "$*"; }
+bad()  { fail=$((fail + 1)); printf 'FAIL: %s\n' "$*"; }
+
+DIAG_RE='\[pie-driver-portable\] fatal: caught'
+
+# marked: diagnostic present + terminated by the raised signal.
+test_marked() {
+    local signame="$1"
+    local signum; signum="$("$bin" signum "$signame")"
+    local err; err="$(mktemp)"
+    set +e
+    "$bin" marked "$signame" 2>"$err"
+    local rc=$?
+    set -e
+    local body; body="$(cat "$err")"; rm -f "$err"
+
+    if [[ $rc -le 128 ]]; then
+        bad "marked $signame: expected death-by-signal (rc>128), got rc=$rc"; return
+    fi
+    if [[ $((rc - 128)) -ne $signum ]]; then
+        bad "marked $signame: died by $((rc - 128)), expected $signum"; return
+    fi
+    if ! grep -Eq "$DIAG_RE $signame \(model=/test/model.gguf\)" <<<"$body"; then
+        bad "marked $signame: diagnostic line missing/wrong: [$body]"; return
+    fi
+    ok "marked $signame: diagnostic emitted + died by $signame (rc=$rc)"
+}
+
+# unmarked: NO diagnostic + recovered via chain to the prev handler.
+test_unmarked() {
+    local signame="$1"
+    local out err; out="$(mktemp)"; err="$(mktemp)"
+    set +e
+    "$bin" unmarked "$signame" >"$out" 2>"$err"
+    local rc=$?
+    set -e
+    local sout serr; sout="$(cat "$out")"; serr="$(cat "$err")"; rm -f "$out" "$err"
+
+    if [[ $rc -ne 0 ]]; then
+        bad "unmarked $signame: expected recovery (rc=0), got rc=$rc [$serr]"; return
+    fi
+    if grep -Eq "$DIAG_RE" <<<"$serr"; then
+        bad "unmarked $signame: diagnostic leaked on a non-driver thread: [$serr]"; return
+    fi
+    if ! grep -q "RECOVERED prev_ran=1" <<<"$sout"; then
+        bad "unmarked $signame: prev handler not chained / no recovery: [$sout]"; return
+    fi
+    ok "unmarked $signame: no diagnostic + chained to prev (recovered)"
+}
+
+# marked + recovering prev: diagnostic AND chain runs (recovers).
+test_marked_recover() {
+    local signame="$1"
+    local out err; out="$(mktemp)"; err="$(mktemp)"
+    set +e
+    "$bin" marked_recover "$signame" >"$out" 2>"$err"
+    local rc=$?
+    set -e
+    local sout serr; sout="$(cat "$out")"; serr="$(cat "$err")"; rm -f "$out" "$err"
+
+    if [[ $rc -ne 0 ]]; then
+        bad "marked_recover $signame: expected recovery (rc=0), got rc=$rc [$serr]"; return
+    fi
+    if ! grep -Eq "$DIAG_RE $signame" <<<"$serr"; then
+        bad "marked_recover $signame: diagnostic missing: [$serr]"; return
+    fi
+    if ! grep -q "RECOVERED-MARKED prev_ran=1" <<<"$sout"; then
+        bad "marked_recover $signame: prev handler not chained: [$sout]"; return
+    fi
+    ok "marked_recover $signame: diagnostic emitted AND chained to prev"
+}
+
+for s in SIGSEGV SIGBUS SIGILL SIGFPE SIGABRT; do
+    test_marked "$s"
+done
+# Chain/gate behavior is signal-independent; SIGSEGV/SIGBUS are the wasm
+# guard-page signals that matter most on Linux.
+for s in SIGSEGV SIGBUS; do
+    test_unmarked "$s"
+    test_marked_recover "$s"
+done
+
+echo
+echo "== fatal_backstop: $pass passed, $fail failed =="
+[[ $fail -eq 0 ]]

--- a/driver/portable/tests/run-fatal-backstop-test.sh
+++ b/driver/portable/tests/run-fatal-backstop-test.sh
@@ -28,6 +28,10 @@ bad()  { fail=$((fail + 1)); printf 'FAIL: %s\n' "$*"; }
 
 DIAG_RE='\[pie-driver-portable\] fatal: caught'
 
+# Existing cases run under Linux semantics (wasm traps reach the handler):
+# that is the regime where the thread-local gate matters.
+export PIE_BACKSTOP_FORCE_WASM_TRAPS=1
+
 # marked: diagnostic present + terminated by the raised signal.
 test_marked() {
     local signame="$1"
@@ -95,6 +99,32 @@ test_marked_recover() {
     ok "marked_recover $signame: diagnostic emitted AND chained to prev"
 }
 
+# worker: an unmarked compute-worker thread under Apple/Mach semantics
+# (wasm traps cannot reach the handler) -> diagnostic still emitted +
+# terminated by the signal. This is the inference-time ggml-worker fault
+# F2 is about. Runs in a subshell so the FORCE override is local.
+test_worker() {
+    local signame="$1"
+    local signum; signum="$("$bin" signum "$signame")"
+    local err; err="$(mktemp)"
+    set +e
+    ( PIE_BACKSTOP_FORCE_WASM_TRAPS=0 "$bin" worker "$signame" ) 2>"$err"
+    local rc=$?
+    set -e
+    local body; body="$(cat "$err")"; rm -f "$err"
+
+    if [[ $rc -le 128 ]]; then
+        bad "worker $signame: expected death-by-signal (rc>128), got rc=$rc"; return
+    fi
+    if [[ $((rc - 128)) -ne $signum ]]; then
+        bad "worker $signame: died by $((rc - 128)), expected $signum"; return
+    fi
+    if ! grep -Eq "$DIAG_RE $signame \(model=/test/model.gguf\)" <<<"$body"; then
+        bad "worker $signame: diagnostic missing on unmarked worker (Mach): [$body]"; return
+    fi
+    ok "worker $signame: unmarked worker fault surfaced + died by $signame (rc=$rc)"
+}
+
 for s in SIGSEGV SIGBUS SIGILL SIGFPE SIGABRT; do
     test_marked "$s"
 done
@@ -103,6 +133,10 @@ done
 for s in SIGSEGV SIGBUS; do
     test_unmarked "$s"
     test_marked_recover "$s"
+done
+# Inference-time worker-thread coverage on Mach-port platforms (#691 F2).
+for s in SIGSEGV SIGBUS; do
+    test_worker "$s"
 done
 
 echo


### PR DESCRIPTION
Sibling PRs for this ticket:
- shsym/RatioThink#268 — https://github.com/shsym/RatioThink/pull/268

## What

Surface the cause of any uncatchable native fault on the embedded driver thread (SIGBUS/SIGSEGV/SIGILL/SIGFPE/SIGABRT), not just the truncated-GGUF SIGBUS the #688 bounds guard covers. Previously such a fault killed the whole host process with no surfaced cause: the C++ run wrappers catch only `std::exception`, host-side exit detection sees only a clean nonzero rc, and the driver is launched with `install_signal_handlers=0`.

## How

- New header-only `driver/portable/src/fatal_backstop.hpp`, installed at the top of `run_impl` before model load (so a load-time fault is caught too). It writes an async-signal-safe `[pie-driver-portable] fatal: caught <SIG> (model=...)` to stderr, then chains to the previously-installed disposition so the process still terminates with the correct signal status. No new FFI surface — surfaces via stderr, leaving `run_inproc`/`InProcVTable` untouched.
- wasmtime coexistence via a thread-local "driver thread" gate: wasmtime executes wasm only on host worker threads, never on the driver thread, so a fault on the driver thread is always a real driver fault (emit + chain to die). On any other thread we emit nothing and chain straight through, so wasm guard-page recovery is byte-for-byte preserved (the saved prev handler's `ctx` is the one the kernel `sigreturn`s into). macOS uses Mach exception ports, so the sigaction handler never even sees an expected wasm trap.

## Tests

`driver/portable/tests/run-fatal-backstop-test.sh` (hermetic, no ggml/Metal build needed): 9/9 covering emit / gate / chain / exit-status across all five signals. Mutation-proven — breaking the gate (always-emit) or the chain (no prev invocation) fails the suite. Also verified in the real Metal build: engine boots + serves (real-model + HTTP e2e) with the backstop installed and no spurious diagnostics.

## Scope

Portable flavor only. cuda can adopt the same header once the Linux/wasmtime guard-page recovery is verified on a Linux host (cannot be exercised on macOS). dummy (Rust, memory-safe) cannot native-fault.