### PR TITLE
fix(scheduler): relax AdaptivePolicy cohort watermark instead of ratcheting monotonically

### DIFF
--- a/runtime/src/inference/adaptive_policy.rs
+++ b/runtime/src/inference/adaptive_policy.rs
@@ -32,8 +32,8 @@ use super::scheduler::{Decision, SchedulingPolicy};
 //   1. `B >= max_forward_requests`  — structural driver limit.
 //   2. `fired_high_water == 0`      — no historical fire yet; fire
 //                                     whatever we have (cold start).
-//   3. `B >= fired_high_water`      — we've matched the largest cohort
-//                                     ever fired; firing more won't
+//   3. `B >= fired_high_water`      — we've matched the recent cohort
+//                                     high-water; firing more won't
 //                                     produce a bigger batch from
 //                                     existing peers.
 //   4. `elapsed >= last_latency`    — deadlock watchdog: the cohort
@@ -52,11 +52,44 @@ use super::scheduler::{Decision, SchedulingPolicy};
 // `fired_high_water` is the only firing-rule concept; `last_latency`
 // is a watchdog to prevent indefinite parking, not a steady-state
 // trigger.
+//
+// `fired_high_water` tracks the *recent* cohort high-water, not an
+// all-time maximum: it ratchets up immediately when a fire meets or
+// exceeds it, and relaxes by one on any below-watermark fire (see
+// `relax_high_water`). A monotonic, never-decaying watermark is a bug:
+// once a transient burst lifts it (e.g. a one-off larger cohort, or
+// pass-level speculation inflating a batch), every later steady-state
+// cohort that lands below the peak fails rule 3 and needlessly waits
+// out the rule-4 watchdog. Relaxing the watermark lets it follow the
+// live cohort back down so those fires go out immediately.
+
+/// Evolve `fired_high_water` after a fire of `fired_size`.
+///
+/// Ratchets up immediately when the fire meets or exceeds the current
+/// watermark; otherwise relaxes by exactly one toward the live cohort.
+/// Stepping down by one (rather than snapping straight to `fired_size`)
+/// is deliberate: it ignores a single anomalously small fire but tracks
+/// a sustained drop within a couple of fires, which matches observed
+/// cohort dynamics (concurrency rarely falls by more than one between
+/// consecutive fires).
+///
+/// Free function (not a method) so the firing-rule arithmetic is unit
+/// testable in isolation.
+#[inline]
+fn relax_high_water(current: usize, fired_size: usize) -> usize {
+    if fired_size >= current {
+        fired_size
+    } else {
+        current.saturating_sub(1)
+    }
+}
 
 pub(super) struct AdaptivePolicy {
     max_forward_requests: usize,
-    /// Largest batch size that has fired. Monotonic; only ratchets
-    /// upward. The single firing-rule concept.
+    /// Recent cohort high-water — the single firing-rule concept.
+    /// Ratchets up on a meet-or-exceed fire and relaxes by one on a
+    /// below-watermark fire (see `relax_high_water`), so it tracks the
+    /// current steady-state cohort rather than an all-time peak.
     fired_high_water: usize,
     /// Previous fire's compute time, in seconds. Used solely as the
     /// deadlock watchdog (rule 4). Zero until the second fire
@@ -97,9 +130,7 @@ impl SchedulingPolicy for AdaptivePolicy {
 
     fn on_fired(&mut self, fired_size: usize) {
         self.batch_start_time = None;
-        if fired_size > self.fired_high_water {
-            self.fired_high_water = fired_size;
-        }
+        self.fired_high_water = relax_high_water(self.fired_high_water, fired_size);
     }
 
     fn decide(&mut self, current_forward_requests: usize) -> Decision {
@@ -333,12 +364,53 @@ mod tests {
     }
 
     #[test]
-    fn adaptive_fired_high_water_ratchets_only_upward() {
+    fn adaptive_fired_high_water_ratchets_up_immediately() {
+        // A larger cohort lifts the watermark on the very next fire.
         let mut policy = AdaptivePolicy::new(512, 0);
         policy.on_fired(40);
+        assert_eq!(policy.fired_high_water, 40);
         policy.on_fired(80);
-        policy.on_fired(60); // smaller — must not pull the watermark down
         assert_eq!(policy.fired_high_water, 80);
+    }
+
+    #[test]
+    fn adaptive_fired_high_water_relaxes_after_transient_burst() {
+        // A transient burst lifts the watermark, then a sustained drop
+        // to a smaller steady-state cohort relaxes it by one per fire —
+        // so the smaller cohort stops failing rule 3 and waiting out
+        // the watchdog. A monotonic watermark would stay pinned at 7.
+        let mut policy = AdaptivePolicy::new(512, 0);
+        for s in [4, 4, 7, 7] {
+            policy.on_fired(s);
+        }
+        assert_eq!(policy.fired_high_water, 7);
+        policy.on_fired(5);
+        assert_eq!(policy.fired_high_water, 6);
+        policy.on_fired(5);
+        assert_eq!(policy.fired_high_water, 5);
+        policy.on_fired(5);
+        assert_eq!(policy.fired_high_water, 5); // settled at the live cohort
+    }
+
+    #[test]
+    fn adaptive_fired_high_water_steady_cohort_is_stable() {
+        // A uniform cohort keeps the watermark exactly at the cohort
+        // size — never inflated, never relaxed below it — so every fire
+        // satisfies rule 3 and goes out immediately.
+        let mut policy = AdaptivePolicy::new(512, 0);
+        for _ in 0..1000 {
+            policy.on_fired(4);
+        }
+        assert_eq!(policy.fired_high_water, 4);
+    }
+
+    #[test]
+    fn relax_high_water_steps_down_by_one() {
+        assert_eq!(relax_high_water(8, 8), 8); // meet -> hold
+        assert_eq!(relax_high_water(8, 9), 9); // exceed -> ratchet up
+        assert_eq!(relax_high_water(8, 7), 7); // below -> decay by one
+        assert_eq!(relax_high_water(8, 3), 7); // far below -> still only one step
+        assert_eq!(relax_high_water(0, 0), 0); // cold start, no underflow
     }
 
     // ---- EagerPolicy --------------------------------------------------------


### PR DESCRIPTION
## Summary

`AdaptivePolicy::fired_high_water` only ever ratchets **up** and never decays. Once a transient
burst lifts it above the steady-state cohort size, every later fire whose batch lands *below*
that peak fails the rule-3 firing test (`B >= fired_high_water`) and is parked on the rule-4
`last_latency` watchdog before it goes out — adding a full ~one-fire-time stall to a large
fraction of fires for the rest of the engine's lifetime.

This PR makes `fired_high_water` track the **recent** cohort instead of an all-time peak: it
still ratchets up immediately on a meet-or-exceed fire, but relaxes by one (floored at the
observed size) on a below-watermark fire, so it follows the live cohort back down. Fixes #436 

## Why the current behavior is a bug

The watermark exists to avoid firing a half-empty batch when more peers are about to re-submit.
But because it never decays, *any* event that lifts it above the current steady state poisons
every subsequent sub-peak fire:

- **Concurrency decline** (no speculation needed): as in-flight requests finish, the active
  cohort falls from its peak (say 6) through 5, 4, 3… Each sub-peak cohort now fails rule 3 and
  waits out the watchdog, even though no more peers are coming.
- **Pass-level speculation**: speculative pre-fires transiently inflate a batch (e.g. 4 → 6–7),
  lifting the watermark; the normal cohort of ~4–5 is then permanently "below peak" and stalls.

So this is a general scheduler-policy defect, not a speculation-specific one — speculation is
just one trigger. (It surfaced first under speculation because that re-triggers the condition
continuously; see the speculation throughput discussion in #434's companion thread.)

## Reproduction & evidence

Workload: `tau2-bench` airline, `--num-tasks 12 --max-concurrency 6 --seed 10`,
`max_tokens=16384`, served via an OpenAI-compatible inferlet; 25-min budget per arm; engine
built `PIE_PORTABLE_CUDA=1 PIE_PORTABLE_CUDA_ARCH=89`, NVIDIA L40S, Qwen3-30B-A3B-GGUF (Q4_K_M).
Per-fire scheduler trace parsed into inter-fire gap by batch size; "stall %" = fires whose
preceding gap exceeds 2× the dominant (at-watermark) cohort's median.

| arm | watermark | stall % | inter-fire p95 |
|---|---|---|---|
| spec-off (no speculation) | monotonic (today) | **37.5%** | 104 ms |
| spec-on | monotonic (today) | 23.9–25.2% | 117–127 ms |
| spec-on | **relaxing (this PR)** | **0.2–0.6%** | **55–69 ms** |

Note the spec-**off** control already shows 37.5 % stalled fires purely from concurrency
decline — the bug reproduces with speculation entirely disabled. With the fix, the sub-peak
cohorts that previously sat at 100–125 ms (batch sizes 4–5 while the watermark was pinned at 6)
drop to ~40–65 ms, and the relaxing-watermark spec-on arms end up *cleaner than the monotonic
spec-off control*. Result reproduced in both verbose and quiet logging configurations.

## The change

`runtime/src/inference/adaptive_policy.rs` only:

```rust
fn relax_high_water(current: usize, fired_size: usize) -> usize {
    if fired_size >= current { fired_size } else { current.saturating_sub(1) }
}
// on_fired: self.fired_high_water = relax_high_water(self.fired_high_water, fired_size);
```

Decay-by-one (rather than e.g. snapping straight to the live size, or a sliding-window max) was
chosen against the recorded fire-size sequences: a window-max doesn't relax when large batches
recur, while snapping to the size of a single fire is too eager; stepping down by one removed
~99.7 % of the watchdog stalls in replay and reacts within 1–2 fires, while ignoring a lone
anomalously small fire. (On the observed traces the cohort never fell by more than one between
consecutive fires, so a snap-to-size variant would have been indistinguishable here.)

**Behavior preserved:** cold-start (`fired_high_water == 0`), the structural cap, and the
`last_latency` watchdog are unchanged. A uniform cohort keeps the watermark exactly at the
cohort size (verified by test), so steady-state batching and the existing coalescing benefit
are untouched — only the never-decaying tail behavior changes.

## Tests

`cargo test -p pie -- adaptive relax_high_water`: ratchet-up-on-exceed, relax-after-burst
(7 → settles at the live cohort of 5), steady-cohort stability (uniform load stays at the
cohort size, never inflates or under-fires), and the `relax_high_water` floor cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Adaptive policy watermark behavior enhanced to dynamically respond to workload changes with both upward and downward adjustments, providing improved flexibility in system adaptation.
* **Documentation**
  * Updated documentation reflecting the new adaptive policy watermark adjustment patterns.
* **Tests**
  * Expanded unit tests to validate watermark behavior under various workload scenarios and adjustment patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->