### PR TITLE
fix(runtime): enforce network policy for wasi:http

### DIFF
--- a/runtime/src/bootstrap.rs
+++ b/runtime/src/bootstrap.rs
@@ -81,9 +81,9 @@ pub struct RuntimeConfig {
     /// linker binding is dropped entirely.
     pub allow_network: bool,
     /// Allowlist of `cidr[:port]` / `cidr:lo-hi`. `["*"]` = no
-    /// restriction. NOTE: only filters `wasi:sockets`; `wasi:http`
-    /// bypasses the per-socket hook. Set `allow_network = false` for
-    /// tight outbound HTTP control.
+    /// restriction. Applies to both `wasi:sockets` and outbound
+    /// `wasi:http`; restricted HTTP policies accept IP-literal authorities
+    /// only to avoid DNS time-of-check/time-of-use gaps.
     pub network_allowed_hosts: Vec<String>,
 
     // ── upload cap ───────────────────────────────────────────────────

--- a/runtime/src/instance.rs
+++ b/runtime/src/instance.rs
@@ -10,12 +10,18 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use wasmtime::component::{ResourceAny, ResourceTable};
 use wasmtime_wasi::{DirPerms, FilePerms, WasiCtx, WasiCtxView, WasiView};
+use wasmtime_wasi_http::bindings::http::types::ErrorCode as HttpErrorCode;
+use wasmtime_wasi_http::body::HyperOutgoingBody;
+use wasmtime_wasi_http::types::{
+    HostFutureIncomingResponse, OutgoingRequestConfig, default_send_request,
+};
 use wasmtime_wasi_http::{WasiHttpCtx, WasiHttpView};
 
 use self::output::LogStream;
 
 use crate::context;
 use crate::linker::InstancePolicy;
+use crate::policy::NetworkPolicy;
 use crate::process::ProcessId;
 
 /// Where an instance's stdout/stderr are routed.
@@ -40,6 +46,7 @@ pub struct InstanceState {
     wasi_ctx: WasiCtx,
     resource_table: ResourceTable,
     http_ctx: WasiHttpCtx,
+    network_policy: NetworkPolicy,
 
     /// Per-instance scratch directory, deleted on Drop.
     scratch_dir: PathBuf,
@@ -77,6 +84,43 @@ impl WasiHttpView for InstanceState {
 
     fn table(&mut self) -> &mut ResourceTable {
         &mut self.resource_table
+    }
+
+    fn send_request(
+        &mut self,
+        request: hyper::Request<HyperOutgoingBody>,
+        config: OutgoingRequestConfig,
+    ) -> wasmtime_wasi_http::HttpResult<HostFutureIncomingResponse> {
+        let default_port = if config.use_tls { 443 } else { 80 };
+        let target = request.uri().authority().map(|authority| {
+            (
+                authority.host().to_owned(),
+                authority.port_u16().unwrap_or(default_port),
+            )
+        });
+
+        let allowed = target
+            .as_ref()
+            .map_or(false, |(host, port)| {
+                self.network_policy.check_http_authority(host, *port)
+            });
+        if !allowed {
+            let (host, port) = target
+                .as_ref()
+                .map(|(host, port)| (host.as_str(), *port))
+                .unwrap_or(("<missing>", default_port));
+            tracing::warn!(
+                scheme = request.uri().scheme_str().unwrap_or("<none>"),
+                host = %host,
+                port = port,
+                "[runtime] denied wasi:http outbound request by network policy"
+            );
+            return Ok(HostFutureIncomingResponse::ready(Ok(Err(
+                HttpErrorCode::ConnectionRefused,
+            ))));
+        }
+
+        Ok(default_send_request(request, config))
     }
 }
 
@@ -169,6 +213,7 @@ impl InstanceState {
             wasi_ctx: builder.build(),
             resource_table: ResourceTable::new(),
             http_ctx: WasiHttpCtx::new(),
+            network_policy: policy.network.clone(),
             scratch_dir,
             // Dynamic linking support
             dynamic_resource_map: HashMap::new(),

--- a/runtime/src/linker.rs
+++ b/runtime/src/linker.rs
@@ -159,13 +159,10 @@ impl Linker {
 
         wasmtime_wasi::p2::add_to_linker_async(&mut linker).expect("Failed to link WASI");
 
-        // wasi:http operates above wasi:sockets and bypasses the per-socket
-        // policy hook (it uses the host's hyper stack with its own DNS).
-        // Drop the binding entirely when the network is disabled so the
-        // policy is honored end-to-end. With allow_network=true the hook
-        // is wired; the allowlist still applies to wasi:sockets but
-        // wasi:http is unrestricted (pre-DNS hostname allowlisting would
-        // require a DNS shim — not in v1).
+        // Drop the wasi:http binding entirely when the network is disabled.
+        // When enabled, InstanceState::send_request applies the same network
+        // policy used by wasi:sockets before forwarding through Wasmtime's
+        // default HTTP client.
         if self.policy.network.allow {
             wasmtime_wasi_http::add_only_http_to_linker_async(&mut linker)
                 .expect("Failed to link WASI HTTP");

--- a/runtime/src/policy.rs
+++ b/runtime/src/policy.rs
@@ -146,6 +146,30 @@ impl NetworkPolicy {
             .iter()
             .any(|r| ip_in_cidr(ip, &r.cidr) && r.port.matches(port))
     }
+
+    /// Check an HTTP authority after applying the default HTTP(S) port.
+    ///
+    /// Unrestricted policies allow hostnames for legacy compatibility. Restricted
+    /// policies only accept IP-literal authorities and apply the same CIDR/port
+    /// rules used for wasi:sockets. Hostnames are denied in restricted mode to
+    /// avoid a DNS time-of-check/time-of-use gap before Wasmtime's HTTP client
+    /// opens the connection.
+    pub fn check_http_authority(&self, host: &str, port: u16) -> bool {
+        if !self.allow {
+            return false;
+        }
+        if self.unrestricted {
+            return true;
+        }
+        let host = host
+            .strip_prefix('[')
+            .and_then(|s| s.strip_suffix(']'))
+            .unwrap_or(host);
+        let Ok(ip) = host.parse::<IpAddr>() else {
+            return false;
+        };
+        self.check(&SocketAddr::new(ip, port))
+    }
 }
 
 /// `cidr` or `cidr:port` or `cidr:lo-hi`. A bare IP without `/<n>` is
@@ -237,6 +261,39 @@ mod tests {
 
     fn sa(s: &str) -> SocketAddr {
         s.parse().unwrap()
+    }
+
+    #[test]
+    fn http_authority_denied_when_disabled() {
+        let p = NetworkPolicy::parse(false, &[]).unwrap();
+        assert!(!p.check_http_authority("127.0.0.1", 80));
+    }
+
+    #[test]
+    fn http_authority_allows_unrestricted_hostname() {
+        let p = NetworkPolicy::parse(true, &["*".into()]).unwrap();
+        assert!(p.check_http_authority("example.com", 443));
+    }
+
+    #[test]
+    fn http_authority_checks_ip_literal_and_port() {
+        let p = NetworkPolicy::parse(true, &["127.0.0.1:443".into()]).unwrap();
+        assert!(p.check_http_authority("127.0.0.1", 443));
+        assert!(!p.check_http_authority("127.0.0.1", 80));
+        assert!(!p.check_http_authority("127.0.0.2", 443));
+    }
+
+    #[test]
+    fn http_authority_checks_bracketed_ipv6_literal() {
+        let p = NetworkPolicy::parse(true, &["[::1]:443".into()]).unwrap();
+        assert!(p.check_http_authority("[::1]", 443));
+        assert!(!p.check_http_authority("[::1]", 80));
+    }
+
+    #[test]
+    fn http_authority_denies_hostname_when_restricted() {
+        let p = NetworkPolicy::parse(true, &["127.0.0.1:443".into()]).unwrap();
+        assert!(!p.check_http_authority("localhost", 443));
     }
 
     #[test]

--- a/server/src/cli/config_cmd/template.rs
+++ b/server/src/cli/config_cmd/template.rs
@@ -51,9 +51,9 @@ wasm_warm_slots = 100
 # Filesystem. allow_fs = true mounts a per-process /scratch dir with full RW.
 allow_fs = false
 
-# Network. `network_allowed_hosts` filters wasi:sockets only — wasi:http
-# bypasses the per-socket hook (its host stack does its own DNS). Set
-# allow_network = false for tight outbound HTTP control.
+# Network. `network_allowed_hosts` filters wasi:sockets and outbound
+# wasi:http. Restricted HTTP policies accept IP-literal authorities only;
+# use ["*"] for legacy unrestricted host networking.
 allow_network = true
 network_allowed_hosts = ["*"]
 

--- a/website/docs/reference/configuration.mdx
+++ b/website/docs/reference/configuration.mdx
@@ -107,8 +107,8 @@ The `[runtime]` block tunes the tokio worker pool, the wasmtime engine pool, the
 | `wasm_warm_slots` | `100` | Number of pool slots to keep warm. Must be `>= 0`. |
 | `allow_fs` | `false` | When true, every inferlet receives a preopened scratch directory at `/scratch` mapped to a per-process subdirectory under `fs_scratch_dir`. Inferlets without this flag have no host filesystem visibility. |
 | `fs_scratch_dir` | `<tempdir>/pie` | Host root under which per-process `/scratch` directories are created when `allow_fs = true`. |
-| `allow_network` | `true` | When false, wasi:sockets is denied. Useful for tight outbound HTTP control. |
-| `network_allowed_hosts` | `["*"]` | Allowed-host filter for wasi:sockets. Supports CIDRs and host:port forms (e.g. `["10.0.0.0/8", "127.0.0.1"]`, `["10.0.0.0/8:443"]`). Filters wasi:sockets only — wasi:http bypasses the per-socket hook. |
+| `allow_network` | `true` | When false, wasi:sockets is denied and outbound wasi:http is not linked. Useful for tight outbound HTTP control. |
+| `network_allowed_hosts` | `["*"]` | Allowed-host filter for wasi:sockets and outbound wasi:http. Supports CIDRs and host:port forms (e.g. `["10.0.0.0/8", "127.0.0.1"]`, `["10.0.0.0/8:443"]`). Restricted wasi:http policies accept IP-literal authorities only; use `["*"]` for legacy unrestricted host networking. |
 | `max_upload_mb` | `256` | Maximum size of a single chunked upload accepted by the server, in MiB. Must be `> 0`. |
 
 ## Per-model keys


### PR DESCRIPTION
## Problem

`wasi:http` runs through Wasmtime's host HTTP stack, not the `wasi:sockets` connect hook. Pie already dropped the HTTP linker binding when `allow_network = false`, but with `allow_network = true` a restricted `network_allowed_hosts` policy still did not constrain outbound HTTP requests.

That meant an inferlet with a socket allowlist could still use `wasi:http` to reach hosts outside the allowlist.

## Fix

Override `WasiHttpView::send_request` in `InstanceState` and check the outgoing request authority before handing it to Wasmtime's default HTTP client.

- `allow_network = false`: unchanged; `wasi:http` is not linked.
- `network_allowed_hosts = ["*"]`: preserves legacy unrestricted hostname behavior.
- restricted allowlists: outbound HTTP must use an IP-literal authority and pass the same CIDR/port rules as `wasi:sockets`.

Restricted mode deliberately rejects hostname authorities instead of resolving them in policy code, avoiding a DNS time-of-check/time-of-use gap before the default HTTP client opens the connection. Denied requests return `ConnectionRefused` and log only scheme/host/port, not the full URI.

The runtime config comments and generated config template are updated to describe the HTTP behavior.

## Verification

- `git diff --check main..feat/wasi-http-network-policy`
- `cargo check -p pie`
- `cargo test -p pie --lib policy::tests` — 36 passed, 0 failed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Network allowlist policies now consistently apply to outbound HTTP requests, matching `wasi:sockets` behavior.
  * HTTP requests in restricted policies are limited to IP-literal authorities to prevent DNS timing-of-check/time-of-use vulnerabilities.

* **Documentation**
  * Updated configuration guidance to clarify network policy enforcement across both socket and HTTP interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->