### PR TITLE
Fix Gemma4 pure-decode full attention

### DIFF
--- a/driver/portable/CMakeLists.txt
+++ b/driver/portable/CMakeLists.txt
@@ -123,6 +123,9 @@ add_library(pie_driver_portable_lib STATIC
   # (#712): head_count_kv reduction + rope_freqs.weight requirement, from
   # pie-server #[cfg(test)] Rust tests. GC'd in release.
   src/gemma4_hparams_testhook.cpp
+  # Test-only entry guarding Gemma4 pure-decode manual full-attention mask
+  # shape. GC'd in release.
+  src/gemma4_decode_mask_testhook.cpp
   # Test-only entry exposing KvCachePaged::page_bytes() on a non-uniform
   # (Gemma 4 alternating-attention) cache for a pie-server #[cfg(test)] Rust
   # test (per-layer KV-swap/fork page sizing). GC'd in release.

--- a/driver/portable/src/gemma4_decode_mask_testhook.cpp
+++ b/driver/portable/src/gemma4_decode_mask_testhook.cpp
@@ -1,0 +1,42 @@
+// Test-only entry called from pie-server #[cfg(test)] Rust tests; no release
+// code references it, so the linker can garbage-collect it from shipped binaries.
+
+#include <cstdint>
+
+#include <ggml.h>
+
+#include "graph_gemma4.hpp"
+#include "plan.hpp"  // MASK_PAD
+
+extern "C" int pie_portable_test_gemma4_manual_decode_mask_view_status() {
+    ggml_init_params ip{
+        /*.mem_size   =*/ ggml_tensor_overhead() * 8,
+        /*.mem_buffer =*/ nullptr,
+        /*.no_alloc   =*/ true,
+    };
+    ggml_context* ctx = ggml_init(ip);
+    if (ctx == nullptr) return 10;
+
+    constexpr std::int32_t max_n_kv = 64;
+    constexpr std::int32_t n_req = 3;
+    ggml_tensor* packed = ggml_new_tensor_4d(
+        ctx, GGML_TYPE_F16, max_n_kv, pie_portable_driver::MASK_PAD, 1, n_req);
+    ggml_tensor* viewed = pie_portable_driver::gemma4_manual_decode_mask_view(
+        ctx, packed, max_n_kv, n_req);
+
+    int status = 0;
+    if (viewed == nullptr) {
+        status = 11;
+    } else if (viewed->ne[0] != max_n_kv ||
+               viewed->ne[1] != 1 ||
+               viewed->ne[2] != 1 ||
+               viewed->ne[3] != n_req) {
+        status = 12;
+    } else if (viewed->nb[1] != packed->nb[1] ||
+               viewed->nb[2] != packed->nb[2] ||
+               viewed->nb[3] != packed->nb[3]) {
+        status = 13;
+    }
+    ggml_free(ctx);
+    return status;
+}

--- a/driver/portable/src/graph_gemma4.cpp
+++ b/driver/portable/src/graph_gemma4.cpp
@@ -27,6 +27,20 @@ inline std::int32_t gemma4_kv_source(const std::string& pattern,
 
 }  // namespace
 
+ggml_tensor* gemma4_manual_decode_mask_view(ggml_context* ctx,
+                                            ggml_tensor* packed_mask,
+                                            std::int32_t max_n_kv,
+                                            std::int32_t n_req) {
+    // Pure-decode masks are flash-attn shaped; manual full-attention SDPA
+    // needs only the live single-query row.
+    return ggml_view_4d(ctx, packed_mask,
+                        max_n_kv, /*ne1=*/1, /*ne2=*/1, n_req,
+                        packed_mask->nb[1],
+                        packed_mask->nb[2],
+                        packed_mask->nb[3],
+                        /*offset=*/0);
+}
+
 // Gemma 4 / 3n-style graph. Differs from build_qwen3_graph in:
 //   - per-layer head_dim (sliding=head_dim, full=gemma4_head_dim_global),
 //   - per-layer-type rope_theta + proportional rotary factor,
@@ -289,31 +303,25 @@ GraphResult build_gemma4_graph(ggml_context* ctx,
                     ggml_flash_attn_ext_set_prec(attn, GGML_PREC_F32);
                 } else {
                     // Full layers (head_dim=512): manual SDPA, batched over
-                    // n_req via ne[3]. GQA expands K/V from n_kv_heads_il to
-                    // n_q_heads via repeat_4d so mul_mat lines up per head.
-                    const std::int32_t gqa_factor = n_q_heads / n_kv_heads_il;
+                    // n_req via ne[3]. Keep K/V at n_kv_heads_il; ggml_mul_mat
+                    // applies the same grouped-query broadcast as the slow path.
                     ggml_tensor* K_h = K_4d;
                     ggml_tensor* V_h = V_4d;
-                    if (gqa_factor > 1) {
-                        K_h = ggml_repeat_4d(
-                            ctx, K_4d, head_dim_il, n_q_heads,
-                            plan.max_n_kv, n_req);
-                        V_h = ggml_repeat_4d(
-                            ctx, V_4d, head_dim_il, n_q_heads,
-                            plan.max_n_kv, n_req);
-                    }
-                    // K_perm: [head_dim, max_n_kv, n_q_heads, n_req]
+                    // K_perm: [head_dim, max_n_kv, n_kv_heads_il, n_req]
                     // Q_4d  : [head_dim, 1,        n_q_heads, n_req]
                     // KQ = mul_mat(K_perm, Q_4d) → [max_n_kv, 1, n_q_heads, n_req]
                     auto* K_perm = ggml_cont(ctx, ggml_permute(ctx, K_h, 0, 2, 1, 3));
                     auto* KQ = ggml_mul_mat(ctx, K_perm, Q_4d);
                     // mask shape [max_n_kv, MASK_PAD, 1, n_req]; broadcast
                     // ne[2]=1 onto KQ's ne[2]=n_q_heads.
+                    auto* mask_one_q = gemma4_manual_decode_mask_view(
+                        ctx, mask, plan.max_n_kv, n_req);
                     auto* KQ_soft = ggml_soft_max_ext(
-                        ctx, KQ, mask,
+                        ctx, KQ, mask_one_q,
                         layer_kq_scale, /*max_bias=*/0.0f);
                     // V_T: transpose kv-axis and head-axis to feed mul_mat.
-                    // Want [max_n_kv, head_dim, n_q_heads, n_req] for V^T @ KQ_soft.
+                    // Shape is [n_kv_heads_il, max_n_kv, head_dim, n_req];
+                    // ggml applies grouped-query broadcast against KQ_soft.
                     auto* V_T = ggml_cont(
                         ctx, ggml_permute(ctx, V_h, 1, 2, 0, 3));
                     // mul_mat: [head_dim, 1, n_q_heads, n_req]

--- a/driver/portable/src/graph_gemma4.hpp
+++ b/driver/portable/src/graph_gemma4.hpp
@@ -5,6 +5,8 @@
 // and KV-cache sharing across layer types — the shared builder's
 // uniform-head-dim assumption doesn't hold.
 
+#include <cstdint>
+
 #include <ggml.h>
 
 #include "executor/executor.hpp"
@@ -18,5 +20,11 @@ GraphResult build_gemma4_graph(ggml_context* ctx,
                                const Model& model,
                                KvCachePaged& kv,
                                const Executor::BatchPlan& plan);
+
+// View a pure-decode packed mask as the single-query mask used by manual SDPA.
+ggml_tensor* gemma4_manual_decode_mask_view(ggml_context* ctx,
+                                            ggml_tensor* packed_mask,
+                                            std::int32_t max_n_kv,
+                                            std::int32_t n_req);
 
 }  // namespace pie_portable_driver

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -300,6 +300,26 @@ mod portable_gemma4_hardening_tests {
     }
 }
 
