### PR TITLE
fix: ToT KV-pressure crashes — free pages on context drop + break collect_* on starvation

### DIFF
--- a/runtime/src/api/context.rs
+++ b/runtime/src/api/context.rs
@@ -233,18 +233,31 @@ impl pie::core::context::HostContext for InstanceState {
     }
 
     async fn drop(&mut self, this: Resource<Context>) -> Result<()> {
-        // Pull ctx + model identifiers BEFORE we release the table
-        // entry — the resource handle is invalid after delete.
+        // Free the context's KV pages when the guest drops the handle — each
+        // WIT Context resource maps 1:1 to a ContextId, so a dropped handle
+        // means the guest is done with that context. A whole-instance
+        // DestroyAll still runs on instance teardown for anything still live,
+        // but deferring ALL cleanup to teardown leaks every intermediate
+        // context for the lifetime of a long-lived daemon inferlet (chat-apc
+        // serves every request on ONE instance). The tree-of-thought search
+        // forks many transient contexts per request — children, per-node
+        // value-scoring forks, pruned beam losers — and relied on this drop
+        // to reclaim them; without eager freeing the KV pool is exhausted and
+        // the engine wedges (#679). Named snapshots are unaffected:
+        // `save`/`snapshot` persist a SEPARATE `owner: None` context id, so
+        // destroying the live owned context here never touches them.
+        //
+        // Pull ctx + model identifiers BEFORE we release the table entry —
+        // the resource handle is invalid after delete. Drop the speculation
+        // chain while the ctx still exists so any in-flight BatchComplete
+        // handler that races us sees a coherent state (chain gone → output
+        // silently discarded). Idempotent if no chain exists.
         let (model_id, context_id) = {
             let ctx = self.ctx().table.get(&this)?;
             (ctx.model_id, ctx.context_id)
         };
-        // Drop the speculation chain associated with this ctx. The
-        // ctx itself stays alive for the process's wider cleanup
-        // path (InstanceState::drop → unregister_process); only the
-        // speculative state attached to it goes away here. Idempotent
-        // if no chain exists.
         crate::inference::invalidate_speculation_for_ctx(model_id, context_id);
+        let _ = context::destroy(model_id, context_id).await;
         self.ctx().table.delete(this)?;
         Ok(())
     }

--- a/sdk/rust/inferlet/src/generation.rs
+++ b/sdk/rust/inferlet/src/generation.rs
@@ -34,6 +34,32 @@ use std::collections::VecDeque;
 
 const GENERATION_RESERVATION_WINDOW_TOKENS: u32 = 512;
 
+/// Diagnostic returned by the `collect_*` sugars when a generation step
+/// comes back with no sampled token — see [`forward_pass_starved`].
+const STARVED_MESSAGE: &str =
+    "forward_pass_starved: engine produced no tokens for a decode step \
+     (device failure, per-batch timeout, or KV eviction); generation cannot continue";
+
+/// True when a generation step came back with **no sampled token**: the
+/// host returned zero `Token` slots for a decode that had the auto-sampler
+/// attached.
+///
+/// pie's scheduler folds a forward-pass failure / per-batch timeout /
+/// mid-stream KV eviction into an empty `Output` (`Ok`, **not** `Err`).
+/// The `collect_*` loops fold that as "0 tokens accepted", which never
+/// advances `tokens_generated` and never errors — so the loop neither hits
+/// `max_tokens` nor a stop token. It spins, and the next step issues an
+/// empty-input forward pass that hangs the driver (the tree-of-thought
+/// daemon crash in #679; the same class the chat-completions loop guards
+/// against in #439). A natural stop is NOT starvation: the host still
+/// samples and returns `Token(stop)`, so a `Token` slot is present and this
+/// returns `false` (the SDK truncates that stop token out of
+/// `Output::tokens` afterward — which is why this inspects the raw slots,
+/// not `out.tokens`).
+fn forward_pass_starved(slots: &[SlotOutput]) -> bool {
+    !slots.iter().any(|s| matches!(s, SlotOutput::Token(_)))
+}
+
 // Re-export so callers don't have to pull from `context` directly.
 pub use crate::context::{Constrain, GrammarConstraint, Schema};
 
