### PR TITLE
fixed install.sh 0.3.0 specific version install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -158,14 +158,31 @@ fi
 # .github/workflows/build.yml uploads). CUDA flavors select the per-compute-
 # capability build (glibc 2.28 floor) for the detected (or PIE_CC) capability.
 assets_for() {
+  if [[ "$PIE_VERSION" =~ ^0\.3\. ]]; then
+    case "$os/$arch/$1" in
+      linux/x86_64/portable)            echo "pie-x86_64-manylinux_2_28.tar.gz" ;;
+      linux/aarch64/portable)           echo "pie-aarch64-manylinux_2_28.tar.gz" ;;
+      darwin/aarch64/portable)          echo "pie-aarch64-darwin.tar.gz" ;;
+      linux/x86_64/cuda12.6 \
+      | linux/x86_64/cuda12.8 \
+      | linux/x86_64/cuda13.0 \
+      | linux/x86_64/portable-cuda12.6 \
+      | linux/x86_64/portable-cuda12.8 \
+      | linux/x86_64/portable-cuda13.0)
+        echo "pie-x86_64-linux-${1}.tar.gz" ;;
+      linux/aarch64/cuda*)
+        echo "pie-aarch64-manylinux_2_28.tar.gz" ;;
+      *) return 1 ;;
+    esac
+    return 0
+  fi
+
   case "$os/$arch/$1" in
     linux/x86_64/portable)            echo "pie-x86_64-linux-vulkan.tar.gz" ;;
     linux/aarch64/portable)           echo "pie-aarch64-linux-vulkan.tar.gz" ;;
     darwin/aarch64/portable)          echo "pie-aarch64-macos-metal.tar.gz" ;;
     linux/x86_64/cuda12.8 | linux/x86_64/cuda13.0 \
     | linux/aarch64/cuda12.8 | linux/aarch64/cuda13.0)
-      # Per-compute-capability binary, selected from the detected (or
-      # PIE_CC-overridden) compute capability.
       if [ -n "${PIE_CC:-}" ]; then
         echo "pie-${arch}-linux-${1}-sm${PIE_CC}.tar.gz"
       fi
@@ -179,13 +196,15 @@ candidates="$(assets_for "$PIE_FLAVOR")" || err \
 
 # CUDA flavors select per-compute-capability binaries; without a CC we have
 # nothing to download. Guide the user to set PIE_CC.
-case "$PIE_FLAVOR" in
-  cuda*)
-    [ -n "${PIE_CC:-}" ] || err \
-      "CUDA flavor '${PIE_FLAVOR}' needs a GPU compute capability, but none was detected. \
+if [[ ! "$PIE_VERSION" =~ ^0\.3\. ]]; then
+  case "$PIE_FLAVOR" in
+    cuda*)
+      [ -n "${PIE_CC:-}" ] || err \
+        "CUDA flavor '${PIE_FLAVOR}' needs a GPU compute capability, but none was detected. \
 Set PIE_CC explicitly, e.g. PIE_CC=90 (H100), 100 (B200), 89 (L40/RTX40), 86 (A10), 80 (A100)."
-    ;;
-esac
+      ;;
+  esac
+fi
 
 heading "Installing Pie"
 detail "Version:  ${PIE_VERSION}"


### PR DESCRIPTION
### Description
Fixes #458
This PR fixes an installation crash on Linux machines when a user explicitly requests to install version 0.3.0 of Pie.

### Changes
- Added a `0.3.x` version check in the `assets_for()` function of install.sh.
- Added bypass to compute capability validation rule check when installing v0.3.0
- Added an explicit `linux/aarch64/cuda*` case to gracefully downgrade to portable `pie-aarch64-manylinux_2_28.tar.gz` archive instead of attempting to install cuda build for `linux/aarch64`.

### Testing Done
- Verified that specifying `PIE_VERSION=0.3.0` on an x86_64 system correctly pulls the standard Linux CUDA packages.
- Verified that `v0.4.0` asset workflows remain untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer support for a specific release line, including correct download selection for portable and CUDA builds.
  * Relaxed CUDA installation checks for that release line so installs won’t fail when compute capability can’t be detected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->