### PR TITLE
Dedupe uniform-top-K sampling reshape into graph_common; key on n_slots

### DIFF
--- a/driver/portable/CMakeLists.txt
+++ b/driver/portable/CMakeLists.txt
@@ -102,6 +102,10 @@ add_library(pie_driver_portable_lib STATIC
   src/sampler.cpp
   src/host_swap_pool.cpp
   src/adapter.cpp
+  # Test-only entry exercising build_sampling_outputs() from a pie-server
+  # #[cfg(test)] Rust test (driver/portable ctest never runs in CI). The
+  # symbol is GC'd out of release builds — no Rust code references it there.
+  src/graph_sampling_testhook.cpp
 )
 
 target_compile_options(pie_driver_portable_lib PRIVATE

--- a/driver/portable/src/graph_common.cpp
+++ b/driver/portable/src/graph_common.cpp
@@ -447,4 +447,58 @@ void upload_graph_inputs(const GraphResult& g,
     }
 }
 
+void build_sampling_outputs(ggml_context* ctx,
+                            ggml_cgraph*  gf,
+                            ggml_tensor*  logits,
+                            const Executor::BatchPlan& plan,
+                            GraphResult&  res) {
+    if (plan.all_greedy) {
+        // GPU-greedy fast path: argmax along the vocab axis on-device. The
+        // caller downloads only n_slots i32 ids; the F32 logits block
+        // never becomes a graph output, so gallocr skips its backing
+        // buffer.
+        ggml_tensor* tokens_out = ggml_argmax(ctx, logits);
+        ggml_set_name(tokens_out, "tokens_out");
+        ggml_set_output(tokens_out);
+        ggml_build_forward_expand(gf, tokens_out);
+        res.tokens_out = tokens_out;
+    } else if (plan.uniform_top_sample) {
+        // GPU non-greedy fast path: temperature-scaled softmax → probs,
+        // take top-K indices, gather the K matching probs. The caller
+        // downloads only K * n_slots * 8 bytes and finalizes per-slot
+        // top-p / min-p / sample host-side.
+        const float inv_t = 1.0f / plan.reqs[0].sampler.temperature;
+        ggml_tensor* probs = ggml_soft_max_ext(ctx, logits, /*mask=*/nullptr,
+                                               /*scale=*/inv_t,
+                                               /*max_bias=*/0.0f);
+        // probs is [vocab, n_slots]; ggml_top_k yields indices [K, n_slots]
+        // sorted descending. Reshape probs to [1, vocab, n_slots] so
+        // get_rows gathers along ne[1] → [1, K, n_slots], then flatten to
+        // [K, n_slots]. Both reshapes key on the slot count probs->ne[1],
+        // which is >= n_req under speculation (see header).
+        const std::int64_t vocab   = probs->ne[0];
+        const std::int64_t n_slots = probs->ne[1];
+        ggml_tensor* top_k_idx = ggml_top_k(ctx, probs, plan.uniform_top_k);
+        ggml_tensor* probs_3d  = ggml_reshape_3d(ctx, probs, 1, vocab, n_slots);
+        ggml_tensor* gathered  = ggml_get_rows(ctx, probs_3d, top_k_idx);
+        ggml_tensor* top_k_probs =
+            ggml_reshape_2d(ctx, gathered, plan.uniform_top_k, n_slots);
+        ggml_set_name(top_k_idx,   "top_k_idx");
+        ggml_set_name(top_k_probs, "top_k_probs");
+        ggml_set_output(top_k_idx);
+        ggml_set_output(top_k_probs);
+        ggml_build_forward_expand(gf, top_k_idx);
+        ggml_build_forward_expand(gf, top_k_probs);
+        res.top_k_idx   = top_k_idx;
+        res.top_k_probs = top_k_probs;
+    } else {
+        // Slow path: materialize the full [vocab, n_slots] logits block;
+        // the host sampler handles every per-slot cut and the draw.
+        ggml_set_name(logits, "logits");
+        ggml_set_output(logits);
+        ggml_build_forward_expand(gf, logits);
+        res.logits = logits;
+    }
+}
+
 }  // namespace pie_portable_driver

