### PR TITLE
feat(context): expose effective KV-page budget via budget-page-count

### DIFF
--- a/runtime/src/api/context.rs
+++ b/runtime/src/api/context.rs
@@ -287,6 +287,11 @@ impl pie::core::context::HostContext for InstanceState {
         Ok(context::committed_page_count(ctx.model_id, ctx.context_id))
     }
 
+    async fn budget_page_count(&mut self, this: Resource<Context>) -> Result<u32> {
+        let ctx = self.ctx().table.get(&this)?;
+        Ok(context::budget_page_count(ctx.model_id, ctx.context_id))
+    }
+
     async fn working_page_count(&mut self, this: Resource<Context>) -> Result<u32> {
         let ctx = self.ctx().table.get(&this)?;
         Ok(context::working_page_count(ctx.model_id, ctx.context_id))

--- a/runtime/src/context.rs
+++ b/runtime/src/context.rs
@@ -230,6 +230,9 @@ impl Ord for RestoreEntry {
 
 pub(crate) static SERVICES: LazyLock<ServiceArray<Message>> = LazyLock::new(ServiceArray::new);
 static PAGE_SIZES: LazyLock<boxcar::Vec<usize>> = LazyLock::new(boxcar::Vec::new);
+/// Per-model `total_pages`, indexed by `model_idx` then driver ordinal.
+/// Pushed once at `spawn`; read lock-free by `budget_page_count`.
+static GPU_PAGE_BUDGETS: LazyLock<boxcar::Vec<Vec<usize>>> = LazyLock::new(boxcar::Vec::new);
 
 // ---------------------------------------------------------------------------
 // Lock-free read caches — written by the actor, read directly by callers.
@@ -350,6 +353,7 @@ pub fn spawn(
 ) -> usize {
     let model_idx = SERVICES.len();
     PAGE_SIZES.push(page_size);
+    GPU_PAGE_BUDGETS.push(num_gpu_pages.clone());
     MARKET.push(Market::new(default_endowment_pages));
     SERVICES
         .spawn(move || {
@@ -820,6 +824,20 @@ pub fn committed_page_count(model_idx: usize, id: ContextId) -> u32 {
     CACHED_CONTEXT_INFO
         .get(&(model_idx, id))
         .map(|v| v.committed_pages)
+        .unwrap_or(0)
+}
+
+/// Per-driver KV-page budget (`total_pages`) for this context; window in
+/// tokens = `budget_page_count * tokens_per_page`. 0 until the driver is cached.
+pub fn budget_page_count(model_idx: usize, id: ContextId) -> u32 {
+    let driver = match CACHED_CONTEXT_INFO.get(&(model_idx, id)) {
+        Some(v) => v.driver,
+        None => return 0,
+    };
+    GPU_PAGE_BUDGETS
+        .get(model_idx)
+        .and_then(|budgets| budgets.get(driver))
+        .map(|&n| n as u32)
         .unwrap_or(0)
 }
 

--- a/runtime/tests/context.rs
+++ b/runtime/tests/context.rs
@@ -219,6 +219,12 @@ fn full_page_lifecycle() {
             .unwrap();
 
         assert_eq!(pie::context::committed_page_count(MODEL, id), 1);
+        // budget == the mock env's per-driver total_pages (64); a page op
+        // above has cached the driver so the lock-free read resolves.
+        assert_eq!(
+            pie::context::budget_page_count(MODEL, id), 64,
+            "budget_page_count should report the driver total_pages"
+        );
         // 16 filled tokens remain (second page's worth)
         assert_eq!(
             pie::context::working_page_token_count(MODEL, id),

--- a/runtime/wit/core/wit/context.wit
+++ b/runtime/wit/core/wit/context.wit
@@ -79,6 +79,9 @@ interface context {
         // Number of committed KV pages in the context
         committed-page-count: func() -> u32;
 
+        // Total KV-page budget (total_pages) for this context's driver; window in tokens = budget-page-count * tokens-per-page.
+        budget-page-count: func() -> u32;
+
         // Number of working KV pages (based on buffered tokens in the resource handle)
         working-page-count: func() -> u32;
 

--- a/runtime/wit/deps/core/context.wit
+++ b/runtime/wit/deps/core/context.wit
@@ -79,6 +79,9 @@ interface context {
         // Number of committed KV pages in the context
         committed-page-count: func() -> u32;
 
+        // Total KV-page budget (total_pages) for this context's driver; window in tokens = budget-page-count * tokens-per-page.
+        budget-page-count: func() -> u32;
+
         // Number of working KV pages (based on buffered tokens in the resource handle)
         working-page-count: func() -> u32;
 

--- a/runtime/wit/zo/wit/deps/core/context.wit
+++ b/runtime/wit/zo/wit/deps/core/context.wit
@@ -79,6 +79,9 @@ interface context {
         // Number of committed KV pages in the context
         committed-page-count: func() -> u32;
 
+        // Total KV-page budget (total_pages) for this context's driver; window in tokens = budget-page-count * tokens-per-page.
+        budget-page-count: func() -> u32;
+
         // Number of uncommitted KV pages (based on buffered tokens in the resource handle)
         working-page-count: func() -> u32;
 

--- a/sdk/rust/inferlet/src/context.rs
+++ b/sdk/rust/inferlet/src/context.rs
@@ -282,6 +282,18 @@ impl Context {
         self.seq_len
     }
 
+    /// Per-driver KV-page budget (`total_pages`); read live, since a context
+    /// can migrate drivers. 0 before the host has cached this context.
+    pub fn budget_pages(&self) -> u32 {
+        self.inner.budget_page_count()
+    }
+
+    /// Context window in tokens (`budget_pages * page_size`) — the
+    /// ceiling `seq_len` can grow to before KV pages are exhausted.
+    pub fn max_tokens(&self) -> u32 {
+        self.budget_pages().saturating_mul(self.page_size)
+    }
+
     /// Pending (buffered but not yet flushed) tokens.
     pub fn buffer(&self) -> &[u32] {
         &self.buffer

--- a/sdk/rust/inferlet/wit/deps/core/context.wit
+++ b/sdk/rust/inferlet/wit/deps/core/context.wit
@@ -79,6 +79,9 @@ interface context {
         // Number of committed KV pages in the context
         committed-page-count: func() -> u32;
 
+        // Total KV-page budget (total_pages) for this context's driver; window in tokens = budget-page-count * tokens-per-page.
+        budget-page-count: func() -> u32;
+
         // Number of working KV pages (based on buffered tokens in the resource handle)
         working-page-count: func() -> u32;
 

--- a/sdk/tools/bakery/src/bakery/wit/deps/core/context.wit
+++ b/sdk/tools/bakery/src/bakery/wit/deps/core/context.wit
@@ -79,6 +79,9 @@ interface context {
         // Number of committed KV pages in the context
         committed-page-count: func() -> u32;
 
+        // Total KV-page budget (total_pages) for this context's driver; window in tokens = budget-page-count * tokens-per-page.
+        budget-page-count: func() -> u32;
+
         // Number of working KV pages (based on buffered tokens in the resource handle)
         working-page-count: func() -> u32;
 


### PR DESCRIPTION
Add `context.budget-page-count() -> u32` to the WIT context resource. It returns the total KV-page budget of the context's current device — the effective page count the driver allocated (post-OOM-backoff), not the model's architectural maximum. Guests derive the true context window as `budget-page-count * tokens-per-page`.

## Wiring
- **WIT**: `budget-page-count` on the `context` resource (all vendored copies; the host bindgen reads `runtime/wit/deps/core`).
- **host** (`runtime/src/context.rs`): a per-model, per-device `GPU_PAGE_BUDGETS` global, pushed in `context::spawn` from `num_gpu_pages`. `budget_page_count(model_idx, id)` resolves the context's device from the cached context info and reads the budget lock-free, mirroring the existing committed/working page-count reads. `runtime/src/api/context.rs` delegates the WIT method.
- **SDK** (`sdk/rust/inferlet/src/context.rs`): `Context::budget_pages()` (read live, since a context can migrate devices) and `max_tokens()` (= `budget_pages × page_size`).

## Why
Downstream consumers can render an engine-true context-occupancy meter: the engine already knows the real KV budget (driver READY caps `total_pages` → `DeviceConfig` → `spawn`), so this exposes it instead of forcing an app-side estimate. The reported budget is the post-OOM-backoff value the portable/Metal driver actually allocated (`entry.cpp`).

## Tests
Adds a `budget_page_count == device total_pages` assertion to the context integration test. Note: the runtime integration harness on this branch has pre-existing, unrelated breakage (a stale `lookup_snapshot` reference and missing `ForwardPassResponse` fields in the mock device), so the host function is additionally validated by `cargo check -p pie` and the full guest→host path is exercised by the downstream HTTP e2e suite.