### PR TITLE
test(qwen35): unit guard for GGUF->HF mapper coverage + hparams derivation

### DIFF
--- a/driver/portable/CMakeLists.txt
+++ b/driver/portable/CMakeLists.txt
@@ -106,6 +106,11 @@ add_library(pie_driver_portable_lib STATIC
   # #[cfg(test)] Rust test (driver/portable ctest never runs in CI). The
   # symbol is GC'd out of release builds — no Rust code references it there.
   src/graph_sampling_testhook.cpp
+  # Test-only entries exercising gguf_to_hf_name + parse_gguf_hparams for the
+  # qwen35 hybrid arch from pie-server #[cfg(test)] Rust tests (driver/portable
+  # ctest never runs in CI). The symbols are GC'd out of release builds — no
+  # Rust code references them there.
+  src/qwen35_mapping_testhook.cpp
 )
 
 target_compile_options(pie_driver_portable_lib PRIVATE

--- a/driver/portable/src/gguf_archive.cpp
+++ b/driver/portable/src/gguf_archive.cpp
@@ -60,94 +60,14 @@ bool get_rows_supports(ggml_type t) {
     }
 }
 
-// GGUF tensor name → HF-canonical name. Currently covers the
-// Llama-family layout used by qwen3 / qwen2 / llama3 / mistral3 / olmo3
-// and Qwen3-MoE / Mixtral / gpt-oss MoE variants. Returns empty string
-// when a tensor has no canonical mapping (the caller keeps the raw
-// name; per-arch loaders that look up by HF name will simply not find
-// it, which is what we want for unknown-but-harmless extras).
-std::string gguf_to_hf_name(const std::string& g, bool gemma_norm_layout) {
-    // Top-level tensors.
-    if (g == "token_embd.weight")  return "model.embed_tokens.weight";
-    if (g == "output_norm.weight") return "model.norm.weight";
-    if (g == "output.weight")      return "lm_head.weight";
-
-    // Per-block: `blk.{N}.<part>` → `model.layers.{N}.<...>`.
-    const std::string blk = "blk.";
-    if (g.compare(0, blk.size(), blk) != 0) return {};
-    auto dot = g.find('.', blk.size());
-    if (dot == std::string::npos) return {};
-    const std::string n = g.substr(blk.size(), dot - blk.size());
-    const std::string suffix = g.substr(dot + 1);
-    const std::string layer = "model.layers." + n + ".";
-
-    // Norms.
-    if (suffix == "attn_norm.weight")        return layer + "input_layernorm.weight";
-    // `ffn_norm` is the pre-MLP norm. In the Llama family it is the only
-    // post-attention norm, so it maps to `post_attention_layernorm`. The
-    // Gemma family instead carries BOTH a distinct `post_attention_norm`
-    // (the post-attention norm) AND `ffn_norm` (the PRE-feedforward norm),
-    // so for gemma `ffn_norm` is the pre-feedforward layernorm.
-    if (suffix == "ffn_norm.weight")
-        return layer + (gemma_norm_layout ? "pre_feedforward_layernorm.weight"
-                                          : "post_attention_layernorm.weight");
-    if (suffix == "post_attention_norm.weight") return layer + "post_attention_layernorm.weight";
-    if (suffix == "post_ffw_norm.weight")    return layer + "post_feedforward_layernorm.weight";
-    // Gemma 4 per-layer residual scalar (HF `layer_scalar`).
-    if (suffix == "layer_output_scale.weight") return layer + "layer_scalar";
-    // Attention projections.
-    if (suffix == "attn_q.weight")           return layer + "self_attn.q_proj.weight";
-    if (suffix == "attn_k.weight")           return layer + "self_attn.k_proj.weight";
-    if (suffix == "attn_v.weight")           return layer + "self_attn.v_proj.weight";
-    if (suffix == "attn_output.weight")      return layer + "self_attn.o_proj.weight";
-    if (suffix == "attn_q.bias")             return layer + "self_attn.q_proj.bias";
-    if (suffix == "attn_k.bias")             return layer + "self_attn.k_proj.bias";
-    if (suffix == "attn_v.bias")             return layer + "self_attn.v_proj.bias";
-    if (suffix == "attn_output.bias")        return layer + "self_attn.o_proj.bias";
-    // Per-head q/k norms (Qwen 3, Olmo 3, Gemma 3).
-    if (suffix == "attn_q_norm.weight")      return layer + "self_attn.q_norm.weight";
-    if (suffix == "attn_k_norm.weight")      return layer + "self_attn.k_norm.weight";
-    // Dense FFN.
-    if (suffix == "ffn_gate.weight")         return layer + "mlp.gate_proj.weight";
-    if (suffix == "ffn_up.weight")           return layer + "mlp.up_proj.weight";
-    if (suffix == "ffn_down.weight")         return layer + "mlp.down_proj.weight";
-    // MoE: stacked-expert tensors land directly on the same canonical
-    // names our existing model.cpp uses for `moe_gate_exps` etc. We
-    // include both the qwen3_moe / mixtral / gpt-oss style stacked
-    // tensors and the legacy per-expert form (some converters still
-    // emit `blk.N.ffn_gate.E.weight`).
-    if (suffix == "ffn_gate_inp.weight")     return layer + "mlp.gate.weight";
-    if (suffix == "ffn_gate_exps.weight")    return layer + "mlp.experts.gate_proj.weight";
-    if (suffix == "ffn_up_exps.weight")      return layer + "mlp.experts.up_proj.weight";
-    if (suffix == "ffn_down_exps.weight")    return layer + "mlp.experts.down_proj.weight";
-    // Qwen 3.5 / 3.6 shared expert (qwen35moe). `ffn_gate_inp_shexp` is the
-    // 1-D sigmoid gate over the shared expert (HF `mlp.shared_expert_gate`),
-    // distinct from the per-token router `ffn_gate_inp`.
-    if (suffix == "ffn_gate_shexp.weight")     return layer + "mlp.shared_expert.gate_proj.weight";
-    if (suffix == "ffn_up_shexp.weight")       return layer + "mlp.shared_expert.up_proj.weight";
-    if (suffix == "ffn_down_shexp.weight")     return layer + "mlp.shared_expert.down_proj.weight";
-    if (suffix == "ffn_gate_inp_shexp.weight") return layer + "mlp.shared_expert_gate.weight";
-    // Qwen 3.5 / 3.6 hybrid gated-delta-rule linear attention. The GGUF
-    // (llama.cpp qwen35 convention) packs the linear-attn input projection
-    // as `attn_qkv` (the fused q/k/v of the delta net) + `attn_gate` (the
-    // output Z gate), and the gated-delta params as `ssm_*`. These names
-    // only ever appear on the *linear* layers; full-attention layers carry
-    // the ordinary `attn_q/k/v` handled above. The convert-time value
-    // transforms (A_log = -exp(raw); folded norm.weight +1) are inverted at
-    // load in `model.cpp::build_qwen3_5_`, not here.
-    if (suffix == "attn_qkv.weight")         return layer + "linear_attn.in_proj_qkv.weight";
-    if (suffix == "attn_gate.weight")        return layer + "linear_attn.in_proj_z.weight";
-    if (suffix == "ssm_alpha.weight")        return layer + "linear_attn.in_proj_a.weight";
-    if (suffix == "ssm_beta.weight")         return layer + "linear_attn.in_proj_b.weight";
-    if (suffix == "ssm_a")                   return layer + "linear_attn.A_log";
-    if (suffix == "ssm_dt.bias")             return layer + "linear_attn.dt_bias";
-    if (suffix == "ssm_conv1d.weight")       return layer + "linear_attn.conv1d.weight";
-    if (suffix == "ssm_norm.weight")         return layer + "linear_attn.norm.weight";
-    if (suffix == "ssm_out.weight")          return layer + "linear_attn.out_proj.weight";
-    return {};
-}
-
 }  // namespace
