### PR TITLE
feat(sdk): align generator rebidding across sdks

### DIFF
--- a/sdk/javascript/src/generation.ts
+++ b/sdk/javascript/src/generation.ts
@@ -319,7 +319,7 @@ export class Generator implements AsyncIterable<GenStep> {
     const balance = _scheduling.balance(this._ctx._model._handle);
     const dividend = _scheduling.dividend(this._ctx._model._handle);
     const pages = Math.max(1, this._ctx._committedPages + this._ctx._workingPages);
-    const [mu, cv2] = this._bidShape();
+    const [mu, cv2] = this._initialBidShape();
     this._ctx.setBid(_computeBid(balance, pages, mu, cv2, this._ctx._pageSize, dividend));
   }
 
@@ -343,6 +343,17 @@ export class Generator implements AsyncIterable<GenStep> {
       return [Math.max(this._maxTokens - this._tokensGenerated, 1), 1.0];
     }
     return [Math.max(this._tokensGenerated, 64), 1.0];
+  }
+
+  /** @internal */
+  _initialBidShape(): [number, number] {
+    if (this._horizon !== undefined) {
+      return [Math.max(this._horizon, 1), 0.0];
+    }
+    if (this._maxTokens !== undefined) {
+      return [Math.max(this._maxTokens, 1), 1.0];
+    }
+    return [4096.0, 1.0];
   }
 
   /** @internal */

