### PR TITLE
fix(driver/cuda): gate FlashInfer Mamba SM90 SSU on min arch, not any arch

### DIFF
--- a/driver/cuda/CMakeLists.txt
+++ b/driver/cuda/CMakeLists.txt
@@ -119,6 +119,8 @@ endif()
 
 set(PIE_CUDA_FLASHINFER_HOPPER_SOURCE src/ops/attention_flashinfer_hopper_stub.cpp)
 set(PIE_CUDA_FLASHINFER_MAMBA_SM90 OFF)
+set(_PIE_CUDA_HAS_SM90PLUS OFF)
+set(_PIE_CUDA_HAS_PRE_SM90 OFF)
 foreach(PIE_CUDA_ARCH IN LISTS CMAKE_CUDA_ARCHITECTURES)
   string(REGEX REPLACE "[^0-9].*$" "" PIE_CUDA_ARCH_NUMBER "${PIE_CUDA_ARCH}")
   if(PIE_CUDA_ARCH_NUMBER STREQUAL "90")
@@ -126,17 +128,19 @@ foreach(PIE_CUDA_ARCH IN LISTS CMAKE_CUDA_ARCHITECTURES)
       src/ops/attention_flashinfer_hopper.cu
       src/ops/attention_xqa_gqa8_sm90.cu
     )
-    set(PIE_CUDA_FLASHINFER_MAMBA_SM90 ON)
   endif()
-  # FlashInfer's Mamba SSU vertical/horizontal kernels use TMA +
-  # memcpy_async_tx, which Blackwell also supports. The runtime
-  # algorithm auto-selector in selective_state_update prefers the
-  # horizontal kernel for sm >= 10 with bf16/fp16 state — so the same
-  # FLASHINFER_MAMBA_ENABLE_SM90 compile gate should be on for sm_100.
-  if(PIE_CUDA_ARCH_NUMBER STREQUAL "100")
-    set(PIE_CUDA_FLASHINFER_MAMBA_SM90 ON)
+  if(PIE_CUDA_ARCH_NUMBER GREATER_EQUAL 90)
+    set(_PIE_CUDA_HAS_SM90PLUS ON)
+  else()
+    set(_PIE_CUDA_HAS_PRE_SM90 ON)
   endif()
 endforeach()
+# SM90 SSU uses CCCL TMA intrinsics that compile only when __CUDA_MINIMUM_ARCH__
+# >= 900 — i.e. the whole arch list is sm_90+. Enable the gate only for pure
+# sm_90+ builds; mixed builds fall back to the simple SSU algo (kAuto picks kSimple).
+if(_PIE_CUDA_HAS_SM90PLUS AND NOT _PIE_CUDA_HAS_PRE_SM90)
+  set(PIE_CUDA_FLASHINFER_MAMBA_SM90 ON)
+endif()
 if(PIE_CUDA_FLASHINFER_HOPPER_SOURCE MATCHES "stub")
   message(STATUS "Disabling FlashInfer Hopper/FA3 attention for CUDA architecture ${CMAKE_CUDA_ARCHITECTURES}")
 else()


### PR DESCRIPTION
## Problem

The slim CUDA Docker image (added in #363) no longer builds on `main`. A fresh e2e rebuild on yecl-gpu-02 (RTX 4090, CUDA 12.9) fails compiling `src/ops/flashinfer_mamba.cu`:

```
flashinfer/mamba/kernel_selective_state_update_stp.cuh:
  error: namespace "cuda::device::experimental" has no member
         "cp_async_bulk_tensor_4d_global_to_shared"   (+ ~30 more)
```

Routine CI never caught it: the `driver-cuda` job is gated behind a self-hosted runner + `ci-cuda` label, so the CUDA kernels are not compiled in normal PR CI.

## Root cause

The SM90 SSU vertical/horizontal kernels (new in v0.4.0; absent at the #363 merge) use CCCL's experimental TMA intrinsics, which `<cuda/barrier>` exposes only behind `__cccl_lib_experimental_ctk12_cp_async_exposure` — defined solely when `__CUDA_MINIMUM_ARCH__ >= 900`. `__CUDA_MINIMUM_ARCH__` is the **minimum** of the whole `CUDA_ARCHITECTURES` list and is constant across device passes, so the fat `80;86;89;90` Docker build pins it to 800 and `#ifdef`s the intrinsics out of every pass — even the sm_90 one.

The existing gate set `FLASHINFER_MAMBA_ENABLE_SM90` whenever **any** targeted arch was 90/100 — a condition a mixed build can never compile.

## Fix

Enable the SM90 SSU compile gate only when **every** targeted arch is sm_90+ (a pure Hopper/Blackwell build — e.g. the per-compute-capability release binaries). Mixed/fat builds fall back to the simple SSU algorithm: flashinfer's `kAuto` dispatch already selects `kSimple` on every device incl. Hopper when `FLASHINFER_MAMBA_ENABLE_SM90` is unset (verified in `invokeSelectiveStateUpdate`), so behavior is correct — just not the TMA-optimized path in a fat binary.

Hopper/FA3 attention gating is unchanged (it compiles fine in fat builds; it uses CUTLASS TMA, not the CCCL experimental gate).

## Verification

e2e on yecl-gpu-02 (RTX 4090, driver 575.57.08, CUDA 12.9) — current `main` + this fix:
- image builds, 4.11 GB runtime stage
- `pie doctor` → GPU 0 detected, `cuda_native` compiled in
- `pie run text-completion --prompt "The capital of France is"` → `The capital of France is **Paris**.`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Refined CUDA build configuration for FlashInfer Mamba SM90 optimization so the SM90+ path is enabled only when the build targets SM90+ exclusively, improving correctness and consistency for mixed-architecture builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