--- a/driver/portable/src/graph_common.hpp
+++ b/driver/portable/src/graph_common.hpp
@@ -141,6 +141,25 @@ struct GraphResult {
 void upload_graph_inputs(const GraphResult& g,
                          const Executor::BatchPlan& plan);
 
+// Build the GPU-side sampling output tensors from the final `logits` and
+// attach them to the graph, then record them on `res`. This is the shared
+// tail of every per-arch graph builder. Exactly one path fires, matched
+// against the BatchPlan sampler flags:
+//   all_greedy        → res.tokens_out  (on-device ggml_argmax)
+//   uniform_top_sample → res.top_k_idx + res.top_k_probs (top-K + gather)
+//   else              → res.logits      (raw block; host samples)
+//
+// The uniform-top-K gather reshapes key on the slot count `probs->ne[1]`
+// (= n_slots), NOT the request count: pass-level speculation samples more
+// than one slot per request (draft verification), so n_slots >= n_req.
+// Keying on n_req trips GGML's `nelements == ne0*ne1*ne2` assert once
+// speculation widens the batch.
+void build_sampling_outputs(ggml_context* ctx,
+                            ggml_cgraph*  gf,
+                            ggml_tensor*  logits,
+                            const Executor::BatchPlan& plan,
+                            GraphResult&  res);
+
 // Allocate the standard set of per-batch graph input tensors
 // (`tok_input`, `pos_input`, `kv_idxs`, `out_idx`) plus either the
 // packed-decode pair (`packed_gather` + `packed_mask`) or per-request

--- a/driver/portable/src/graph_gemma4.cpp
+++ b/driver/portable/src/graph_gemma4.cpp
@@ -509,43 +509,10 @@ GraphResult build_gemma4_graph(ggml_context* ctx,
     }
 
     // GPU-side sampler fast paths (mirror graph_qwen3 / graph_qwen3_5).
-    ggml_tensor* tokens_out  = nullptr;
-    ggml_tensor* top_k_idx   = nullptr;
-    ggml_tensor* top_k_probs = nullptr;
-    if (plan.all_greedy) {
-        tokens_out = ggml_argmax(ctx, logits);
-        ggml_set_name(tokens_out, "tokens_out");
-        ggml_set_output(tokens_out);
-        ggml_build_forward_expand(gf, tokens_out);
-    } else if (plan.uniform_top_sample) {
-        const float inv_t = 1.0f / plan.reqs[0].sampler.temperature;
-        ggml_tensor* probs = ggml_soft_max_ext(ctx, logits, /*mask=*/nullptr,
-                                                /*scale=*/inv_t, /*max_bias=*/0.0f);
-        top_k_idx = ggml_top_k(ctx, probs, plan.uniform_top_k);
-        // n_slots (sampled rows), not n_req: speculation samples >1 slot
-        // per request, so n_slots >= n_req.
-        const std::int64_t n_slots = probs->ne[1];
-        ggml_tensor* probs_3d = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_slots);
-        ggml_tensor* gathered = ggml_get_rows(ctx, probs_3d, top_k_idx);
-        top_k_probs = ggml_reshape_2d(ctx, gathered, plan.uniform_top_k, n_slots);
-        ggml_set_name(top_k_idx,   "top_k_idx");
-        ggml_set_name(top_k_probs, "top_k_probs");
-        ggml_set_output(top_k_idx);
-        ggml_set_output(top_k_probs);
-        ggml_build_forward_expand(gf, top_k_idx);
-        ggml_build_forward_expand(gf, top_k_probs);
-    } else {
-        ggml_set_name(logits, "logits");
-        ggml_set_output(logits);
-        ggml_build_forward_expand(gf, logits);
-    }
-
     GraphResult res{};
     res.gf = gf;
-    if (plan.all_greedy)              res.tokens_out = tokens_out;
-    else if (plan.uniform_top_sample) { res.top_k_idx = top_k_idx; res.top_k_probs = top_k_probs; }
-    else                               res.logits = logits;
     res.in = in;
+    build_sampling_outputs(ctx, gf, logits, plan, res);
     return res;
 }
 