+
+// `gguf_to_hf_name` is defined `inline` in gguf_archive.hpp so the
+// qwen35 mapper-coverage testhook (a separate TU) carries its own copy and
+// does not depend on this object being pulled into the test binary's link
+// (the dummy/portable `--bin pie` test never instantiates GGUFArchive, so
+// gc-sections would otherwise drop the definition and leave the testhook's
+// reference undefined).
 
 void GGUFArchive::close_mmap_() noexcept {
 #ifdef _WIN32

--- a/driver/portable/src/gguf_archive.hpp
+++ b/driver/portable/src/gguf_archive.hpp
@@ -48,6 +48,102 @@ struct GgufMeta {
     std::unordered_map<std::string, KV> kv;
 };
 
+// GGUF tensor name → HF-canonical name (e.g. `blk.3.attn_q.weight` →
+// `model.layers.3.self_attn.q_proj.weight`). Returns an empty string when a
+// tensor has no canonical mapping. Pure function. Defined `inline` here (not
+// in gguf_archive.cpp) so the qwen35 mapper-coverage testhook — a separate TU
+// in the same static lib — carries its own copy: the dummy/portable
+// `--bin pie` test never instantiates GGUFArchive, so a cross-TU reference to
+// a definition in gguf_archive.o would be dropped by gc-sections and fail to
+// link. The archive constructor also uses it to key the tensor table.
+//
+// Currently covers the Llama-family layout used by qwen3 / qwen2 / llama3 /
+// mistral3 / olmo3 and Qwen3-MoE / Mixtral / gpt-oss MoE variants, plus the
+// Qwen 3.5 / 3.6 hybrid (linear-attn + shared expert) and Gemma 4.
+//
+// `gemma_norm_layout` selects the Gemma `ffn_norm` interpretation (see below);
+// the caller derives it from `general.architecture` (gemma* → true).
+inline std::string gguf_to_hf_name(const std::string& g, bool gemma_norm_layout) {
+    // Top-level tensors.
+    if (g == "token_embd.weight")  return "model.embed_tokens.weight";
+    if (g == "output_norm.weight") return "model.norm.weight";
+    if (g == "output.weight")      return "lm_head.weight";
+
+    // Per-block: `blk.{N}.<part>` → `model.layers.{N}.<...>`.
+    const std::string blk = "blk.";
+    if (g.compare(0, blk.size(), blk) != 0) return {};
+    auto dot = g.find('.', blk.size());
+    if (dot == std::string::npos) return {};
+    const std::string n = g.substr(blk.size(), dot - blk.size());
+    const std::string suffix = g.substr(dot + 1);
+    const std::string layer = "model.layers." + n + ".";
+
+    // Norms.
+    if (suffix == "attn_norm.weight")        return layer + "input_layernorm.weight";
+    // `ffn_norm` is the pre-MLP norm. In the Llama family it is the only
+    // post-attention norm, so it maps to `post_attention_layernorm`. The
+    // Gemma family instead carries BOTH a distinct `post_attention_norm`
+    // (the post-attention norm) AND `ffn_norm` (the PRE-feedforward norm),
+    // so for gemma `ffn_norm` is the pre-feedforward layernorm.
+    if (suffix == "ffn_norm.weight")
+        return layer + (gemma_norm_layout ? "pre_feedforward_layernorm.weight"
+                                          : "post_attention_layernorm.weight");
+    if (suffix == "post_attention_norm.weight") return layer + "post_attention_layernorm.weight";
+    if (suffix == "post_ffw_norm.weight")    return layer + "post_feedforward_layernorm.weight";
+    // Gemma 4 per-layer residual scalar (HF `layer_scalar`).
+    if (suffix == "layer_output_scale.weight") return layer + "layer_scalar";
+    // Attention projections.
+    if (suffix == "attn_q.weight")           return layer + "self_attn.q_proj.weight";
+    if (suffix == "attn_k.weight")           return layer + "self_attn.k_proj.weight";
+    if (suffix == "attn_v.weight")           return layer + "self_attn.v_proj.weight";
+    if (suffix == "attn_output.weight")      return layer + "self_attn.o_proj.weight";
+    if (suffix == "attn_q.bias")             return layer + "self_attn.q_proj.bias";
+    if (suffix == "attn_k.bias")             return layer + "self_attn.k_proj.bias";
+    if (suffix == "attn_v.bias")             return layer + "self_attn.v_proj.bias";
+    if (suffix == "attn_output.bias")        return layer + "self_attn.o_proj.bias";
+    // Per-head q/k norms (Qwen 3, Olmo 3, Gemma 3).
+    if (suffix == "attn_q_norm.weight")      return layer + "self_attn.q_norm.weight";
+    if (suffix == "attn_k_norm.weight")      return layer + "self_attn.k_norm.weight";
+    // Dense FFN.
+    if (suffix == "ffn_gate.weight")         return layer + "mlp.gate_proj.weight";
+    if (suffix == "ffn_up.weight")           return layer + "mlp.up_proj.weight";
+    if (suffix == "ffn_down.weight")         return layer + "mlp.down_proj.weight";
+    // MoE: stacked-expert tensors land directly on the same canonical
+    // names our existing model.cpp uses for `moe_gate_exps` etc. We
+    // include both the qwen3_moe / mixtral / gpt-oss style stacked
+    // tensors and the legacy per-expert form (some converters still
+    // emit `blk.N.ffn_gate.E.weight`).
+    if (suffix == "ffn_gate_inp.weight")     return layer + "mlp.gate.weight";
+    if (suffix == "ffn_gate_exps.weight")    return layer + "mlp.experts.gate_proj.weight";
+    if (suffix == "ffn_up_exps.weight")      return layer + "mlp.experts.up_proj.weight";
+    if (suffix == "ffn_down_exps.weight")    return layer + "mlp.experts.down_proj.weight";
+    // Qwen 3.5 / 3.6 shared expert (qwen35moe). `ffn_gate_inp_shexp` is the
+    // 1-D sigmoid gate over the shared expert (HF `mlp.shared_expert_gate`),
+    // distinct from the per-token router `ffn_gate_inp`.
+    if (suffix == "ffn_gate_shexp.weight")     return layer + "mlp.shared_expert.gate_proj.weight";
+    if (suffix == "ffn_up_shexp.weight")       return layer + "mlp.shared_expert.up_proj.weight";
+    if (suffix == "ffn_down_shexp.weight")     return layer + "mlp.shared_expert.down_proj.weight";
+    if (suffix == "ffn_gate_inp_shexp.weight") return layer + "mlp.shared_expert_gate.weight";
+    // Qwen 3.5 / 3.6 hybrid gated-delta-rule linear attention. The GGUF
+    // (llama.cpp qwen35 convention) packs the linear-attn input projection
+    // as `attn_qkv` (the fused q/k/v of the delta net) + `attn_gate` (the
+    // output Z gate), and the gated-delta params as `ssm_*`. These names
+    // only ever appear on the *linear* layers; full-attention layers carry
+    // the ordinary `attn_q/k/v` handled above. The convert-time value
+    // transforms (A_log = -exp(raw); folded norm.weight +1) are inverted at
+    // load in `model.cpp::build_qwen3_5_`, not here.
+    if (suffix == "attn_qkv.weight")         return layer + "linear_attn.in_proj_qkv.weight";
+    if (suffix == "attn_gate.weight")        return layer + "linear_attn.in_proj_z.weight";
+    if (suffix == "ssm_alpha.weight")        return layer + "linear_attn.in_proj_a.weight";
+    if (suffix == "ssm_beta.weight")         return layer + "linear_attn.in_proj_b.weight";
+    if (suffix == "ssm_a")                   return layer + "linear_attn.A_log";
+    if (suffix == "ssm_dt.bias")             return layer + "linear_attn.dt_bias";
+    if (suffix == "ssm_conv1d.weight")       return layer + "linear_attn.conv1d.weight";
+    if (suffix == "ssm_norm.weight")         return layer + "linear_attn.norm.weight";
+    if (suffix == "ssm_out.weight")          return layer + "linear_attn.out_proj.weight";
+    return {};
+}
+
 class GGUFArchive : public WeightArchive {
 public:
     explicit GGUFArchive(const std::filesystem::path& gguf_file);

--- a/driver/portable/src/qwen35_mapping_testhook.cpp
+++ b/driver/portable/src/qwen35_mapping_testhook.cpp
@@ -1,0 +1,189 @@
+// Test-only entry points exercising the GGUF→HF tensor-name mapper and the
+// GGUF hparams parser for the hybrid Qwen 3.5 / 3.6 ("qwen35" / "qwen35moe")
+// architecture, in isolation — no model file, no backend, no compute.
+//
+// Linked into `pie_driver_portable_lib` and called from `#[cfg(test)]` Rust
+// tests in pie-server (`cargo test -p pie-server --bin pie`, which runs in
+// CI; the driver/portable ctest targets do not — see server/build.rs, which
+// only builds the `pie_driver_portable_lib` target). In a release build no
+// Rust code references these symbols, so the linker garbage-collects this
+// object out of the final binary.
+//
+// Why this exists: the qwen35 load path is otherwise guarded only by real
+// 27B/35B model boots (#694). These hooks give a cheap regression guard for
+// the two pure pieces that path depends on:
+//
+//   1. `gguf_to_hf_name` — every GGUF tensor that `Model::build_qwen3_5_` /
+//      `Model::load_qwen3_5_moe_layer_` look up by HF name must be reachable
+//      through the mapper. Dropping a mapper arm (e.g. the `ssm_*` linear-
+//      attention or `*_shexp` shared-expert entries) silently strands those
+//      weights at load; this hook turns that into a unit failure.
+//   2. `parse_gguf_hparams` — the per-layer attention pattern (`layer_types`)
+//      derived from `qwen35.full_attention_interval`, and the linear-attn
+//      dims read from the `ssm.*` keys.
+
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "gguf_archive.hpp"   // gguf_to_hf_name, GgufMeta
+#include "gguf_hparams.hpp"   // parse_gguf_hparams
+#include "hf_config.hpp"      // Hparams
+
+namespace {
+
+using pie_portable_driver::GgufMeta;
+
+// The qwen35-UNIQUE HF-canonical names `build_qwen3_5_` /
+// `load_qwen3_5_moe_layer_` (GGUF path) declare — the gated-delta-rule linear
+// attention and the always-active shared expert. These are the only mapper
+// arms no other GGUF arch exercises: the shared arms (self_attn.*_proj +
+// q/k_norm, dense mlp.gate/up/down_proj, MoE router mlp.gate + routed
+// mlp.experts.*, layernorms, top-level embed/norm/lm_head) are covered
+// broadly by every other model's load (qwen3 / llama / mistral / qwen3-moe),
+// so re-asserting them here adds no non-redundant coverage.
+//
+// This list is the qwen35-unique loader SPEC — it mirrors the linear-attn +
+// shared-expert declarations in model.cpp and must be updated whenever those
+// builders declare a new unique tensor. Kept independent of the mapper so the
+// coverage check is not tautological: it asserts the mapper can PRODUCE every
+// unique name the loader CONSUMES.
+const std::vector<std::string>& required_layer_hf() {
+    static const std::vector<std::string> v = {
+        // Linear-attention layer ('l') — gated delta rule.
+        "linear_attn.in_proj_qkv.weight",
+        "linear_attn.in_proj_z.weight",
+        "linear_attn.in_proj_a.weight",
+        "linear_attn.in_proj_b.weight",
+        "linear_attn.A_log",
+        "linear_attn.dt_bias",
+        "linear_attn.norm.weight",
+        "linear_attn.out_proj.weight",
+        "linear_attn.conv1d.weight",
+        // Always-active shared expert (qwen35moe).
+        "mlp.shared_expert.gate_proj.weight",
+        "mlp.shared_expert.up_proj.weight",
+        "mlp.shared_expert.down_proj.weight",
+        "mlp.shared_expert_gate.weight",
+    };
+    return v;
+}
+
+// The GGUF tensor names (llama.cpp qwen35 convention) that map to the
+// qwen35-unique HF names above. The mapper is fed exactly these; the produced
+// HF names must cover the loader spec. Shared GGUF suffixes (attn_*, dense
+// ffn_*, routed ffn_*_exps, norms, top level) are omitted — their mapping is
+// exercised by other arches' loads.
+const std::vector<std::string>& qwen35_gguf_layer_suffixes() {
+    static const std::vector<std::string> v = {
+        // Linear-attn delta-net inputs.
+        "attn_qkv.weight", "attn_gate.weight",
+        "ssm_alpha.weight", "ssm_beta.weight", "ssm_a",
+        "ssm_dt.bias", "ssm_conv1d.weight", "ssm_norm.weight", "ssm_out.weight",
+        // Shared-expert inputs.
+        "ffn_gate_shexp.weight", "ffn_up_shexp.weight", "ffn_down_shexp.weight",
+        "ffn_gate_inp_shexp.weight",
+    };
+    return v;
+}
+
+bool produced_contains(const std::vector<std::string>& produced,
+                       const std::string& want) {
+    for (const auto& p : produced) {
+        if (p == want) return true;
+    }
+    return false;
+}
+
+void add_kv(GgufMeta& m, const std::string& key, double num) {
+    GgufMeta::KV kv;
+    kv.key = key;
+    kv.type = 0;
+    kv.num_value = num;
+    m.kv.emplace(key, std::move(kv));
+}
+
+// Synthetic qwen35moe metadata. `interval` and `num_layers` drive the
+// layer_types derivation; the ssm.* / expert_* values are fixed knowns the
+// linear-dim hook asserts against.
+GgufMeta make_qwen35_meta(int interval, int num_layers) {
+    GgufMeta m;
+    m.general_architecture = "qwen35";
+    m.has_output_weight = true;
+    add_kv(m, "qwen35.block_count", num_layers);
+    add_kv(m, "qwen35.full_attention_interval", interval);
+    // Linear-attention dims (mapped from ssm.* in gguf_hparams.cpp).
+    add_kv(m, "qwen35.ssm.group_count", 2);     // -> num K heads
+    add_kv(m, "qwen35.ssm.time_step_rank", 16);  // -> num V heads
+    add_kv(m, "qwen35.ssm.state_size", 128);     // -> K/V head dim
+    add_kv(m, "qwen35.ssm.conv_kernel", 4);      // -> conv width
+    // Shared expert + routed experts (qwen35moe).
+    add_kv(m, "qwen35.expert_count", 8);
+    add_kv(m, "qwen35.expert_shared_feed_forward_length", 512);
+    return m;
+}
+
+}  // namespace
+
+extern "C" {
+
+// Returns the number of qwen35-unique loader-required HF names the mapper
+// FAILS to produce from the qwen35-unique GGUF tensor set — 0 means full
+// coverage. Missing names are written to stderr so a failing Rust assert is
+// diagnosable.
+int pie_portable_test_qwen35_mapper_missing_count() {
+    using pie_portable_driver::gguf_to_hf_name;
+
+    // Produce the HF set from the qwen35-unique GGUF vocabulary (layer 0).
+    // qwen35 is not a gemma arch, so the gemma `ffn_norm` layout is off.
+    std::vector<std::string> produced;
+    for (const auto& s : qwen35_gguf_layer_suffixes()) {
+        const std::string hf = gguf_to_hf_name("blk.0." + s, /*gemma_norm_layout=*/false);
+        if (!hf.empty()) produced.push_back(hf);
+    }
+
+    int missing = 0;
+    for (const auto& need : required_layer_hf()) {
+        if (!produced_contains(produced, "model.layers.0." + need)) {
+            std::fprintf(stderr,
+                         "[qwen35-mapper-test] uncovered layer tensor: %s\n",
+                         need.c_str());
+            ++missing;
+        }
+    }
+    return missing;
+}
+
+// Returns layer_types[idx] (the char 'g' or 'l', as an int) for a qwen35
+// model with the given full-attention `interval` and `num_layers`, or a
+// negative error code on bad input / parse shape.
+int pie_portable_test_qwen35_layer_type_at(int interval, int num_layers,
+                                           int idx) {
+    if (interval <= 0 || num_layers <= 0 || idx < 0 || idx >= num_layers) {
+        return -1;
+    }
+    const auto h = pie_portable_driver::parse_gguf_hparams(
+        make_qwen35_meta(interval, num_layers));
+    if (static_cast<int>(h.layer_types.size()) != num_layers) return -2;
+    return static_cast<int>(h.layer_types[static_cast<std::size_t>(idx)]);
+}
+
+// Returns one parsed linear-attention / shared-expert dim, selected by
+// `which`, from the synthetic qwen35moe metadata. Lets the Rust test assert
+// the ssm.* / expert_* keys flow into the right Hparams fields.
+//   0: num K heads   1: num V heads   2: K/V head dim
+//   3: conv kernel   4: shared-expert intermediate size
+int pie_portable_test_qwen35_parsed_linear_dim(int which) {
+    const auto h = pie_portable_driver::parse_gguf_hparams(
+        make_qwen35_meta(/*interval=*/4, /*num_layers=*/8));
+    switch (which) {
+        case 0: return h.qwen35_linear_num_k_heads;
+        case 1: return h.qwen35_linear_num_v_heads;
+        case 2: return h.qwen35_linear_k_head_dim;
+        case 3: return h.qwen35_linear_conv_kernel;
+        case 4: return h.shared_expert_intermediate_size;
+        default: return -1;
+    }
+}
+
+}  // extern "C"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -91,3 +91,65 @@ mod portable_graph_sampling_tests {
         assert_eq!(slot_dim(3, 3, 4, 32), 3);
     }
 }
