### PR TITLE
fix(runtime,portable): correct Llama3 portable GGUF RoPE + stop on eom

### DIFF
--- a/driver/portable/src/graph_qwen3.cpp
+++ b/driver/portable/src/graph_qwen3.cpp
@@ -406,14 +406,18 @@ GraphResult build_qwen3_graph(ggml_context* ctx,
                                     rope_beta_fast, rope_beta_slow);
             }
         } else {
+            // Llama3 GGUFs use ggml normal RoPE pairing; NEOX rotates the
+            // wrong dimension pairs and the model attends incoherently.
+            const int rope_type = (h.arch == PieArch::Llama3)
+                ? GGML_ROPE_TYPE_NORMAL : GGML_ROPE_TYPE_NEOX;
             Q = ggml_rope_ext(ctx, Q, in.pos_input, c_rope,
-                              head_dim, GGML_ROPE_TYPE_NEOX, rope_n_ctx_orig,
+                              head_dim, rope_type, rope_n_ctx_orig,
                               layer_rope_theta, rope_freq_scale,
                               rope_ext_factor, rope_attn_factor,
                               rope_beta_fast, rope_beta_slow);
             if (!is_shared) {
                 K = ggml_rope_ext(ctx, K, in.pos_input, c_rope,
-                                  head_dim, GGML_ROPE_TYPE_NEOX, rope_n_ctx_orig,
+                                  head_dim, rope_type, rope_n_ctx_orig,
                                   layer_rope_theta, rope_freq_scale,
                                   rope_ext_factor, rope_attn_factor,
                                   rope_beta_fast, rope_beta_slow);

--- a/runtime/src/model/instruct/llama3.rs
+++ b/runtime/src/model/instruct/llama3.rs
@@ -119,7 +119,8 @@ pub struct LlamaInstruct {
 impl LlamaInstruct {
     pub fn new(tokenizer: Arc<Tokenizer>) -> Self {
         let encode = |s: &str| tokenizer.encode(s);
-        let stop_strs = ["<|eot_id|>", "<|end_of_text|>"];
+        // <|eom_id|> ends a tool/ipython message turn (Llama 3.1+).
+        let stop_strs = ["<|eot_id|>", "<|eom_id|>", "<|end_of_text|>"];
         let stop_ids: Vec<u32> = stop_strs
             .iter()
             .filter_map(|s| tokenizer.token_to_id(s))
@@ -328,6 +329,7 @@ mod tests {
             "<|start_header_id|>",
             "<|end_header_id|>",
             "<|eot_id|>",
+            "<|eom_id|>",
             "<|end_of_text|>",
             "system",
             "user",
@@ -373,7 +375,7 @@ mod tests {
     fn has_correct_stop_tokens() {
         let inst = llama3();
         let stop = inst.seal();
-        assert_eq!(stop.len(), 2);
+        assert_eq!(stop.len(), 3);
     }
 
     #[test]


### PR DESCRIPTION
**Problem:** Llama3 GGUFs use ggml's *normal* RoPE pairing (adjacent head values), but the shared qwen graph hard-codes `GGML_ROPE_TYPE_NEOX` for every arch. That rotates Llama Q/K with the wrong dimension pairs, so the model attends incoherently while tokenization/template look correct (e.g. Llama 3.1 answers a simple prompt with generic boilerplate). Separately, generation only stopped on `<|eot_id|>`/`<|end_of_text|>`, so Llama 3.1+ tool/ipython turns that end with `<|eom_id|>` ran on.

**Fix:** pick `rope_type` by arch (`Llama3` -> normal, else NEOX) in the portable graph; add `<|eom_id|>` to the Llama3 stop set. Regression: `has_correct_stop_tokens` now expects 3 stop ids.

Note: the fork carry-patch also rewired the Llama3 prompt prologue, but `main` already builds that via the Jinja chat template, so only the RoPE + eom parts apply here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rotational position embedding handling by selecting the correct RoPE variant per model architecture, improving attention behavior across different models.
  * Improved Llama3 instruction generation stopping accuracy by adding `<|eom_id|>` as an additional end marker.
* **Tests**
  * Updated the unit-test tokenizer vocabulary and stop-token count expectations to cover the new `<|eom_id|>` stop token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->