--- a/driver/portable/src/graph_phi3_5moe.cpp
+++ b/driver/portable/src/graph_phi3_5moe.cpp
@@ -182,38 +182,7 @@ GraphResult build_phi3_5moe_graph(ggml_context* ctx,
     GraphResult r;
     r.gf = gf;
     r.in = in;
-    if (plan.all_greedy) {
-        auto* tokens_out = ggml_argmax(ctx, logits);
-        ggml_set_name(tokens_out, "tokens_out");
-        ggml_set_output(tokens_out);
-        ggml_build_forward_expand(gf, tokens_out);
-        r.tokens_out = tokens_out;
-    } else if (plan.uniform_top_sample) {
-        const float inv_t = 1.0f / plan.reqs[0].sampler.temperature;
-        auto* probs = ggml_soft_max_ext(ctx, logits, /*mask=*/nullptr,
-                                        /*scale=*/inv_t, /*max_bias=*/0.0f);
-        auto* top_k_idx = ggml_top_k(ctx, probs, plan.uniform_top_k);
-        // n_slots (sampled rows), not n_req: speculation samples >1 slot
-        // per request, so n_slots >= n_req.
-        const std::int64_t n_slots = probs->ne[1];
-        auto* probs_3d  = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_slots);
-        auto* gathered  = ggml_get_rows(ctx, probs_3d, top_k_idx);
-        auto* top_k_probs = ggml_reshape_2d(
-            ctx, gathered, plan.uniform_top_k, n_slots);
-        ggml_set_name(top_k_idx, "top_k_idx");
-        ggml_set_name(top_k_probs, "top_k_probs");
-        ggml_set_output(top_k_idx);
-        ggml_set_output(top_k_probs);
-        ggml_build_forward_expand(gf, top_k_idx);
-        ggml_build_forward_expand(gf, top_k_probs);
-        r.top_k_idx = top_k_idx;
-        r.top_k_probs = top_k_probs;
-    } else {
-        ggml_set_name(logits, "logits");
-        ggml_set_output(logits);
-        ggml_build_forward_expand(gf, logits);
-        r.logits = logits;
-    }
+    build_sampling_outputs(ctx, gf, logits, plan, r);
     return r;
 }
 

--- a/driver/portable/src/graph_phi3small.cpp
+++ b/driver/portable/src/graph_phi3small.cpp
@@ -208,38 +208,7 @@ GraphResult build_phi3small_graph(ggml_context* ctx,
     GraphResult r;
     r.gf = gf;
     r.in = in;
-    if (plan.all_greedy) {
-        auto* tokens_out = ggml_argmax(ctx, logits);
-        ggml_set_name(tokens_out, "tokens_out");
-        ggml_set_output(tokens_out);
-        ggml_build_forward_expand(gf, tokens_out);
-        r.tokens_out = tokens_out;
-    } else if (plan.uniform_top_sample) {
-        const float inv_t = 1.0f / plan.reqs[0].sampler.temperature;
-        auto* probs = ggml_soft_max_ext(ctx, logits, /*mask=*/nullptr,
-                                        /*scale=*/inv_t, /*max_bias=*/0.0f);
-        auto* top_k_idx = ggml_top_k(ctx, probs, plan.uniform_top_k);
-        // n_slots (sampled rows), not n_req: speculation samples >1 slot
-        // per request, so n_slots >= n_req.
-        const std::int64_t n_slots = probs->ne[1];
-        auto* probs_3d  = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_slots);
-        auto* gathered  = ggml_get_rows(ctx, probs_3d, top_k_idx);
-        auto* top_k_probs = ggml_reshape_2d(
-            ctx, gathered, plan.uniform_top_k, n_slots);
-        ggml_set_name(top_k_idx, "top_k_idx");
-        ggml_set_name(top_k_probs, "top_k_probs");
-        ggml_set_output(top_k_idx);
-        ggml_set_output(top_k_probs);
-        ggml_build_forward_expand(gf, top_k_idx);
-        ggml_build_forward_expand(gf, top_k_probs);
-        r.top_k_idx = top_k_idx;
-        r.top_k_probs = top_k_probs;
-    } else {
-        ggml_set_name(logits, "logits");
-        ggml_set_output(logits);
-        ggml_build_forward_expand(gf, logits);
-        r.logits = logits;
-    }
+    build_sampling_outputs(ctx, gf, logits, plan, r);
     return r;
 }
 

--- a/driver/portable/src/graph_qwen3.cpp
+++ b/driver/portable/src/graph_qwen3.cpp
@@ -819,71 +819,14 @@ GraphResult build_qwen3_graph(ggml_context* ctx,
         logits = ggml_scale(ctx, logits, spec.final_softcap);
     }
 