+
+// Mapper-coverage + hparams regression tests for the hybrid Qwen 3.5 / 3.6
+// ("qwen35" / "qwen35moe") load path. The qwen35 GGUF loader is otherwise
+// guarded only by real 27B/35B model boots (#694); these assert the two pure
+// pieces it depends on — `gguf_to_hf_name` covering the qwen35-UNIQUE tensors
+// (gated-delta-rule linear attention + shared expert; the shared arms are
+// covered broadly by other arches' loads), and `parse_gguf_hparams` deriving
+// `layer_types` + linear-attn dims — without a model load. Test-only C entries
+// live in the portable driver (`qwen35_mapping_testhook.cpp`); they are
+// exercised here, in the `pie` bin, because CI runs `cargo test -p pie-server
+// --bin pie` and the driver/portable ctest targets never run in CI.
+#[cfg(all(test, feature = "driver-portable"))]
+mod portable_qwen35_mapping_tests {
+    use std::os::raw::c_int;
+
+    unsafe extern "C" {
+        fn pie_portable_test_qwen35_mapper_missing_count() -> c_int;
+        fn pie_portable_test_qwen35_layer_type_at(
+            interval: c_int,
+            num_layers: c_int,
+            idx: c_int,
+        ) -> c_int;
+        fn pie_portable_test_qwen35_parsed_linear_dim(which: c_int) -> c_int;
+    }
+
+    // Every qwen35-UNIQUE HF tensor name `build_qwen3_5_` /
+    // `load_qwen3_5_moe_layer_` look up must be producible by
+    // `gguf_to_hf_name`. Dropping a linear-attn (`ssm_*`/`attn_qkv`/`attn_gate`)
+    // or shared-expert (`*_shexp`) mapper arm makes this nonzero.
+    #[test]
+    fn mapper_covers_qwen35_unique_loader_tensors() {
+        let missing = unsafe { pie_portable_test_qwen35_mapper_missing_count() };
+        assert_eq!(
+            missing, 0,
+            "{missing} qwen35 loader tensor(s) have no gguf_to_hf_name mapping \
+             (see stderr for names)"
+        );
+    }
+
+    // layer_types: layer i is full attention ('g') iff (i+1) % interval == 0,
+    // else linear ('l'). For interval=4, num_layers=6 → "lllgll".
+    #[test]
+    fn layer_types_follow_full_attention_interval() {
+        let at = |i| unsafe { pie_portable_test_qwen35_layer_type_at(4, 6, i) };
+        let g = i32::from(b'g');
+        let l = i32::from(b'l');
+        let pattern: Vec<i32> = (0..6).map(at).collect();
+        assert_eq!(pattern, vec![l, l, l, g, l, l]);
+    }
+
+    // Linear-attention + shared-expert dims read from the ssm.* / expert_*
+    // GGUF keys must land in the matching Hparams fields.
+    #[test]
+    fn linear_attn_dims_parse_from_ssm_keys() {
+        let dim = |w| unsafe { pie_portable_test_qwen35_parsed_linear_dim(w) };
+        assert_eq!(dim(0), 2, "num K heads (ssm.group_count)");
+        assert_eq!(dim(1), 16, "num V heads (ssm.time_step_rank)");
+        assert_eq!(dim(2), 128, "K/V head dim (ssm.state_size)");
+        assert_eq!(dim(3), 4, "conv kernel (ssm.conv_kernel)");
+        assert_eq!(dim(4), 512, "shared-expert intermediate size");
+    }
+}


