### PR TITLE
fix(portable): key uniform-sample reshape on slot count, not request count

### DIFF
--- a/driver/portable/src/graph_common.hpp
+++ b/driver/portable/src/graph_common.hpp
@@ -94,7 +94,7 @@ struct GraphInputs {
     ggml_tensor*              tok_input;   // I32 [total_n_tokens]
     ggml_tensor*              pos_input;   // I32 [total_n_tokens]
     ggml_tensor*              kv_idxs;     // I64 [total_n_tokens] (write idxs)
-    ggml_tensor*              out_idx;     // I32 [n_request]
+    ggml_tensor*              out_idx;     // I32 [n_sample_slots] (>= n_request under spec decode)
     // Slow path (per-request): one mask + gather tensor per request.
     std::vector<ggml_tensor*> masks;       // F16 [n_kv_r, n_tokens_pad_r]
     // Phi-3-small only: per-request blocksparse-clipped mask used by

--- a/driver/portable/src/graph_gemma4.cpp
+++ b/driver/portable/src/graph_gemma4.cpp
@@ -522,9 +522,12 @@ GraphResult build_gemma4_graph(ggml_context* ctx,
         ggml_tensor* probs = ggml_soft_max_ext(ctx, logits, /*mask=*/nullptr,
                                                 /*scale=*/inv_t, /*max_bias=*/0.0f);
         top_k_idx = ggml_top_k(ctx, probs, plan.uniform_top_k);
-        ggml_tensor* probs_3d = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_req);
+        // n_slots (sampled rows), not n_req: speculation samples >1 slot
+        // per request, so n_slots >= n_req.
+        const std::int64_t n_slots = probs->ne[1];
+        ggml_tensor* probs_3d = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_slots);
         ggml_tensor* gathered = ggml_get_rows(ctx, probs_3d, top_k_idx);
-        top_k_probs = ggml_reshape_2d(ctx, gathered, plan.uniform_top_k, n_req);
+        top_k_probs = ggml_reshape_2d(ctx, gathered, plan.uniform_top_k, n_slots);
         ggml_set_name(top_k_idx,   "top_k_idx");
         ggml_set_name(top_k_probs, "top_k_probs");
         ggml_set_output(top_k_idx);

--- a/driver/portable/src/graph_phi3_5moe.cpp
+++ b/driver/portable/src/graph_phi3_5moe.cpp
@@ -193,10 +193,13 @@ GraphResult build_phi3_5moe_graph(ggml_context* ctx,
         auto* probs = ggml_soft_max_ext(ctx, logits, /*mask=*/nullptr,
                                         /*scale=*/inv_t, /*max_bias=*/0.0f);
         auto* top_k_idx = ggml_top_k(ctx, probs, plan.uniform_top_k);
-        auto* probs_3d  = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_req);
+        // n_slots (sampled rows), not n_req: speculation samples >1 slot
+        // per request, so n_slots >= n_req.
+        const std::int64_t n_slots = probs->ne[1];
+        auto* probs_3d  = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_slots);
         auto* gathered  = ggml_get_rows(ctx, probs_3d, top_k_idx);
         auto* top_k_probs = ggml_reshape_2d(
-            ctx, gathered, plan.uniform_top_k, n_req);
+            ctx, gathered, plan.uniform_top_k, n_slots);
         ggml_set_name(top_k_idx, "top_k_idx");
         ggml_set_name(top_k_probs, "top_k_probs");
         ggml_set_output(top_k_idx);

--- a/driver/portable/src/graph_phi3small.cpp
+++ b/driver/portable/src/graph_phi3small.cpp
@@ -219,10 +219,13 @@ GraphResult build_phi3small_graph(ggml_context* ctx,
         auto* probs = ggml_soft_max_ext(ctx, logits, /*mask=*/nullptr,
                                         /*scale=*/inv_t, /*max_bias=*/0.0f);
         auto* top_k_idx = ggml_top_k(ctx, probs, plan.uniform_top_k);
-        auto* probs_3d  = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_req);
+        // n_slots (sampled rows), not n_req: speculation samples >1 slot
+        // per request, so n_slots >= n_req.
+        const std::int64_t n_slots = probs->ne[1];
+        auto* probs_3d  = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_slots);
         auto* gathered  = ggml_get_rows(ctx, probs_3d, top_k_idx);
         auto* top_k_probs = ggml_reshape_2d(
-            ctx, gathered, plan.uniform_top_k, n_req);
+            ctx, gathered, plan.uniform_top_k, n_slots);
         ggml_set_name(top_k_idx, "top_k_idx");
         ggml_set_name(top_k_probs, "top_k_probs");
         ggml_set_output(top_k_idx);