-    ggml_tensor* tokens_out  = nullptr;
-    ggml_tensor* top_k_idx   = nullptr;
-    ggml_tensor* top_k_probs = nullptr;
-    if (plan.all_greedy) {
-        // Greedy fast path: argmax along vocab axis on the GPU. Caller
-        // downloads only n_slots i32 ids; the F32 logits buffer never
-        // needs to be a graph output, so gallocr can avoid the
-        // ~vocab*n_slots*4-byte materialization. (CPU argmax in our
-        // host sampler uses first-wins-on-tie; the CUDA reduction picks
-        // a different tied index in rare exact-tie cases — both are
-        // valid greedy choices.)
-        tokens_out = ggml_argmax(ctx, logits);
-        ggml_set_name(tokens_out, "tokens_out");
-        ggml_set_output(tokens_out);
-        ggml_build_forward_expand(gf, tokens_out);
-    } else if (plan.uniform_top_sample) {
-        // Non-greedy uniform fast path: temperature-scale + softmax →
-        // probs, take top-K indices, gather K probs. Caller downloads
-        // only K * n_slots * 8 bytes (vs vocab * n_slots * 4 bytes for
-        // the slow path) and finalizes per-slot top-p / min-p / sample
-        // host-side.
-        const float inv_t = 1.0f / plan.reqs[0].sampler.temperature;
-        ggml_tensor* probs = ggml_soft_max_ext(ctx, logits, /*mask=*/ nullptr,
-                                               /*scale=*/ inv_t, /*max_bias=*/ 0.0f);
-        // ggml_top_k returns indices [K, n_slots] sorted descending.
-        top_k_idx = ggml_top_k(ctx, probs, plan.uniform_top_k);
-
-        // Gather the K probabilities matching those indices, mirroring
-        // the get_rows trick used by the MoE router (build_moe_ffn).
-        // probs reshaped to [1, vocab, n_slots]; get_rows along ne[1]
-        // with index [K, n_slots] yields [1, K, n_slots] → reshape.
-        // n_slots (sampled rows), not n_req: speculation samples >1 slot
-        // per request, so n_slots >= n_req.
-        const std::int64_t n_slots = probs->ne[1];
-        ggml_tensor* probs_3d = ggml_reshape_3d(
-            ctx, probs, 1, h.vocab_size, n_slots);
-        ggml_tensor* gathered = ggml_get_rows(ctx, probs_3d, top_k_idx);
-        top_k_probs = ggml_reshape_2d(ctx, gathered, plan.uniform_top_k, n_slots);
-
-        ggml_set_name(top_k_idx, "top_k_idx");
-        ggml_set_name(top_k_probs, "top_k_probs");
-        ggml_set_output(top_k_idx);
-        ggml_set_output(top_k_probs);
-        ggml_build_forward_expand(gf, top_k_idx);
-        ggml_build_forward_expand(gf, top_k_probs);
-    } else {
-        ggml_set_name(logits, "logits");
-        ggml_set_output(logits);
-        ggml_build_forward_expand(gf, logits);
-    }
-
+    // Emit the chosen sampling-stage output(s). Only one of tokens_out /
+    // top_k_{idx,probs} / logits is materialized; the others stay null and
+    // gallocr skips their backing buffers (most importantly the
+    // [vocab, n_slots] F32 logits block). Shared across all arch builders.
     GraphResult res{};
     res.gf = gf;
-    // Only one output is materialized depending on the chosen sampling
-    // path. The other two stay null and gallocr skips their backing
-    // buffers (most importantly the [vocab, n_slots] F32 logits block).
-    if (plan.all_greedy) {
-        res.tokens_out = tokens_out;
-    } else if (plan.uniform_top_sample) {
-        res.top_k_idx   = top_k_idx;
-        res.top_k_probs = top_k_probs;
-    } else {
-        res.logits = logits;
-    }
     res.in = std::move(in);
+    build_sampling_outputs(ctx, gf, logits, plan, res);
     return res;
 }
 