+// Gemma4 pure-decode packs masks for flash-attn; manual full-attention SDPA
+// must view the single live query row.
+#[cfg(all(test, feature = "driver-portable"))]
+mod portable_gemma4_decode_mask_tests {
+    use std::os::raw::c_int;
+
+    unsafe extern "C" {
+        fn pie_portable_test_gemma4_manual_decode_mask_view_status() -> c_int;
+    }
+
+    #[test]
+    fn manual_full_attention_decode_uses_single_query_mask_view() {
+        assert_eq!(
+            unsafe { pie_portable_test_gemma4_manual_decode_mask_view_status() },
+            0,
+            "Gemma4 pure-decode manual SDPA must view packed masks as one query row"
+        );
+    }
+}
+
 // Bug-B regression guard: the KV-swap / ToT-fork page-copy loop in
 // service/inproc_service.cpp sizes and offsets every per-layer page copy with
 // `KvCachePaged::page_bytes(layer)`. Gemma 4's alternating attention gives


### PR DESCRIPTION
Gemma4 31B full/global layers (32 Q / 4 KV heads) corrupted in pure decode because the manual full-attention path materialized GQA with `ggml_repeat_4d` instead of letting `ggml_mul_mat` apply grouped-query broadcast.

This keeps K/V grouped like the slow path and views the packed decode mask as a single-query mask for manual SDPA.

Verified with clean 31B Q4 long-gen, clean 31B Q8, and no 12B Q4 regression.