### PR TITLE
ci(build): pin MSVC toolset to 14.44 for Windows CUDA portable build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -268,9 +268,19 @@ jobs:
         # node24 equivalent of ilammy/msvc-dev-cmd (which is node20-only and
         # warns under the Node-20 deprecation). Sets up vcvars so cl.exe is on
         # PATH for the Ninja CUDA build.
+        #
+        # Pin the VC++ toolset. GitHub's windows runner image periodically adds
+        # an MSVC toolset newer than the pinned CUDA 12.9.1 toolkit supports;
+        # without a pin, vcvars activates the newest one and nvcc's front-end
+        # (cudafe++) crashes during CMake's CUDA compiler probe ("unsupported
+        # Microsoft Visual Studio version" / ACCESS_VIOLATION). 14.44 (VS 2022
+        # 17.14, MSVC 19.44) ships on the image and is within CUDA 12.9's
+        # supported host-compiler range. Bump this when the CUDA toolkit is
+        # bumped (or when the image drops 14.44).
         uses: TheMrMilchmann/setup-msvc-dev@v4.0.0
         with:
           arch: x64
+          toolset: "14.44"
 
       - name: Cache cargo
         uses: actions/cache@v5


### PR DESCRIPTION
## Root cause
The `portable / x86_64-windows-cuda` job broke on runner **image drift**, not code — the same job was green on the last run. The `windows-large-x64` runner drifted to **Visual Studio 18**, which now ships two MSVC toolsets: **14.44.35207 (MSVC 19.44)** and **14.51.36231 (MSVC 19.51)**. `TheMrMilchmann/setup-msvc-dev` with no toolset pin activates the newest (**14.51**), which the pinned **CUDA 12.9.1** toolkit does not support:

- nvcc's `host_config.h` version gate rejects it during CMake's CUDA compiler probe — `C1189: unsupported Microsoft Visual Studio version`.
- Forcing past that gate with `-allow-unsupported-compiler` just moves the failure downstream: nvcc's front-end crashes — `nvcc error : 'cudafe++' died with status 0xC0000005 (ACCESS_VIOLATION)`. So the newer MSVC is *genuinely* incompatible with CUDA 12.9, which is exactly why the gate exists.

## Fix
Pin the VC++ toolset to **14.44** (MSVC 19.44) in the Windows CUDA step. 14.44 ships on the current image (confirmed via the run's vcvars dump) and is within CUDA 12.9.1's supported host-compiler range, so nvcc's probe and the ggml-cuda build both succeed. The `-allow-unsupported-compiler` approach was evaluated and dropped (it segfaults cudafe++).

```yaml
uses: TheMrMilchmann/setup-msvc-dev@v4.0.0
with:
  arch: x64
  toolset: "14.44"
```

## Verification
Green test run: https://github.com/pie-project/pie/actions/runs/28537465006 — `portable / x86_64-windows-cuda` built and packaged `pie-x86_64-windows-cuda.zip` end-to-end in **13m20s** (cargo build → package → upload). Tested with a windows-cuda-only matrix + throwaway tag; this PR restores the full matrix and carries only the toolset pin.

## Notes
- Code was unchanged since the last green build — pure toolchain drift.
- Re-evaluate the pin on a future CUDA-toolkit bump or if the runner image drops 14.44 (at which point bumping the CUDA toolkit to one supporting the newer MSVC becomes the alternative).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows CUDA build reliability by using a compatible compiler toolset during portable build jobs.
  * Reduced the chance of build failures caused by toolchain mismatch checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->