--- a/sdk/javascript/src/generation.ts
+++ b/sdk/javascript/src/generation.ts
@@ -190,7 +190,11 @@ export class Generator implements AsyncIterable<GenStep> {
   // ── Chain methods (alternative to options-object) ──────────────────────
 
   /** Hard cap on tokens generated. */
-  maxTokens(n: number): this { this._maxTokens = n; return this; }
+  maxTokens(n: number): this {
+    this._maxTokens = n;
+    this._refreshStaticBid();
+    return this;
+  }
 
   /** Stop tokens. */
   stop(tokens: Iterable<number>): this {
@@ -219,12 +223,17 @@ export class Generator implements AsyncIterable<GenStep> {
   }
 
   /** Hint expected output length for budget planning. */
-  horizon(n: number): this { this._horizon = n; return this; }
+  horizon(n: number): this {
+    this._horizon = n;
+    this._refreshStaticBid();
+    return this;
+  }
 
   /** Control whether the generator refreshes its scheduler bid before
    *  every decode step. */
   rebidEachStep(enabled: boolean): this {
     this._rebidEachStep = enabled;
+    this._refreshStaticBid();
     return this;
   }
 
@@ -310,14 +319,8 @@ export class Generator implements AsyncIterable<GenStep> {
     const balance = _scheduling.balance(this._ctx._model._handle);
     const dividend = _scheduling.dividend(this._ctx._model._handle);
     const pages = Math.max(1, this._ctx._committedPages + this._ctx._workingPages);
-    this._ctx.setBid(_computeBid(
-      balance,
-      pages,
-      4096.0,
-      1.0,
-      this._ctx._pageSize,
-      dividend,
-    ));
+    const [mu, cv2] = this._bidShape();
+    this._ctx.setBid(_computeBid(balance, pages, mu, cv2, this._ctx._pageSize, dividend));
   }
 
   /** @internal */
@@ -327,20 +330,24 @@ export class Generator implements AsyncIterable<GenStep> {
     const pages = this._ctx._committedPages + this._ctx._workingPages;
     const pageSize = this._ctx._pageSize;
 
-    let mu: number;
-    let cv2: number;
-    if (this._horizon !== undefined) {
-      mu = Math.max(this._horizon - this._tokensGenerated, 1);
-      cv2 = 0.0;
-    } else if (this._maxTokens !== undefined) {
-      mu = Math.max(this._maxTokens - this._tokensGenerated, 1);
-      cv2 = 1.0;
-    } else {
-      mu = Math.max(this._tokensGenerated, 64);
-      cv2 = 1.0;
-    }
-
+    const [mu, cv2] = this._bidShape();
     this._ctx.setBid(_computeBid(balance, pages, mu, cv2, pageSize, dividend));
+  }
+
+  /** @internal */
+  _bidShape(): [number, number] {
+    if (this._horizon !== undefined) {
+      return [Math.max(this._horizon - this._tokensGenerated, 1), 0.0];
+    }
+    if (this._maxTokens !== undefined) {
+      return [Math.max(this._maxTokens - this._tokensGenerated, 1), 1.0];
+    }
+    return [Math.max(this._tokensGenerated, 64), 1.0];
+  }
+
+  /** @internal */
+  _refreshStaticBid(): void {
+    if (!this._rebidEachStep) this._primeBid();
   }
 
   // ── User-sampled mode ──────────────────────────────────────────────────

--- a/sdk/javascript/src/generation.ts
+++ b/sdk/javascript/src/generation.ts
@@ -29,6 +29,7 @@ import {
   type Output as WitOutput,
   type Brle,
 } from 'pie:core/inference';
+import * as _scheduling from 'pie:core/scheduling';
 
 import { awaitFuture } from './_async.js';
 import * as _chat from './chat.js';
@@ -56,6 +57,20 @@ import type { Speculator } from './spec.js';
 function _samplerIsArgmax(sampler: Sampler): boolean {
   const variant = sampler._variant;
   return variant.tag === 'top-p' && variant.val[0] === 0.0;
+}
+
+function _computeBid(
+  balance: number,
+  pages: number,
+  mu: number,
+  cv2: number,
+  pageSize: number,
+  dividend: number,
+): number {
+  mu = Math.max(mu, 1.0);
+  const numerator = balance / mu + dividend;
+  const denominator = pages + (mu * (1.0 + cv2)) / (2.0 * pageSize);
+  return denominator > 0 ? numerator / denominator : numerator;
 }
 
 // =============================================================================
@@ -86,6 +101,8 @@ export interface GenerateOptions {
   zoSeed?: number;
   /** Expected output length for budget planning. */
   horizon?: number;
+  /** Refresh the scheduler bid before every decode step. Defaults to true. */
+  rebidEachStep?: boolean;
 }
 
 // =============================================================================
@@ -113,6 +130,7 @@ export class Generator implements AsyncIterable<GenStep> {
   /** @internal */ _zoSeed: number | undefined;
   /** @internal */ _stepProbes: Array<[number, Probe]> = [];
   /** @internal */ _tokensGenerated = 0;
+  /** @internal */ _rebidEachStep: boolean;
   /** @internal */ _done = false;
 
   constructor(
@@ -127,6 +145,7 @@ export class Generator implements AsyncIterable<GenStep> {
     this._horizon = options.horizon;
     this._adapter = options.adapter;
     this._zoSeed = options.zoSeed;
+    this._rebidEachStep = options.rebidEachStep ?? true;
 
     // Constraints — accept Schema, Constraint, or array.
     if (options.constrain !== undefined) {
@@ -150,6 +169,8 @@ export class Generator implements AsyncIterable<GenStep> {
       (options.speculator === undefined &&
         _samplerIsArgmax(sampler) &&
         ctx._model.defaultSystemSpeculation());
+
+    this._primeBid();
   }
 
   /** @internal */
@@ -200,6 +221,13 @@ export class Generator implements AsyncIterable<GenStep> {
   /** Hint expected output length for budget planning. */
   horizon(n: number): this { this._horizon = n; return this; }
 
+  /** Control whether the generator refreshes its scheduler bid before
+   *  every decode step. */
+  rebidEachStep(enabled: boolean): this {
+    this._rebidEachStep = enabled;
+    return this;
+  }
+
   /** Apply an adapter on every forward pass. */
   adapter(a: Adapter): this { this._adapter = a; return this; }
 
@@ -244,6 +272,8 @@ export class Generator implements AsyncIterable<GenStep> {
 
   /** @internal */
   _buildStep(): GenStep {
+    if (this._rebidEachStep) this._recomputeBid();
+
     // Drain context buffer (filled by `system / user / cue / ...`).
     const pending = this._ctx._pendingTokens;
     this._ctx._pendingTokens = new Uint32Array();
@@ -273,6 +303,44 @@ export class Generator implements AsyncIterable<GenStep> {
     }
 
     return new GenStep(this, pending, drafts, draftPositions, mask);
+  }
+
+  /** @internal */
+  _primeBid(): void {
+    const balance = _scheduling.balance(this._ctx._model._handle);
+    const dividend = _scheduling.dividend(this._ctx._model._handle);
+    const pages = Math.max(1, this._ctx._committedPages + this._ctx._workingPages);
+    this._ctx.setBid(_computeBid(
+      balance,
+      pages,
+      4096.0,
+      1.0,
+      this._ctx._pageSize,
+      dividend,
+    ));
+  }
+
+  /** @internal */
+  _recomputeBid(): void {
+    const balance = _scheduling.balance(this._ctx._model._handle);
+    const dividend = _scheduling.dividend(this._ctx._model._handle);
+    const pages = this._ctx._committedPages + this._ctx._workingPages;
+    const pageSize = this._ctx._pageSize;
+
+    let mu: number;
+    let cv2: number;
+    if (this._horizon !== undefined) {
+      mu = Math.max(this._horizon - this._tokensGenerated, 1);
+      cv2 = 0.0;
+    } else if (this._maxTokens !== undefined) {
+      mu = Math.max(this._maxTokens - this._tokensGenerated, 1);
+      cv2 = 1.0;
+    } else {
+      mu = Math.max(this._tokensGenerated, 64);
+      cv2 = 1.0;
+    }
+
+    this._ctx.setBid(_computeBid(balance, pages, mu, cv2, pageSize, dividend));
   }
 
   // ── User-sampled mode ──────────────────────────────────────────────────

--- a/sdk/python/src/inferlet/context.py
+++ b/sdk/python/src/inferlet/context.py
@@ -288,6 +288,7 @@ class Context:
         adapter: Adapter | None = None,
         zo_seed: int | None = None,
         horizon: int | None = None,
+        rebid_each_step: bool = True,
         auto_flush: bool = True,
     ) -> Generator:
         """Build a :class:`Generator` for token generation.
@@ -319,6 +320,7 @@ class Context:
             adapter: Adapter to apply on every forward pass.
             zo_seed: Evolution Strategies seed for every forward pass.
             horizon: Expected output length for budget planning.
+            rebid_each_step: Refresh the scheduler bid before every decode step.
             auto_flush: Append ``cue()`` and use chat stop tokens by default.
         """
         if auto_flush:
@@ -338,6 +340,7 @@ class Context:
             adapter=adapter,
             zo_seed=zo_seed,
             horizon=horizon,
+            rebid_each_step=rebid_each_step,
         )
 
     # ── Bidding / scheduling ─────────────────────────────────────────

--- a/sdk/python/src/inferlet/generation.py
+++ b/sdk/python/src/inferlet/generation.py
@@ -38,6 +38,7 @@ from wit_world.imports import zo as _zo
 from wit_world.imports.inference import SlotOutput_Token
 
 from . import chat as _chat
+from . import scheduling as _sched
 from ._async import await_future
 from .forward import Output, ProbeHandle, SampleHandle, _probe_kind
 from .grammar import (
@@ -64,6 +65,21 @@ def _sampler_is_argmax(sampler: Any) -> bool:
         return False
     temperature, _ = value
     return float(temperature) == 0.0
+
+
+def _compute_bid(
+    balance: float,
+    pages: float,
+    mu: float,
+    cv2: float,
+    page_size: float,
+    dividend: float,
+) -> float:
+    """Budget-exhausting bid formula (matches Rust SDK)."""
+    mu = max(mu, 1.0)
+    numerator = balance / mu + dividend
+    denominator = pages + mu * (1.0 + cv2) / (2.0 * page_size)
+    return numerator / denominator if denominator > 0 else numerator
 
 
 # =============================================================================
@@ -112,6 +128,7 @@ class Generator:
         "_zo_seed",
         "_step_probes",
         "_tokens_generated",
+        "_rebid_each_step",
         "_done",
     )
 
@@ -129,6 +146,7 @@ class Generator:
         adapter: Adapter | None = None,
         zo_seed: int | None = None,
         horizon: int | None = None,
+        rebid_each_step: bool = True,
     ) -> None:
         self._ctx = ctx
         self._sampler = sampler
@@ -141,6 +159,7 @@ class Generator:
         self._zo_seed = zo_seed
         self._step_probes: list[tuple[int, Any]] = []  # (index, probe)
         self._tokens_generated = 0
+        self._rebid_each_step = rebid_each_step
         self._done = False
 
         # Constraints — accept Schema, Constraint, or list of either.
@@ -167,6 +186,7 @@ class Generator:
         # Cache for next-iter system drafts (populated each step from
         # the WIT output's spec channel when system speculation is on).
         self._spec_drafts: tuple[list[int], list[int]] = ([], [])
+        self._prime_bid()
 
     def _add_constraint(self, c: Schema | Constraint) -> None:
         if hasattr(c, "build_constraint"):
@@ -213,6 +233,12 @@ class Generator:
         self._horizon = n
         return self
 
+    def rebid_each_step(self, enabled: bool) -> Generator:
+        """Control whether the generator refreshes its scheduler bid before
+        every decode step."""
+        self._rebid_each_step = enabled
+        return self
+
     def adapter(self, a: Adapter) -> Generator:
         """Apply an adapter (LoRA etc.) on every forward pass."""
         self._adapter = a
@@ -253,6 +279,9 @@ class Generator:
         if self.is_done:
             raise StopAsyncIteration
 
+        if self._rebid_each_step:
+            self._recompute_bid()
+
         # Drain context buffer (filled by `system / user / cue / ...`).
         pending = self._ctx._pending_tokens
         self._ctx._pending_tokens = []
@@ -283,6 +312,36 @@ class Generator:
             list(draft_positions),
             mask,
         )
+
+    def _prime_bid(self) -> None:
+        balance = _sched.balance(self._ctx._model)
+        dividend = _sched.dividend(self._ctx._model)
+        pages = max(1.0, float(self._ctx._committed_pages + self._ctx._working_pages))
+        self._ctx.set_bid(
+            _compute_bid(
+                balance,
+                pages,
+                4096.0,
+                1.0,
+                float(self._ctx._page_size),
+                dividend,
+            )
+        )
+
+    def _recompute_bid(self) -> None:
+        balance = _sched.balance(self._ctx._model)
+        dividend = _sched.dividend(self._ctx._model)
+        pages = float(self._ctx._committed_pages + self._ctx._working_pages)
+        page_size = float(self._ctx._page_size)
+
+        if self._horizon is not None:
+            mu, cv2 = max(self._horizon - self._tokens_generated, 1), 0.0
+        elif self._max_tokens is not None:
+            mu, cv2 = max(self._max_tokens - self._tokens_generated, 1), 1.0
+        else:
+            mu, cv2 = max(self._tokens_generated, 64), 1.0
+
+        self._ctx.set_bid(_compute_bid(balance, pages, mu, cv2, page_size, dividend))
 
     # ── User-sampled mode ────────────────────────────────────────────
 

--- a/sdk/python/src/inferlet/generation.py
+++ b/sdk/python/src/inferlet/generation.py
@@ -204,6 +204,7 @@ class Generator:
     def max_tokens(self, n: int) -> Generator:
         """Hard cap on tokens generated across all steps."""
         self._max_tokens = n
+        self._refresh_static_bid()
         return self
 
     def stop(self, tokens: Iterable[int]) -> Generator:
@@ -231,12 +232,14 @@ class Generator:
     def horizon(self, n: int) -> Generator:
         """Hint expected output length for budget planning."""
         self._horizon = n
+        self._refresh_static_bid()
         return self
 
     def rebid_each_step(self, enabled: bool) -> Generator:
         """Control whether the generator refreshes its scheduler bid before
         every decode step."""
         self._rebid_each_step = enabled
+        self._refresh_static_bid()
         return self
 
     def adapter(self, a: Adapter) -> Generator:
@@ -317,12 +320,13 @@ class Generator:
         balance = _sched.balance(self._ctx._model)
         dividend = _sched.dividend(self._ctx._model)
         pages = max(1.0, float(self._ctx._committed_pages + self._ctx._working_pages))
+        mu, cv2 = self._bid_shape()
         self._ctx.set_bid(
             _compute_bid(
                 balance,
                 pages,
-                4096.0,
-                1.0,
+                mu,
+                cv2,
                 float(self._ctx._page_size),
                 dividend,
             )
@@ -334,14 +338,19 @@ class Generator:
         pages = float(self._ctx._committed_pages + self._ctx._working_pages)
         page_size = float(self._ctx._page_size)
 
-        if self._horizon is not None:
-            mu, cv2 = max(self._horizon - self._tokens_generated, 1), 0.0
-        elif self._max_tokens is not None:
-            mu, cv2 = max(self._max_tokens - self._tokens_generated, 1), 1.0
-        else:
-            mu, cv2 = max(self._tokens_generated, 64), 1.0
-
+        mu, cv2 = self._bid_shape()
         self._ctx.set_bid(_compute_bid(balance, pages, mu, cv2, page_size, dividend))
+
+    def _bid_shape(self) -> tuple[float, float]:
+        if self._horizon is not None:
+            return float(max(self._horizon - self._tokens_generated, 1)), 0.0
+        if self._max_tokens is not None:
+            return float(max(self._max_tokens - self._tokens_generated, 1)), 1.0
+        return float(max(self._tokens_generated, 64)), 1.0
+
+    def _refresh_static_bid(self) -> None:
+        if not self._rebid_each_step:
+            self._prime_bid()
 
     # ── User-sampled mode ────────────────────────────────────────────
 

--- a/sdk/python/src/inferlet/generation.py
+++ b/sdk/python/src/inferlet/generation.py
@@ -320,7 +320,7 @@ class Generator:
         balance = _sched.balance(self._ctx._model)
         dividend = _sched.dividend(self._ctx._model)
         pages = max(1.0, float(self._ctx._committed_pages + self._ctx._working_pages))
-        mu, cv2 = self._bid_shape()
+        mu, cv2 = self._initial_bid_shape()
         self._ctx.set_bid(
             _compute_bid(
                 balance,
@@ -347,6 +347,13 @@ class Generator:
         if self._max_tokens is not None:
             return float(max(self._max_tokens - self._tokens_generated, 1)), 1.0
         return float(max(self._tokens_generated, 64)), 1.0
+
+    def _initial_bid_shape(self) -> tuple[float, float]:
+        if self._horizon is not None:
+            return float(max(self._horizon, 1)), 0.0
+        if self._max_tokens is not None:
+            return float(max(self._max_tokens, 1)), 1.0
+        return 4096.0, 1.0
 
     def _refresh_static_bid(self) -> None:
         if not self._rebid_each_step:

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -100,6 +100,7 @@ class FakeContext:
         self._cursor: int = 0
         self._committed_pages: int = 0
         self._tokens_per_page_val: int = 64
+        self._bid: float = 0.0
 
     @classmethod
     def create(cls, model):
@@ -151,6 +152,9 @@ class FakeContext:
 
     def truncate_working_page_tokens(self, num_tokens):
         self._cursor = max(0, self._cursor - num_tokens)
+
+    def bid(self, value):
+        self._bid = value
 
     def __enter__(self):
         return self

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -265,6 +265,24 @@ class TestForward:
 
 
 class TestGenerator:
+    class _RecordingHandle:
+        def __init__(self, inner):
+            self._inner = inner
+            self.bids: list[float] = []
+
+        def bid(self, value: float) -> None:
+            self.bids.append(value)
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    @staticmethod
+    def _expected_bid(mu: float, cv2: float) -> float:
+        balance = 1000.0
+        pages = 1.0
+        page_size = 64.0
+        return (balance / mu) / (pages + mu * (1.0 + cv2) / (2.0 * page_size))
+
     def test_generate_returns_generator(self):
         from inferlet import Context, Generator, Model, Sampler
         ctx = Context(Model.load("test-model"))
@@ -290,19 +308,8 @@ class TestGenerator:
         import asyncio
         from inferlet import Context, Model, Sampler
 
-        class _RecordingHandle:
-            def __init__(self, inner):
-                self._inner = inner
-                self.bids: list[float] = []
-
-            def bid(self, value: float) -> None:
-                self.bids.append(value)
-
-            def __getattr__(self, name):
-                return getattr(self._inner, name)
-
         ctx = Context(Model.load("test-model"))
-        ctx._handle = _RecordingHandle(ctx._handle)
+        ctx._handle = self._RecordingHandle(ctx._handle)
         g = ctx.generate(Sampler.argmax(), auto_flush=False)
 
         assert len(ctx._handle.bids) == 1
@@ -313,24 +320,47 @@ class TestGenerator:
         import asyncio
         from inferlet import Context, Model, Sampler
 
-        class _RecordingHandle:
-            def __init__(self, inner):
-                self._inner = inner
-                self.bids: list[float] = []
-
-            def bid(self, value: float) -> None:
-                self.bids.append(value)
-
-            def __getattr__(self, name):
-                return getattr(self._inner, name)
-
         ctx = Context(Model.load("test-model"))
-        ctx._handle = _RecordingHandle(ctx._handle)
+        ctx._handle = self._RecordingHandle(ctx._handle)
         g = ctx.generate(Sampler.argmax(), auto_flush=False, rebid_each_step=False)
 
         assert len(ctx._handle.bids) == 1
         asyncio.run(g.__anext__())
         assert len(ctx._handle.bids) == 1
+
+    def test_disabled_step_rebid_primes_from_options(self):
+        import pytest
+        from inferlet import Context, Model, Sampler
+
+        ctx = Context(Model.load("test-model"))
+        ctx._handle = self._RecordingHandle(ctx._handle)
+        ctx.generate(
+            Sampler.argmax(),
+            max_tokens=16,
+            horizon=32,
+            rebid_each_step=False,
+            auto_flush=False,
+        )
+
+        assert len(ctx._handle.bids) == 1
+        assert ctx._handle.bids[-1] == pytest.approx(self._expected_bid(32.0, 0.0))
+
+    def test_disabling_step_rebid_reprimes_after_chain_methods(self):
+        import pytest
+        from inferlet import Context, Model, Sampler
+
+        mu = 16.0
+
+        ctx = Context(Model.load("test-model"))
+        ctx._handle = self._RecordingHandle(ctx._handle)
+        (
+            ctx.generate(Sampler.argmax(), auto_flush=False)
+            .max_tokens(int(mu))
+            .rebid_each_step(False)
+        )
+
+        assert len(ctx._handle.bids) == 2
+        assert ctx._handle.bids[-1] == pytest.approx(self._expected_bid(mu, 1.0))
 
     def test_constrain_with_schema(self):
         from inferlet import (

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -279,10 +279,58 @@ class TestGenerator:
             ctx.generate(Sampler.argmax(), auto_flush=False)
             .max_tokens(128)
             .horizon(256)
+            .rebid_each_step(False)
         )
         assert isinstance(g, Generator)
         assert g._max_tokens == 128
         assert g._horizon == 256
+        assert g._rebid_each_step is False
+
+    def test_generator_rebids_each_step_by_default(self):
+        import asyncio
+        from inferlet import Context, Model, Sampler
+
+        class _RecordingHandle:
+            def __init__(self, inner):
+                self._inner = inner
+                self.bids: list[float] = []
+
+            def bid(self, value: float) -> None:
+                self.bids.append(value)
+
+            def __getattr__(self, name):
+                return getattr(self._inner, name)
+
+        ctx = Context(Model.load("test-model"))
+        ctx._handle = _RecordingHandle(ctx._handle)
+        g = ctx.generate(Sampler.argmax(), auto_flush=False)
+
+        assert len(ctx._handle.bids) == 1
+        asyncio.run(g.__anext__())
+        assert len(ctx._handle.bids) == 2
+
+    def test_generator_can_disable_step_rebids(self):
+        import asyncio
+        from inferlet import Context, Model, Sampler
+
+        class _RecordingHandle:
+            def __init__(self, inner):
+                self._inner = inner
+                self.bids: list[float] = []
+
+            def bid(self, value: float) -> None:
+                self.bids.append(value)
+
+            def __getattr__(self, name):
+                return getattr(self._inner, name)
+
+        ctx = Context(Model.load("test-model"))
+        ctx._handle = _RecordingHandle(ctx._handle)
+        g = ctx.generate(Sampler.argmax(), auto_flush=False, rebid_each_step=False)
+
+        assert len(ctx._handle.bids) == 1
+        asyncio.run(g.__anext__())
+        assert len(ctx._handle.bids) == 1
 
     def test_constrain_with_schema(self):
         from inferlet import (

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -318,6 +318,7 @@ class TestGenerator:
 
     def test_generator_can_disable_step_rebids(self):
         import asyncio
+        import pytest
         from inferlet import Context, Model, Sampler
 
         ctx = Context(Model.load("test-model"))
@@ -325,6 +326,7 @@ class TestGenerator:
         g = ctx.generate(Sampler.argmax(), auto_flush=False, rebid_each_step=False)
 
         assert len(ctx._handle.bids) == 1
+        assert ctx._handle.bids[-1] == pytest.approx(self._expected_bid(4096.0, 1.0))
         asyncio.run(g.__anext__())
         assert len(ctx._handle.bids) == 1
 

--- a/sdk/python/tests/test_sdk.py
+++ b/sdk/python/tests/test_sdk.py
@@ -272,6 +272,7 @@ class TestGenerator:
 
         def bid(self, value: float) -> None:
             self.bids.append(value)
+            self._inner.bid(value)
 
         def __getattr__(self, name):
             return getattr(self._inner, name)

--- a/website/docs/guide/context/scheduling.mdx
+++ b/website/docs/guide/context/scheduling.mdx
@@ -97,6 +97,8 @@ Where `mu` is the expected steps to finish, `cv2` is the squared coefficient of 
 
 You do not need to read this formula to use Pie. It says: bid more when you have more credit, when more dividend is coming, and when fewer pages are at stake; bid less when many pages are at stake or when the horizon is long.
 
+The SDK refreshes this bid before every decode step by default. Throughput-oriented single-tenant loops can disable that refresh with `rebid_each_step(false)` / `rebidEachStep(false)` after the initial bid has been set.
+
 ## Override the bid
 
 Two ways to influence the bid.

--- a/website/docs/guide/context/scheduling.mdx
+++ b/website/docs/guide/context/scheduling.mdx
@@ -97,7 +97,7 @@ Where `mu` is the expected steps to finish, `cv2` is the squared coefficient of 
 
 You do not need to read this formula to use Pie. It says: bid more when you have more credit, when more dividend is coming, and when fewer pages are at stake; bid less when many pages are at stake or when the horizon is long.
 
-The SDK refreshes this bid before every decode step by default. Throughput-oriented single-tenant loops can disable that refresh with `rebid_each_step(false)` / `rebidEachStep(false)` after the initial bid has been set.
+The SDK refreshes this bid before every decode step by default. Throughput-oriented single-tenant loops can disable that refresh with `rebid_each_step(False)` / `rebidEachStep(false)` after the initial bid has been set.
 
 ## Override the bid
 

--- a/website/docs/reference/sdk-javascript.mdx
+++ b/website/docs/reference/sdk-javascript.mdx
@@ -157,6 +157,7 @@ const g = ctx.generate(Sampler.topP(0.6, 0.95), { maxTokens: 256 });
 | `adapter` | `Adapter` | LoRA adapter to apply. |
 | `zoSeed` | `number` | Evolution Strategies seed for every forward pass. |
 | `horizon` | `number` | Hint expected output length. |
+| `rebidEachStep` | `boolean` | Refresh the scheduler bid before every decode step. Default `true`. |
 | `autoFlush` | `boolean` | When `true` (default), append `cue()` to the buffer before returning the Generator and use chat-template stop tokens by default. |
 
 `speculator` and `systemSpeculation` are mutually exclusive.
@@ -170,6 +171,7 @@ const g = ctx.generate(Sampler.topP(0.6, 0.95), { maxTokens: 256 });
 | `g.addStop(tokens): this` | Append to the stop set. |
 | `g.constrain(c): this` | Add a constraint. |
 | `g.horizon(n): this` | Hint expected output length. |
+| `g.rebidEachStep(enabled): this` | Enable or disable per-step scheduler bid refresh. |
 | `g.adapter(a): this` | Apply an adapter. |
 | `g.zoSeed(seed): this` | Set an Evolution Strategies seed for every step. |
 | `g.probeEachStep(idx, probe): ProbeHandle` | Attach a probe at `idx` on every step. |

--- a/website/docs/reference/sdk-python.mdx
+++ b/website/docs/reference/sdk-python.mdx
@@ -142,6 +142,7 @@ g = ctx.generate(Sampler.top_p(0.6, 0.95), max_tokens=256)
 | `adapter` | `Adapter \| None` | LoRA adapter to apply on every step. |
 | `zo_seed` | `int \| None` | Evolution Strategies seed for every forward pass. |
 | `horizon` | `int \| None` | Hint expected output length for credit pacing. |
+| `rebid_each_step` | `bool` | Refresh the scheduler bid before every decode step. Default `True`. |
 | `auto_flush` | `bool` | When `True` (default), append `cue()` to the buffer before returning the Generator and use chat-template stop tokens by default. Set `False` to inspect the buffer or call `cue()` yourself. |
 
 `speculator` and `system_speculation` are mutually exclusive.
@@ -155,6 +156,7 @@ g = ctx.generate(Sampler.top_p(0.6, 0.95), max_tokens=256)
 | `g.add_stop(tokens)` | Append to the stop set. |
 | `g.constrain(c)` | Add a constraint. Composes with previously attached ones. |
 | `g.horizon(n)` | Hint expected output length. |
+| `g.rebid_each_step(enabled)` | Enable or disable per-step scheduler bid refresh. |
 | `g.adapter(a)` | Apply an adapter. |
 | `g.zo_seed(seed)` | Set an Evolution Strategies seed for every step. |
 | `g.probe_each_step(idx, probe) -> ProbeHandle` | Attach a probe to every step. |

--- a/website/docs/reference/sdk-rust.mdx
+++ b/website/docs/reference/sdk-rust.mdx
@@ -196,6 +196,7 @@ let g = ctx.generate(Sampler::TopP { temperature: 0.6, p: 0.95 })
 | `.adapter(&a)` | Apply a LoRA adapter. |
 | `.zo_seed(seed: i64)` | Set an Evolution Strategies seed for every step. |
 | `.horizon(n)` | Hint expected output length for bid planning. |
+| `.rebid_each_step(enabled)` | Enable or disable per-step scheduler bid refresh. |
 | `.probe_each_step(idx, p)` | Attach a probe to every step (returns a handle). |
 
 ### Inspection


### PR DESCRIPTION
## Summary

Aligns the JavaScript and Python `Generator` scheduler-bid behavior with the Rust SDK:

- prime the context bid when a generator is created
- refresh the bid before each decode step by default
- expose `rebidEachStep(...)` / `rebid_each_step(...)` for throughput-oriented loops that want to keep the initial bid static
- use the same horizon cascade as Rust: explicit `horizon` → `maxTokens` / `max_tokens` → Lindy fallback

The SDK references and scheduling guide now document the per-step refresh behavior and the opt-out knob.

## Why

Rust generation already re-bids as balance, dividend, page count, and remaining horizon change. The JavaScript and Python generators did not have the same behavior, so long-running or contended generation loops could keep a stale scheduler bid.

This makes the three SDKs behave consistently while still allowing single-tenant decode loops to avoid the per-step scheduling host calls when they do not need them.

## Verification

- `git diff --check upstream/main`
- `npm run build`
- `python3 -m pytest sdk/python/tests/test_sdk.py` — 60 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `rebidEachStep` (JavaScript) / `rebid_each_step` (Python/Rust) option to control scheduler bid refresh behavior during token generation. Enabled by default for automatic bid recomputation before each decode step; disable for static bidding in single-tenant throughput scenarios.

* **Documentation**
  * Updated SDK reference documentation and scheduling guide to document the new bid refresh option across all SDKs.

* **Tests**
  * Added test coverage for bid refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->