### PR TITLE
feat(sdk): allow Generator context checkpoints

### DIFF
--- a/runtime/tests/inferlets/generate/src/lib.rs
+++ b/runtime/tests/inferlets/generate/src/lib.rs
@@ -34,10 +34,21 @@ async fn main(_input: String) -> Result<String> {
         .max_tokens(max_tokens);
 
     let mut generated = Vec::new();
+    let mut checkpointed_mid_generation = false;
     while let Some(step) = g.next()? {
         let out = step.execute().await?;
         if out.tokens.is_empty() {
             continue;
+        }
+        if !checkpointed_mid_generation {
+            let buffered_after_step = g.context().buffer().len();
+            let checkpoint = g.fork()?;
+            eprintln!(
+                "[GENERATE] forked checkpoint mid-generation with {} buffered tokens",
+                buffered_after_step
+            );
+            drop(checkpoint);
+            checkpointed_mid_generation = true;
         }
         eprintln!("[GENERATE] got tokens: {:?}", out.tokens);
         generated.extend(out.tokens.iter().copied());

--- a/sdk/rust/inferlet/src/generation.rs
+++ b/sdk/rust/inferlet/src/generation.rs
@@ -232,6 +232,47 @@ impl<'ctx> Generator<'ctx> {
         ProbeHandle::new(slot)
     }
 
+    // ── Context checkpoints ──────────────────────────────────────────
+
+    /// Borrow the underlying context without ending the generation
+    /// session. This is useful for read-only context operations such as
+    /// inspecting `buffer()`, page counts, or scheduler state while the
+    /// generator still owns the mutable borrow.
+    pub fn context(&self) -> &Context {
+        &*self.ctx
+    }
+
+    /// Fork the underlying context without ending the generation session.
+    ///
+    /// Unlike [`snapshot`](Self::snapshot), `Context::fork` also clones the
+    /// SDK-side token buffer, including any sampled token staged for the
+    /// next decode step. Prefer this for a complete in-memory checkpoint.
+    pub fn fork(&self) -> Result<Context> {
+        self.ctx.fork()
+    }
+
+    /// Save the underlying runtime context under `name` without ending the
+    /// generation session.
+    ///
+    /// This saves the host-side context state. It does not persist the
+    /// SDK-side token buffer; callers that need an exact restore point
+    /// should persist [`context().buffer()`](Context::buffer) alongside the
+    /// snapshot name, or use [`fork`](Self::fork) for an in-memory checkpoint.
+    pub fn save(&self, name: &str) -> Result<()> {
+        self.ctx.save(name)
+    }
+
+    /// Create an anonymous runtime snapshot of the underlying context
+    /// without ending the generation session.
+    ///
+    /// This saves the host-side context state. It does not persist the
+    /// SDK-side token buffer; callers that need an exact restore point
+    /// should persist [`context().buffer()`](Context::buffer) alongside the
+    /// snapshot name, or use [`fork`](Self::fork) for an in-memory checkpoint.
+    pub fn snapshot(&self) -> Result<String> {
+        self.ctx.snapshot()
+    }
+
     // ── Iteration ──────────────────────────────────────────────────────
 
     /// Whether generation has terminated (max_tokens or stop hit).


### PR DESCRIPTION
## Summary

Adds `Generator` passthroughs for context checkpoint operations while a generation session is still active:

- `Generator::context()` for read-only context inspection
- `Generator::fork()` for an in-memory checkpoint that also clones the SDK-side token buffer
- `Generator::save()` / `Generator::snapshot()` for host-side runtime snapshots

The generate test inferlet now exercises `g.context()` and `g.fork()?` after the first decode step, while the same `Generator` continues running.

## Why

`Context::generate()` borrows the context mutably for the lifetime of the returned `Generator`, so callers previously had to drop and rebuild the generator before checkpointing. That makes mid-generation checkpoint/restore patterns awkward, especially for tool-calling or recovery loops that want to checkpoint at token boundaries without tearing down the decode session.

Fixes #405.

## Verification

- `git diff --check main..feat/generator-checkpointing`
- `cargo build --manifest-path runtime/tests/inferlets/Cargo.toml --target wasm32-wasip2 -p generate`
- `cargo check -p pie`
- `cargo test -p pie --lib` — 433 passed, 0 failed, 2 ignored


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to save and fork generation context during inference, allowing users to preserve state mid-generation without interrupting the current session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->