--- a/driver/portable/src/graph_qwen3_5.cpp
+++ b/driver/portable/src/graph_qwen3_5.cpp
@@ -567,43 +567,10 @@ GraphResult build_qwen3_5_graph(ggml_context* ctx,
     // Optional GPU-side sampler (mirrors graph_qwen3 fast paths). Saves
     // the ~vocab*n_slots*4-byte logits download on greedy / uniform-top-K
     // batches; the slow path materializes full logits.
-    ggml_tensor* tokens_out  = nullptr;
-    ggml_tensor* top_k_idx   = nullptr;
-    ggml_tensor* top_k_probs = nullptr;
-    if (plan.all_greedy) {
-        tokens_out = ggml_argmax(ctx, logits);
-        ggml_set_name(tokens_out, "tokens_out");
-        ggml_set_output(tokens_out);
-        ggml_build_forward_expand(gf, tokens_out);
-    } else if (plan.uniform_top_sample) {
-        const float inv_t = 1.0f / plan.reqs[0].sampler.temperature;
-        ggml_tensor* probs = ggml_soft_max_ext(ctx, logits, /*mask=*/nullptr,
-                                                /*scale=*/inv_t, /*max_bias=*/0.0f);
-        top_k_idx = ggml_top_k(ctx, probs, plan.uniform_top_k);
-        // n_slots (sampled rows), not n_req: speculation samples >1 slot
-        // per request, so n_slots >= n_req.
-        const std::int64_t n_slots = probs->ne[1];
-        ggml_tensor* probs_3d = ggml_reshape_3d(ctx, probs, 1, h.vocab_size, n_slots);
-        ggml_tensor* gathered = ggml_get_rows(ctx, probs_3d, top_k_idx);
-        top_k_probs = ggml_reshape_2d(ctx, gathered, plan.uniform_top_k, n_slots);
-        ggml_set_name(top_k_idx,   "top_k_idx");
-        ggml_set_name(top_k_probs, "top_k_probs");
-        ggml_set_output(top_k_idx);
-        ggml_set_output(top_k_probs);
-        ggml_build_forward_expand(gf, top_k_idx);
-        ggml_build_forward_expand(gf, top_k_probs);
-    } else {
-        ggml_set_name(logits, "logits");
-        ggml_set_output(logits);
-        ggml_build_forward_expand(gf, logits);
-    }
-
     GraphResult res{};
     res.gf = gf;
-    if (plan.all_greedy)             res.tokens_out = tokens_out;
-    else if (plan.uniform_top_sample) { res.top_k_idx = top_k_idx; res.top_k_probs = top_k_probs; }
-    else                              res.logits = logits;
     res.in = in;
+    build_sampling_outputs(ctx, gf, logits, plan, res);
     return res;
 }
 

--- a/driver/portable/src/graph_sampling_testhook.cpp
+++ b/driver/portable/src/graph_sampling_testhook.cpp
@@ -1,0 +1,71 @@
+// Test-only entry point exercising `build_sampling_outputs()` in isolation.
+//
+// Linked into `pie_driver_portable_lib` and called from a `#[cfg(test)]`
+// Rust test in pie-server (`cargo test -p pie-server`, which runs in CI;
+// the driver/portable ctest targets do not — see server/build.rs, which
+// only builds the `pie_driver_portable_lib` target).
+//
+// It builds the uniform-top-K sampling subgraph over a synthetic
+// `[vocab, n_slots]` logits tensor and reports the slot dimension
+// (`ne[1]`) of the resulting `top_k_probs` tensor. This lets the Rust test
+// assert the gather reshape keys on the slot count (`n_slots`, which is
+// `>= n_req` under pass-level speculation) rather than the request count:
+// keying on `n_req` trips GGML's `nelements == ne0*ne1*ne2` assert
+// whenever `n_slots != n_req`.
+//
+// No backend or compute is needed — `ggml_reshape_*` validates element
+// counts at graph-construction time, which is exactly the invariant under
+// test. In a release build no Rust code references this symbol, so the
+// linker garbage-collects this object out of the final binary.
+
+#include <cstddef>
+
+#include <ggml.h>
+
+#include "graph_common.hpp"
+
+// C linkage so the Rust side can declare it without name mangling. Returns
+// the slot dimension of `top_k_probs`, or a negative error code.
+extern "C" int pie_portable_test_uniform_top_slot_dim(int n_req,
+                                                      int n_slots,
+                                                      int k,
+                                                      int vocab) {
+    using namespace pie_portable_driver;
+
+    if (n_req <= 0 || n_slots <= 0 || k <= 0 || k > vocab) return -1;
+
+    ggml_init_params params{};
+    params.mem_size   = static_cast<std::size_t>(64) * 1024 * 1024;
+    params.mem_buffer = nullptr;
+    params.no_alloc   = true;
+    ggml_context* ctx = ggml_init(params);
+    if (ctx == nullptr) return -2;
+
+    ggml_cgraph* gf = ggml_new_graph(ctx);
+
+    // Synthetic final logits: [vocab, n_slots]. A batch of n_req requests
+    // produces n_slots sampling slots (n_slots >= n_req under speculation).
+    ggml_tensor* logits =
+        ggml_new_tensor_2d(ctx, GGML_TYPE_F32, vocab, n_slots);
+
+    Executor::BatchPlan plan;
+    plan.all_greedy         = false;
+    plan.uniform_top_sample = true;
+    plan.uniform_top_k      = k;
+    plan.reqs.resize(static_cast<std::size_t>(n_req));
+    for (auto& r : plan.reqs) {
+        r.sampler.temperature = 0.7f;
+    }
+
+    GraphResult res{};
+    res.gf = gf;
+    build_sampling_outputs(ctx, gf, logits, plan, res);
+
+    const int slot_dim =
+        res.top_k_probs != nullptr
+            ? static_cast<int>(res.top_k_probs->ne[1])
+            : -3;
+
+    ggml_free(ctx);
+    return slot_dim;
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -49,3 +49,45 @@ fn run() {
         std::process::exit(1);
     }
 }