### PR DESCRIPTION
## What

Cheap unit-level regression guard for the hybrid Qwen 3.5 / 3.6 (`qwen35` / `qwen35moe`) GGUF load path — otherwise guarded only by real 27B/35B model boots (#694) and a semantic gate.

Scoped to the **qwen35-unique** mapper arms (gated-delta-rule linear attention + shared expert); the shared arms (`self_attn.*`, dense `mlp.*`, MoE router + routed `mlp.experts.*`, layernorms, top level) are exercised broadly by every other GGUF arch's load (qwen3 / llama / mistral / qwen3-moe), so re-asserting them here adds no non-redundant coverage.

Rebased onto the current `v1-base-shmem` tip (on top of #696 and #705/gemma4).

## Tests (run in CI)

Test-only `extern "C"` entries in the portable driver (`qwen35_mapping_testhook.cpp`) exercised by `#[cfg(test)]` Rust tests in the `pie` bin, so `cargo test -p pie-server --bin pie` runs them in CI (driver/portable ctest never runs in CI).

1. **`mapper_covers_qwen35_unique_loader_tensors`** — `gguf_to_hf_name` produces the 13 qwen35-unique HF names (9 linear-attn `ssm_*`/`attn_qkv`/`attn_gate` + 4 shared-expert `*_shexp`). List kept independent of the mapper → not tautological.
2. **`layer_types_follow_full_attention_interval`** — `layer_types` from `qwen35.full_attention_interval` (`interval=4,n=6` → `lllgll`).
3. **`linear_attn_dims_parse_from_ssm_keys`** — `ssm.*` / `expert_shared_feed_forward_length` flow into `Hparams`.

## Mechanics

`gguf_to_hf_name` is lifted out of the anonymous namespace and defined **`inline` in `gguf_archive.hpp`** (not the `.cpp`): the dummy/portable `--bin pie` test never instantiates `GGUFArchive`, so a cross-TU reference to a definition in `gguf_archive.o` is dropped by gc-sections and fails to link the test binary. Inlining makes the testhook TU self-sufficient. Merged with #705's `gemma_norm_layout` signature; the testhook passes `false` (qwen35 ≠ gemma). Release builds GC the unreferenced test symbols.

## Verification

3 tests pass under a clean relink (`cargo clean -p pie-server && cargo test -p pie-server --bin pie portable_qwen35`) — no undefined-symbol. Mutation-proven on a kept arm: dropping the `ssm_norm` mapper line → `uncovered layer tensor: linear_attn.norm.weight`.

Additive, host-side test only — no WIT / SDK / graph / FFI change.