--- a/driver/portable/src/graph_qwen3.cpp
+++ b/driver/portable/src/graph_qwen3.cpp
@@ -840,10 +840,13 @@ GraphResult build_qwen3_graph(ggml_context* ctx,
         // the get_rows trick used by the MoE router (build_moe_ffn).
         // probs reshaped to [1, vocab, n_slots]; get_rows along ne[1]
         // with index [K, n_slots] yields [1, K, n_slots] → reshape.
+        // n_slots (sampled rows), not n_req: speculation samples >1 slot
+        // per request, so n_slots >= n_req.
+        const std::int64_t n_slots = probs->ne[1];
         ggml_tensor* probs_3d = ggml_reshape_3d(
-            ctx, probs, 1, h.vocab_size, n_req);
+            ctx, probs, 1, h.vocab_size, n_slots);
         ggml_tensor* gathered = ggml_get_rows(ctx, probs_3d, top_k_idx);
-        top_k_probs = ggml_reshape_2d(ctx, gathered, plan.uniform_top_k, n_req);
+        top_k_probs = ggml_reshape_2d(ctx, gathered, plan.uniform_top_k, n_slots);
 
         ggml_set_name(top_k_idx, "top_k_idx");
         ggml_set_name(top_k_probs, "top_k_probs");

--- a/driver/portable/src/graph_qwen3_5.cpp
+++ b/driver/portable/src/graph_qwen3_5.cpp
@@ -571,9 +571,12 @@ GraphResult build_qwen3_5_graph(ggml_context* ctx,
         ggml_tensor* probs = ggml_soft_max_ext(ctx, logits, /*mask=*/nullptr,
                                                 /*scale=*/inv_t, /*max_bias=*/0.0f);
         top_k_idx = ggml_top_k(ctx, probs, plan.uniform_top_k);
-        ggml_tensor* probs_3d = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_req);
+        // n_slots (sampled rows), not n_req: speculation samples >1 slot
+        // per request, so n_slots >= n_req.
+        const std::int64_t n_slots = probs->ne[1];
+        ggml_tensor* probs_3d = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_slots);
         ggml_tensor* gathered = ggml_get_rows(ctx, probs_3d, top_k_idx);
-        top_k_probs = ggml_reshape_2d(ctx, gathered, plan.uniform_top_k, n_req);
+        top_k_probs = ggml_reshape_2d(ctx, gathered, plan.uniform_top_k, n_slots);
         ggml_set_name(top_k_idx,   "top_k_idx");
         ggml_set_name(top_k_probs, "top_k_probs");
         ggml_set_output(top_k_idx);


### PR DESCRIPTION
**Problem:** the portable non-greedy uniform top-k fast path reshapes the per-slot probability tensor with `n_req` as the trailing dim. `probs` has one row per sampling *slot*, and speculation samples >1 slot per request (`n_slots > n_req`), so `ggml_reshape` trips `GGML_ASSERT(nelements...)` and the driver dies mid-stream. Greedy (`argmax`) is per-slot and unaffected, so only non-greedy sampling under speculation (e.g. tree-of-thought at temperature > 0) hits it.

**Fix:** key both reshapes on the actual slot count (`probs->ne[1]`). With one slot per request `n_slots == n_req`, so non-speculative decoding is unchanged. Same defect/fix across all arch graph builders: qwen3, qwen3.5, gemma4, phi3-small, phi3.5-moe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tensor dimension calculations in top-k sampling operations across Gemma4, Phi3.5-MoE, Phi3-Small, Qwen3, and Qwen3.5 models to correctly handle scenarios with multiple samples per request.

* **Documentation**
  * Updated tensor shape specifications for output indices to reflect correct dimensionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->