+
+// Graph-build regression test for the portable driver's uniform-top-K
+// sampling reshape. The five per-arch graph builders share
+// `build_sampling_outputs`, whose gather reshape must key on the slot count
+// (`n_slots`) rather than the request count (`n_req`): pass-level
+// speculation samples more than one slot per request (draft verification),
+// so `n_slots >= n_req`. A test-only C entry in the portable driver builds
+// the sampling subgraph and reports the slot dimension of `top_k_probs`.
+//
+// This lives in the `pie` bin because CI runs `cargo test -p pie-server
+// --bin pie`, and the driver/portable ctest targets never run in CI.
+#[cfg(all(test, feature = "driver-portable"))]
+mod portable_graph_sampling_tests {
+    use std::os::raw::c_int;
+
+    unsafe extern "C" {
+        fn pie_portable_test_uniform_top_slot_dim(
+            n_req: c_int,
+            n_slots: c_int,
+            k: c_int,
+            vocab: c_int,
+        ) -> c_int;
+    }
+
+    fn slot_dim(n_req: i32, n_slots: i32, k: i32, vocab: i32) -> i32 {
+        unsafe { pie_portable_test_uniform_top_slot_dim(n_req, n_slots, k, vocab) }
+    }
+
+    // The speculation case: more sampling slots than requests. If a future
+    // change keys the gather reshape on n_req again, GGML's nelements
+    // assert aborts this process instead of returning n_slots.
+    #[test]
+    fn uniform_top_reshape_keys_on_n_slots_under_speculation() {
+        assert_eq!(slot_dim(2, 5, 8, 64), 5);
+    }
+
+    // Plain decode: one slot per request. The invariant must still hold.
+    #[test]
+    fn uniform_top_reshape_handles_n_slots_eq_n_req() {
+        assert_eq!(slot_dim(3, 3, 4, 32), 3);
+    }
+}


### PR DESCRIPTION
## What

The five portable graph builders (`graph_qwen3`, `graph_qwen3_5`, `graph_gemma4`, `graph_phi3_5moe`, `graph_phi3small`) each carried a byte-identical sampling-output tail (greedy `ggml_argmax` / uniform-top-K `top_k`+gather / raw logits). Factor it into a shared `build_sampling_outputs()` in `graph_common`; each builder's tail collapses to one call.

## Invariant guarded

The uniform-top-K gather reshape keys on the slot count `probs->ne[1]` (= n_slots), which is what the per-builder code already did after `dbc71826` fixed the n_req-vs-n_slots bug: pass-level speculation samples more than one slot per request (draft verification), so `n_slots >= n_req`, and a reshape keyed on `n_req` trips GGML's `nelements == ne0*ne1*ne2` assert. The helper derives both `vocab` and `n_slots` from `probs` itself, so the invariant lives in one place instead of five.

## Regression test

`graph_sampling_testhook.cpp` is a test-only C entry that builds the sampling subgraph over a synthetic `[vocab, n_slots]` logits tensor and reports `top_k_probs->ne[1]`. A `#[cfg(test)]` Rust test in the `pie` bin asserts it equals `n_slots`.

- Lives in the bin (not a driver ctest, which never runs in CI) so `cargo test -p pie-server --bin pie` exercises it.
- Mutation-verified: keying the reshape on `n_req` aborts via `GGML_ASSERT(ggml_nelements(a) == ne0*ne1*ne2)` (SIGABRT).
- Release builds GC the unreferenced test symbol — zero production cost.

## Verification

- `cargo test -p pie-server --bin pie` → 2 new tests pass; full suite green.
- App-side: `make test-e2e-http` 202 passed / 1 skipped at this pin.

Base `pie.app/v1-base-shmem`; branched from the app's current pin `2714bd22` so the app bump stays additive.