### PR TITLE
harden(gemma4-gguf): fail loudly on missing rope_freqs.weight and mismatched head_count_kv

### DIFF
--- a/driver/portable/CMakeLists.txt
+++ b/driver/portable/CMakeLists.txt
@@ -114,6 +114,10 @@ add_library(pie_driver_portable_lib STATIC
   # Test-only entry exposing the gemma SPM normalizer node for a pie-server
   # #[cfg(test)] Rust test (F3 leading-metaspace fidelity). GC'd in release.
   src/gguf_tokenizer_testhook.cpp
+  # Test-only entries exercising the gemma4 GGUF load-path hardening guards
+  # (#712): head_count_kv reduction + rope_freqs.weight requirement, from
+  # pie-server #[cfg(test)] Rust tests. GC'd in release.
+  src/gemma4_hparams_testhook.cpp
 )
 
 target_compile_options(pie_driver_portable_lib PRIVATE

--- a/driver/portable/src/gemma4_hparams_testhook.cpp
+++ b/driver/portable/src/gemma4_hparams_testhook.cpp
@@ -1,0 +1,133 @@
+// Test-only entry points exercising the gemma4 GGUF load-path hardening
+// guards in isolation — no model file, no backend, no compute.
+//
+// Linked into `pie_driver_portable_lib` and called from `#[cfg(test)]` Rust
+// tests in pie-server (`cargo test -p pie-server --bin pie`, which runs in CI;
+// the driver/portable ctest targets do not). In a release build no Rust code
+// references these symbols, so the linker garbage-collects this object out of
+// the final binary.
+//
+// Why this exists (#712): the gemma4 GGUF load path is otherwise guarded only
+// by a real 12B boot (#705). Two facts it derives from GGUF metadata, if wrong,
+// previously degraded generation SILENTLY rather than failing:
+//
+//   1. `parse_gguf_hparams` reduces the per-layer `attention.head_count_kv`
+//      array to the two scalars the attention path uses (sliding + global).
+//      A length/within-type mismatch must now throw, not be skipped.
+//   2. `validate_gemma4_rope_freqs` requires the root `rope_freqs.weight`
+//      tensor whenever the model has a full-attention layer (the GGUF carries
+//      the proportional-RoPE factors only there). Absent => throw, not a
+//      silent full-rotation fallback.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "gguf_archive.hpp"   // GgufMeta
+#include "gguf_hparams.hpp"   // parse_gguf_hparams, validate_gemma4_rope_freqs
+#include "hf_config.hpp"      // Hparams
+
+namespace {
+
+using pie_portable_driver::GgufMeta;
+
+void add_kv(GgufMeta& m, const std::string& key, double num) {
+    GgufMeta::KV kv;
+    kv.key = key;
+    kv.type = 0;
+    kv.num_value = num;
+    m.kv.emplace(key, std::move(kv));
+}
+
+void add_int_arr(GgufMeta& m, const std::string& key,
+                 std::vector<std::int64_t> arr) {
+    GgufMeta::KV kv;
+    kv.key = key;
+    kv.type = 0;
+    kv.arr_int = std::move(arr);
+    m.kv.emplace(key, std::move(kv));
+}
+
+// Synthetic dense gemma4 metadata: 6 layers, sliding_window_pattern
+// [1,1,1,1,1,0] -> layer_types "sssssg" (1=sliding, 0=full/global). The
+// caller supplies the per-layer head_count_kv array so each guard case can be
+// driven independently.
+GgufMeta make_gemma4_meta(std::vector<std::int64_t> head_count_kv) {
+    GgufMeta m;
+    m.general_architecture = "gemma4";
+    m.has_output_weight = true;
+    add_kv(m, "gemma4.block_count", 6);
+    add_kv(m, "gemma4.attention.head_count", 16);
+    add_kv(m, "gemma4.embedding_length", 3840);
+    add_kv(m, "gemma4.feed_forward_length", 15360);
+    add_kv(m, "gemma4.attention.key_length", 512);
+    add_kv(m, "gemma4.attention.key_length_swa", 256);
+    add_kv(m, "gemma4.rope.freq_base", 1000000.0);
+    add_kv(m, "gemma4.rope.freq_base_swa", 10000.0);
+    add_int_arr(m, "gemma4.attention.sliding_window_pattern",
+                {1, 1, 1, 1, 1, 0});
+    add_int_arr(m, "gemma4.attention.head_count_kv", std::move(head_count_kv));
+    return m;
+}
+
+// 0 = parsed without throwing, 1 = threw (mismatch caught). Selects the
+// head_count_kv array shape by `mode`:
+//   0: valid       [8,8,8,8,8,1] (consistent per attention type)
+//   1: wrong length [8,8,8,8,8]  (5 entries for 6 layers)
+//   2: inconsistent [8,8,8,4,8,1] (sliding layers disagree: 8 vs 4)
+int head_count_kv_status(int mode) {
+    std::vector<std::int64_t> kvh;
+    switch (mode) {
+        case 0: kvh = {8, 8, 8, 8, 8, 1}; break;
+        case 1: kvh = {8, 8, 8, 8, 8};    break;
+        case 2: kvh = {8, 8, 8, 4, 8, 1}; break;
+        default: return -1;
+    }
+    try {
+        (void)pie_portable_driver::parse_gguf_hparams(
+            make_gemma4_meta(std::move(kvh)));
+        return 0;
+    } catch (const std::exception&) {
+        return 1;
+    }
+}
+
+}  // namespace
+
+extern "C" {
+
+// See head_count_kv_status: 0=ok, 1=threw, -1=bad mode.
+int pie_portable_test_gemma4_head_count_kv_status(int mode) {
+    return head_count_kv_status(mode);
+}
+
+// For the valid array, returns the scalar the reduction produced:
+//   0 -> num_key_value_heads (sliding)   1 -> num_global_key_value_heads
+int pie_portable_test_gemma4_parsed_kv_heads(int which) {
+    const auto h = pie_portable_driver::parse_gguf_hparams(
+        make_gemma4_meta({8, 8, 8, 8, 8, 1}));
+    switch (which) {
+        case 0: return h.num_key_value_heads;
+        case 1: return h.num_global_key_value_heads;
+        default: return -1;
+    }
+}
+
+// validate_gemma4_rope_freqs: returns 1 if it threw, 0 if it accepted.
+//   has_full_layer != 0 -> layer_types contains a 'g'
+//   present       != 0 -> rope_freqs.weight tensor is present
+int pie_portable_test_gemma4_rope_freqs_status(int has_full_layer,
+                                               int present) {
+    std::vector<char> layer_types = has_full_layer
+        ? std::vector<char>{'s', 's', 'g'}
+        : std::vector<char>{'s', 's', 's'};
+    try {
+        pie_portable_driver::validate_gemma4_rope_freqs(layer_types,
+                                                        present != 0);
+        return 0;
+    } catch (const std::exception&) {
+        return 1;
+    }
+}
+
+}  // extern "C"

--- a/driver/portable/src/gguf_hparams.cpp
+++ b/driver/portable/src/gguf_hparams.cpp
@@ -1,6 +1,7 @@
 #include "gguf_hparams.hpp"
 #include "gguf_archive.hpp"
 
+#include <algorithm>
 #include <cmath>
 #include <stdexcept>
 
@@ -223,14 +224,39 @@ Hparams parse_gguf_hparams(const GgufMeta& meta) {
         // attention path uses: num_key_value_heads (sliding) and
         // num_global_key_value_heads (full).
         const auto& kvh = get_int_array(meta, a, "attention.head_count_kv");
-        if (!kvh.empty() && kvh.size() == h.layer_types.size()) {
-            for (std::size_t i = 0; i < kvh.size(); ++i) {
-                if (h.layer_types[i] == 'g')
-                    h.num_global_key_value_heads =
-                        static_cast<std::int32_t>(kvh[i]);
-                else
-                    h.num_key_value_heads = static_cast<std::int32_t>(kvh[i]);
+        if (!kvh.empty()) {
+            // A per-layer array MUST cover every layer: a short/long array
+            // silently drops the reduction and leaves the kv-head counts at
+            // their generic-block defaults, mis-sizing attention. Fail loudly.
+            if (kvh.size() != h.layer_types.size()) {
+                throw std::runtime_error(
+                    "gguf gemma4: attention.head_count_kv length (" +
+                    std::to_string(kvh.size()) +
+                    ") does not match layer count (" +
+                    std::to_string(h.layer_types.size()) + ")");
             }
+            // Reduce the per-layer array to the two scalars the attention path
+            // uses (sliding -> num_key_value_heads, full -> num_global_*). The
+            // reduction assumes each attention type carries ONE consistent
+            // count; a within-type disagreement means our two-scalar model is
+            // wrong for this checkpoint, so refuse it rather than silently
+            // keeping whichever value happened to come last.
+            std::int32_t sliding = -1;
+            std::int32_t global  = -1;
+            for (std::size_t i = 0; i < kvh.size(); ++i) {
+                const std::int32_t n = static_cast<std::int32_t>(kvh[i]);
+                std::int32_t& slot = (h.layer_types[i] == 'g') ? global : sliding;
+                if (slot >= 0 && slot != n) {
+                    throw std::runtime_error(
+                        "gguf gemma4: inconsistent attention.head_count_kv "
+                        "within a single attention type (saw " +
+                        std::to_string(slot) + " and " + std::to_string(n) +
+                        ")");
+                }
+                slot = n;
+            }
+            if (sliding >= 0) h.num_key_value_heads        = sliding;
+            if (global  >= 0) h.num_global_key_value_heads = global;
         }
 
         // Per-attention-type RoPE base. Full layers additionally use a
@@ -261,6 +287,21 @@ Hparams parse_gguf_hparams(const GgufMeta& meta) {
     }
 
     return h;
+}
+
+void validate_gemma4_rope_freqs(const std::vector<char>& layer_types,
+                                bool rope_freqs_present) {
+    if (rope_freqs_present) return;
+    const bool has_full_layer =
+        std::find(layer_types.begin(), layer_types.end(), 'g')
+            != layer_types.end();
+    if (has_full_layer) {
+        throw std::runtime_error(
+            "gguf gemma4: required tensor 'rope_freqs.weight' is missing; "
+            "full-attention layers need the proportional-RoPE frequency "
+            "factors (the GGUF is truncated or was converted by a tool that "
+            "dropped it)");
+    }
 }
 
 }  // namespace pie_portable_driver

--- a/driver/portable/src/gguf_hparams.hpp
+++ b/driver/portable/src/gguf_hparams.hpp
@@ -6,6 +6,8 @@
 // we map those into the same Hparams struct so the rest of the driver
 // doesn't branch on the source format.
 
+#include <vector>
+
 #include "hf_config.hpp"
 
 namespace pie_portable_driver {
@@ -13,5 +15,17 @@ namespace pie_portable_driver {
 struct GgufMeta;
 
 Hparams parse_gguf_hparams(const GgufMeta& meta);
+
+// Fail loudly when a GGUF gemma4 checkpoint is missing the full-layer
+// proportional-RoPE frequency factors. On the GGUF path those factors live
+// ONLY in the root `rope_freqs.weight` tensor — no scalar partial-rotary KV
+// exists to reconstruct them. If the tensor is absent while the model has any
+// full-attention ('g') layer, every full layer would silently fall back to a
+// full rotation (`ggml_rope_ext` with freq_factors=nullptr), corrupting its
+// position encoding with no error. Throws std::runtime_error in that case.
+// Exposed (rather than inlined at the load site) so the pie-bin regression
+// test can exercise the invariant without a model file.
+void validate_gemma4_rope_freqs(const std::vector<char>& layer_types,
+                                bool rope_freqs_present);
 
 }  // namespace pie_portable_driver

--- a/driver/portable/src/model.cpp
+++ b/driver/portable/src/model.cpp
@@ -1467,7 +1467,10 @@ void Model::build_gemma4_() {
         // what synth_proportional_rope_factors_ builds). Load it directly so
         // we honour whatever partial-rotary factor the converter encoded
         // (it is not stored as a scalar KV).
-        if (archive_->find("rope_freqs.weight") != nullptr) {
+        const bool rope_freqs_present =
+            archive_->find("rope_freqs.weight") != nullptr;
+        validate_gemma4_rope_freqs(h.layer_types, rope_freqs_present);
+        if (rope_freqs_present) {
             weights_.gemma4_rope_full_factors = declare_("rope_freqs.weight");
         }
     } else if (h.gemma4_rope_partial_factor_full < 1.0f

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -216,3 +216,86 @@ mod portable_gguf_tokenizer_tests {
                 "Prepend must precede Replace so the leading metaspace is added first: {j}");
     }
 }
+
+// #712 hardening guards for the gemma4 GGUF load path. That path is otherwise
+// guarded only by a real 12B boot (#705); these turn two formerly-silent
+// mis-derivations into cheap unit failures, in the `pie` bin because CI runs
+// `cargo test -p pie-server --bin pie` and driver/portable ctest never runs in
+// CI. Test-only C entries live in `gemma4_hparams_testhook.cpp`.
+#[cfg(all(test, feature = "driver-portable"))]
+mod portable_gemma4_hardening_tests {
+    use std::os::raw::c_int;
+
+    unsafe extern "C" {
+        fn pie_portable_test_gemma4_head_count_kv_status(mode: c_int) -> c_int;
+        fn pie_portable_test_gemma4_parsed_kv_heads(which: c_int) -> c_int;
+        fn pie_portable_test_gemma4_rope_freqs_status(
+            has_full_layer: c_int,
+            present: c_int,
+        ) -> c_int;
+    }
+
+    // A well-formed per-layer head_count_kv array (consistent within each
+    // attention type) parses, and reduces to the two scalars the attention
+    // path uses: sliding -> num_key_value_heads (8), full -> global (1).
+    #[test]
+    fn head_count_kv_valid_reduces_to_dual_scalars() {
+        assert_eq!(
+            unsafe { pie_portable_test_gemma4_head_count_kv_status(0) }, 0,
+            "valid head_count_kv array must parse"
+        );
+        assert_eq!(
+            unsafe { pie_portable_test_gemma4_parsed_kv_heads(0) }, 8,
+            "sliding layers -> num_key_value_heads"
+        );
+        assert_eq!(
+            unsafe { pie_portable_test_gemma4_parsed_kv_heads(1) }, 1,
+            "full layers -> num_global_key_value_heads"
+        );
+    }
+
+    // A head_count_kv array whose length does not match the layer count used
+    // to be silently skipped (kv-head counts left at generic defaults). It
+    // must now throw.
+    #[test]
+    fn head_count_kv_wrong_length_throws() {
+        assert_eq!(
+            unsafe { pie_portable_test_gemma4_head_count_kv_status(1) }, 1,
+            "length-mismatched head_count_kv must fail loudly"
+        );
+    }
+
+    // Differing counts within one attention type break the two-scalar
+    // reduction; the last value used to win silently. It must now throw.
+    #[test]
+    fn head_count_kv_inconsistent_within_type_throws() {
+        assert_eq!(
+            unsafe { pie_portable_test_gemma4_head_count_kv_status(2) }, 1,
+            "within-type-inconsistent head_count_kv must fail loudly"
+        );
+    }
+
+    // rope_freqs.weight is required whenever the model has a full-attention
+    // layer (the GGUF carries the proportional-RoPE factors only there); a
+    // missing tensor used to fall back silently to a full rotation.
+    #[test]
+    fn rope_freqs_missing_with_full_layer_throws() {
+        assert_eq!(
+            unsafe { pie_portable_test_gemma4_rope_freqs_status(1, 0) }, 1,
+            "full layer + absent rope_freqs.weight must fail loudly"
+        );
+    }
+
+    // Present tensor, or a model with no full-attention layer, is accepted.
+    #[test]
+    fn rope_freqs_present_or_no_full_layer_ok() {
+        assert_eq!(
+            unsafe { pie_portable_test_gemma4_rope_freqs_status(1, 1) }, 0,
+            "full layer + present rope_freqs.weight is fine"
+        );
+        assert_eq!(
+            unsafe { pie_portable_test_gemma4_rope_freqs_status(0, 0) }, 0,
+            "no full layer => rope_freqs.weight not required"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Hardens the gemma4 GGUF load path (added in #705) so two malformed-metadata cases **fail loudly** instead of silently degrading generation.

### 1. Missing `rope_freqs.weight`
GGUF gemma4 carries the full-attention-layer proportional-RoPE frequency factors **only** in the root `rope_freqs.weight` tensor — there is no scalar partial-rotary KV to reconstruct them. When the tensor was absent, full layers fell through to `ggml_rope_ext` with `freq_factors=nullptr` (a full rotation), corrupting every full-layer position encoding with no error.

New `validate_gemma4_rope_freqs(layer_types, present)` throws when the tensor is missing while the model has any full-attention (`'g'`) layer. Tied to the layers that actually consume it, so a hypothetical all-sliding model is unaffected.

### 2. Mismatched `attention.head_count_kv`
`parse_gguf_hparams` reduces the per-layer kv-head array to the two scalars the attention path uses (sliding → `num_key_value_heads`, full → `num_global_key_value_heads`). Previously:
- an array whose length ≠ layer count silently skipped the whole reduction, leaving the counts at generic-block defaults;
- a within-attention-type disagreement silently let the last value win.

Both now throw. An absent array (uniform/scalar models) is still tolerated.

## Tests
`gemma4_hparams_testhook.cpp` + `portable_gemma4_hardening_tests` in `pie-server`, run by `cargo test -p pie-server --bin pie` (driver/portable ctest never runs in CI). 12/12 portable bin tests green.

Mutation-proven:
- disable the head_count_kv block → 3 tests fail (incl. the valid-reduction assertion);
- drop only the within-type consistency check → only the inconsistency test fails;
- neuter the rope validator → only the rope-missing test fails.

Host-side change only (driver/portable + pie-server); the inferlet SDK and chat-apc wasm are unaffected.