### PR TITLE
fix(driver): enable single-GPU / small-VRAM (4 GB) inference (vllm + cuda-native)

### DIFF
--- a/driver/cuda/src/cuda_memory_planner.cpp
+++ b/driver/cuda/src/cuda_memory_planner.cpp
@@ -613,10 +613,30 @@ CudaMemoryPlan plan_cuda_memory(
                               : 608.0;
             const double score_kv_horizon =
                 score_as_auto ? (low_horizon_kv_heavy ? 384.0 : 544.0) : 608.0;
-            const std::size_t min_kv_tokens = std::max<std::size_t>(
+            const std::size_t desired_kv_tokens = std::max<std::size_t>(
                 32768,
                 static_cast<std::size_t>(
                     std::ceil(static_cast<double>(R) * min_kv_horizon)));
+            // The 32768 residency floor assumes a large GPU. On small cards
+            // (e.g. a 4 GB RTX 3050) the budget cannot hold that many KV tokens
+            // for any model, so every candidate is rejected and the planner
+            // throws "no viable forward/KV layout" even though a modest,
+            // usable KV pool fits (see issue #450). Cap the floor by what this
+            // candidate's budget can actually afford for KV. The `* 7 / 8`
+            // margin absorbs page-flooring (kv_tokens is rounded down to a page
+            // multiple) so the very candidate we mean to admit is not rejected
+            // by a sub-page remainder; a small absolute floor still rejects
+            // genuinely-too-small cards. On large cards `affordable_kv_tokens`
+            // exceeds 32768, so `min_kv_tokens` stays 32768 and behavior is
+            // unchanged.
+            const std::size_t affordable_kv_tokens =
+                (budget > arena + state_bytes)
+                    ? (budget - arena - state_bytes) / per_kv_token_bytes
+                    : 0;
+            const std::size_t affordable_floor =
+                std::max<std::size_t>(2048, affordable_kv_tokens * 7 / 8);
+            const std::size_t min_kv_tokens =
+                std::min(desired_kv_tokens, affordable_floor);
             if (kv_tokens < min_kv_tokens) continue;
 
             CudaMemoryPlan p;

--- a/driver/vllm/src/pie_driver_vllm/loader.py
+++ b/driver/vllm/src/pie_driver_vllm/loader.py
@@ -219,24 +219,35 @@ def _ensure_vllm_distributed(vllm_config: Any, rank: int, local_rank: int) -> No
     from vllm.distributed.parallel_state import set_custom_all_reduce
 
     _debug_stage("set_custom_all_reduce: begin")
-    set_custom_all_reduce(not parallel_config.disable_custom_all_reduce)
+    # A single-GPU (world_size==1) group performs no collectives, so custom
+    # all-reduce is dead weight there. Disable it unconditionally in that case.
+    set_custom_all_reduce(
+        parallel_config.world_size > 1
+        and not parallel_config.disable_custom_all_reduce
+    )
     _debug_stage("set_custom_all_reduce: done")
 
     if not dist.is_initialized() and parallel_config.world_size == 1:
         # Single-rank fallback. FileStore avoids picking a port (no contention).
+        #
+        # Use the gloo (CPU) backend, NOT nccl: on one GPU no GPU-side
+        # collectives ever run (vLLM's tensor_model_parallel_all_reduce
+        # short-circuits at world_size==1), but initializing an NCCL
+        # communicator + vLLM's device communicators here eagerly reserves
+        # ~2.8 GB of GPU memory (NCCL comm buffers + kernel modules) that is
+        # never used single-GPU. On small cards (e.g. a 4 GB RTX 3050 under
+        # WSL2) that overhead alone can leave no room for the KV cache and
+        # trips "Insufficient KV cache budget" (see issue #450). gloo keeps the
+        # group valid for CPU metadata broadcasts while touching no GPU memory.
         store_path = tempfile.mktemp(prefix="pie_vllm_singlerank_")
         store = dist.FileStore(store_path, parallel_config.world_size)
-        device_id = (
-            torch.device(f"cuda:{local_rank}") if torch.cuda.is_available() else None
-        )
         _debug_stage("torch init_process_group: begin")
         dist.init_process_group(
-            backend="nccl" if torch.cuda.is_available() else "gloo",
+            backend="gloo",
             store=store,
             rank=rank,
             world_size=parallel_config.world_size,
             timeout=datetime.timedelta(seconds=300),
-            device_id=device_id,
         )
         _debug_stage("torch init_process_group: done")
 


### PR DESCRIPTION
Enables inference on single-GPU / small-VRAM (4 GB) setups on two drivers. 

`Addresses #450`.

## vllm driver — single-GPU NCCL overhead
On `world_size == 1` the vllm driver's `_ensure_vllm_distributed` (`driver/vllm/src/pie_driver_vllm/loader.py`) still initialized an NCCL process group + vLLM device communicators, eagerly reserving **~2.8 GB** of GPU memory (NCCL comm buffers + kernel modules) that a single GPU never uses. On small cards this alone leaves no room for the KV cache and trips `Insufficient KV cache budget: 0 bytes`.

**Fix:** use the **gloo (CPU) backend** for the single-rank group and disable custom all-reduce for single-GPU. No GPU-side collectives run on one GPU — vLLM's `tensor_model_parallel_all_reduce` short-circuits at `world_size == 1` (`GroupCoordinator.all_reduce` returns the input before touching any communicator) — so the group only needs to stay valid for CPU metadata broadcasts. The multi-GPU (`world_size > 1`) path is unchanged.

**Verified:** Qwen3-0.6B (bnb, eager, FLASHINFER) load footprint **3841 → 1055 MiB (−2786)**. Under a ~3.7 GB constraint, stock OOMs; fixed loads → sizes KV → runs a full 28-layer forward → **emits a token**, with **gloo vs nccl output identical** (numeric invariance, consistent with the ws==1 all-reduce short-circuit). The `world_size > 1` branch is behaviorally identical (custom-all-reduce arg unchanged; gloo block never entered).

## cuda-native driver — hardcoded KV-residency floor
The memory planner rejected every candidate whose resident KV was below a flat **32768-token** floor (`driver/cuda/src/cuda_memory_planner.cpp:616`). That floor assumes a large GPU: for Qwen3-0.6B, 32768 KV tokens cost ~3.5 GB, so on a 4 GB card the planner threw `no viable forward/KV layout fits budget ...` even though a modest, usable KV pool fit (independent of the forward arena — even arena=0 yields `~14.3k < 32768`).

**Fix:** cap the floor by what the candidate's budget can afford for KV — `(budget - arena - state_bytes) / per_kv_token_bytes`, with a `× 7/8` margin to absorb page-flooring and a `2048`-token absolute floor. On large cards `affordable` exceeds 32768, so the floor stays 32768 and **behavior is unchanged**.

**Verified:** full `pie run text-completion` on the cuda-native driver under a **physical ~4 GB VRAM holder** (planner budget = 1236 MiB). Stock throws `no viable forward/KV layout fits budget 1236 MiB` and cannot run; fixed selects a layout and **generates 16 tokens end-to-end (EXIT 0)**. Also confirmed on the standalone driver binary (stock throws at budget 1474 MiB; fixed selects a layout and allocates a 7552-token KV cache).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed startup behavior for vLLM, especially in single-device runs.
  * Ensured custom all-reduce is disabled unless running with multiple ranks.
  * Simplified single-rank process-group initialization for more reliable startup.
  * Updated CUDA KV-memory planning to better account for budget limits, reducing overly strict candidate rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->