@@ -368,10 +394,16 @@ impl<'ctx> Generator<'ctx> {
     // ── Terminal sugar ─────────────────────────────────────────────────
 
     /// Run to completion; return the full token stream.
+    ///
+    /// Terminates with [`STARVED_MESSAGE`] if a forward pass comes back with
+    /// no sampled token (see [`forward_pass_starved`]).
     pub async fn collect_tokens(mut self) -> Result<Vec<u32>> {
         let mut all = Vec::new();
         while let Some(step) = self.next()? {
             let out = step.execute().await?;
+            if forward_pass_starved(&out.raw().slots) {
+                return Err(STARVED_MESSAGE.to_string());
+            }
             all.extend(out.tokens);
         }
         Ok(all)
@@ -384,6 +416,9 @@ impl<'ctx> Generator<'ctx> {
         let mut text = String::new();
         while let Some(step) = self.next()? {
             let out = step.execute().await?;
+            if forward_pass_starved(&out.raw().slots) {
+                return Err(STARVED_MESSAGE.to_string());
+            }
             match decoder.feed(&out.tokens)? {
                 chat::Event::Delta(s) => text.push_str(&s),
                 chat::Event::Done(s) => return Ok(s),
@@ -818,5 +853,42 @@ impl<'g, 'ctx> GenStep<'g, 'ctx> {
             Some(SampleHandle::new(0, 1))
         };
         Ok(crate::forward::Output::from_generator(raw, tokens, auto))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::forward_pass_starved;
+    use crate::pie::core::inference::SlotOutput;
+
+    // The starvation predicate the `collect_*` sugars use to break the
+    // hang-on-eviction loop (#679 / #439). Mirrors the chat-completions
+    // guard so the tree-of-thought generation path is protected too.
+
+    #[test]
+    fn starved_when_no_slots() {
+        // pie's scheduler hands back an empty Output (Ok, not Err) on a
+        // device failure / per-batch timeout / mid-stream KV eviction.
+        assert!(forward_pass_starved(&[]));
+    }
+
+    #[test]
+    fn not_starved_when_a_token_was_sampled() {
+        assert!(!forward_pass_starved(&[SlotOutput::Token(5)]));
+    }
+
+    #[test]
+    fn not_starved_when_a_token_rides_with_probe_slots() {
+        // A stop step still samples Token(stop) (later truncated out of
+        // Output::tokens), so a Token slot is present → not starved.
+        assert!(!forward_pass_starved(&[
+            SlotOutput::Token(2),
+            SlotOutput::Entropy(0.5),
+        ]));
+    }
+
+    #[test]
+    fn starved_when_only_non_token_slots() {
+        assert!(forward_pass_starved(&[SlotOutput::Entropy(0.5)]));
     }
 }


### PR DESCRIPTION
Two complementary fixes for the tree-of-thought daemon crash under KV pressure.

## 1. `fix(context): free KV pages on guest context drop (RAII)` — 528e8bdd

The host WIT context `drop` handler only deleted the wasm resource-table entry and deferred **all** KV-page cleanup to whole-instance `DestroyAll`. A long-lived daemon inferlet (one instance serves every request), and ToT forks many transient contexts per request (`breadth` children + a value-scoring fork per node + spent parents). Those dropped forks' pages were never reclaimed → a heavy tree's fork allocations defer in `when_allocated` waiting on pages only the leaked contexts hold → deadlock.

Free the context eagerly on drop (each WIT `Context` maps 1:1 to a `ContextId`). Snapshots unaffected (separate `owner:None` id). Verified before/after on real portable-Metal: unfixed deadlocks on a heavy tree, fixed completes 3/3.

## 2. `fix(generation): break collect_* on forward-pass starvation` — 2714bd22

The **direct** fix. pie's scheduler folds a device failure / per-batch timeout / mid-stream KV eviction into an empty `Output` (`Ok`, not `Err`). The SDK `Generator::collect_tokens`/`collect_text` sugars folded that as "0 tokens accepted" — never advancing `tokens_generated`, never hitting `max_tokens`/stop — so they **spun**, and the next empty-input forward pass hung the driver ("Server disconnected without sending a response", port dead, driver healthy).

The chat-completions loop already guards this in its own hand-rolled loop, but ToT generates every node + value score via `collect_text`, which had no guard. Add the same starvation predicate (a step whose raw host slots carry no `Token` slot) to the `collect_*` sugars — terminate with a clear error instead of spinning. A natural stop is not starvation (the host still samples `Token(stop)`, later truncated out of `Output::tokens`). Unit-tested (4 cases).

## Tests
- `cargo test --lib` (inferlet SDK): 25 passed incl. 4 starvation-predicate tests.
- Downstream: dummy-driver HTTP e2e 202/1-skip; chat-apc native 106; deep-tree deadlock regression 3/3 (real Metal).
