### PR TITLE
fix(cuda): correct DeepSeek-V4 forward, RoPE/YaRN, stops, and determinism

### DIFF
--- a/driver/cuda/src/kernels/dsv4_hc.cu
+++ b/driver/cuda/src/kernels/dsv4_hc.cu
@@ -221,10 +221,10 @@ __global__ void hc_rmsnorm_to_f32_kernel(
     const __nv_bfloat16* row = input + static_cast<long long>(n) * dim;
     float* out = output + static_cast<long long>(n) * dim;
 
-    // Two-pass: first compute sum-of-squares, then scale
-    __shared__ float shared_sum;
-    if (tid == 0) shared_sum = 0.f;
-    __syncthreads();
+    // Two-pass: first compute sum-of-squares, then scale. The cross-warp
+    // reduction is a fixed-order two-stage tree (not atomicAdd) so the
+    // float sum — and therefore the whole forward — is run-to-run
+    // deterministic.
     float local_sum = 0.f;
     for (int d = tid; d < dim; d += blockDim.x) {
         float v = __bfloat162float(row[d]);
@@ -233,14 +233,21 @@ __global__ void hc_rmsnorm_to_f32_kernel(
     // Warp reduce
     for (int offset = 16; offset > 0; offset >>= 1)
         local_sum += __shfl_down_sync(0xFFFFFFFF, local_sum, offset);
-    if (tid % 32 == 0)
-        atomicAdd(&shared_sum, local_sum);
+
+    __shared__ float warp_sums[32];
+    __shared__ float shared_scale;
+    if ((tid & 31) == 0) warp_sums[tid >> 5] = local_sum;
+    __syncthreads();
+    if (tid < 32) {
+        const int num_warps = (blockDim.x + 31) / 32;
+        float v = (tid < num_warps) ? warp_sums[tid] : 0.f;
+        for (int offset = 16; offset > 0; offset >>= 1)
+            v += __shfl_down_sync(0xFFFFFFFF, v, offset);
+        if (tid == 0) shared_scale = rsqrtf(v / dim + eps);
+    }
     __syncthreads();
 
-    if (tid == 0) shared_sum = rsqrtf(shared_sum / dim + eps);
-    __syncthreads();
-
-    const float scale = shared_sum;
+    const float scale = shared_scale;
     for (int d = tid; d < dim; d += blockDim.x) {
         out[d] = __bfloat162float(row[d]) * scale;
     }

--- a/driver/cuda/src/kernels/dsv4_routing.cu
+++ b/driver/cuda/src/kernels/dsv4_routing.cu
@@ -68,28 +68,45 @@ __global__ void topk_sqrtsoftplus_kernel(
     }
 }
 
+// Hash layers pick experts from the token-id table but still weight them by
+// the router: w_k = sqrtsoftplus(logit[e_k]), normalized over the K selected
+// experts (sum floored at 2^-14) and scaled by routed_scaling_factor.
 __global__ void hash_route_lookup_kernel(
     const std::int32_t* __restrict__ token_ids,
     const std::int64_t* __restrict__ tid2eid,
+    const __nv_bfloat16* __restrict__ router_logits,
     std::int32_t* __restrict__ topk_idx,
     float* __restrict__ topk_w,
+    int tokens,
     int vocab_size,
+    int E,
     int K,
-    float weight_per_expert)
+    float routed_scaling_factor)
 {
     const int n = blockIdx.x * blockDim.x + threadIdx.x;
-    // bounds check happens in launch
+    if (n >= tokens) return;
     const int tok = token_ids[n];
     const int clamped = (tok >= 0 && tok < vocab_size) ? tok : 0;
 
     const std::int64_t* row = tid2eid + static_cast<long long>(clamped) * K;
+    const __nv_bfloat16* logits = router_logits + static_cast<long long>(n) * E;
     std::int32_t* out_idx = topk_idx + static_cast<long long>(n) * K;
     float* out_w = topk_w + static_cast<long long>(n) * K;
 
+    float sum = 0.f;
     for (int k = 0; k < K; ++k) {
-        out_idx[k] = static_cast<std::int32_t>(row[k]);
-        out_w[k] = weight_per_expert;
+        const int e = static_cast<int>(row[k]);
+        out_idx[k] = e;
+        const float p = (e >= 0 && e < E)
+            ? sqrtsoftplus(__bfloat162float(logits[e]))
+            : 0.f;
+        out_w[k] = p;
+        sum += p;
     }
+    // Reference floors the normalizer at 2^-14 to avoid dividing by ~0.
+    sum = fmaxf(sum, 6.103515625e-5f);
+    const float scale = routed_scaling_factor / sum;
+    for (int k = 0; k < K; ++k) out_w[k] *= scale;
 }
 
 }  // namespace
@@ -117,20 +134,24 @@ void launch_topk_sqrtsoftplus_bf16(
 void launch_hash_route_lookup(
     const std::int32_t* token_ids,
     const std::int64_t* tid2eid,
+    const void* router_logits,
     std::int32_t* topk_idx,
     float* topk_w,
     int tokens,
     int vocab_size,
+    int num_experts,
     int top_k,
-    float weight_per_expert,
+    float routed_scaling_factor,
     cudaStream_t stream)
 {
-    if (tokens <= 0 || top_k <= 0) return;
+    if (tokens <= 0 || num_experts <= 0 || top_k <= 0) return;
     constexpr int BLOCK = 256;
     const int grid = (tokens + BLOCK - 1) / BLOCK;
     hash_route_lookup_kernel<<<grid, BLOCK, 0, stream>>>(
-        token_ids, tid2eid, topk_idx, topk_w,
-        vocab_size, top_k, weight_per_expert);
+        token_ids, tid2eid,
+        static_cast<const __nv_bfloat16*>(router_logits),
+        topk_idx, topk_w,
+        tokens, vocab_size, num_experts, top_k, routed_scaling_factor);
 }
 
 }  // namespace pie_cuda_driver::kernels

--- a/driver/cuda/src/kernels/dsv4_routing.hpp
+++ b/driver/cuda/src/kernels/dsv4_routing.hpp
@@ -17,15 +17,21 @@ void launch_topk_sqrtsoftplus_bf16(
     float routed_scaling_factor,
     cudaStream_t stream);
 
+// Hash-layer routing: expert ids come from the token-id lookup table, but the
+// weights come from the router logits — w_k = sqrtsoftplus(logit[e_k]),
+// normalized over the K selected experts (normalizer floored at 2^-14) and
+// scaled by routed_scaling_factor.
 void launch_hash_route_lookup(
     const std::int32_t* token_ids,  // [tokens]
     const std::int64_t* tid2eid,    // [vocab_size, K]
+    const void* router_logits,      // [tokens, E] BF16
     std::int32_t* topk_idx,         // [tokens, K] output
     float* topk_w,                  // [tokens, K] output
     int tokens,
     int vocab_size,
+    int num_experts,
     int top_k,
-    float weight_per_expert,        // typically 1.0/K
+    float routed_scaling_factor,
     cudaStream_t stream);
 
 }  // namespace pie_cuda_driver::kernels

--- a/driver/cuda/src/kernels/rope.cu
+++ b/driver/cuda/src/kernels/rope.cu
@@ -1,5 +1,7 @@
 #include "kernels/rope.hpp"
 
+#include <algorithm>
+#include <cmath>
 #include <cuda_bf16.h>
 
 namespace pie_cuda_driver::kernels {
@@ -706,6 +708,15 @@ void launch_rope_partial_bf16_position_delta(
 
 namespace {
 
+// DeepSeek-V4 tail RoPE. Rotates ADJACENT dim pairs (2p, 2p+1) — GPT-J /
+// interleaved convention — matching the checkpoint's native layout and the
+// reference `rope_tail_ext_inplace`. Pair p carries frequency
+// theta^(-2p / rotary_dim).
+//
+// YaRN long-context interpolation (compressed layers): the rotation angle
+// blends between the interpolated angle (pos * freq_scale * freq) and the
+// extrapolated angle (pos * freq) with a per-dim ramp between corr_low and
+// corr_high, weighted by ext_factor.
 __global__ void rope_partial_last_bf16_kernel(
     __nv_bfloat16* __restrict__ q,
     __nv_bfloat16* __restrict__ k,
@@ -715,6 +726,10 @@ __global__ void rope_partial_last_bf16_kernel(
     int head_dim,
     int rotary_dim,
     float theta,
+    float freq_scale,
+    float ext_factor,
+    float corr_low,
+    float corr_high,
     bool inverse)
 {
     const int n = blockIdx.x;
@@ -730,7 +745,17 @@ __global__ void rope_partial_last_bf16_kernel(
         const float freq = powf(theta,
             -2.f * static_cast<float>(dim_pair) /
                    static_cast<float>(rotary_dim));
-        const float ang = (inverse ? -1.f : 1.f) * static_cast<float>(pos) * freq;
+        const float theta_extrap = static_cast<float>(pos) * freq;
+        float ang = freq_scale * theta_extrap;
+        if (ext_factor != 0.f) {
+            // rope_yarn_ramp over pair index.
+            const float y = (static_cast<float>(dim_pair) - corr_low) /
+                            fmaxf(0.001f, corr_high - corr_low);
+            const float ramp =
+                (1.f - fminf(1.f, fmaxf(0.f, y))) * ext_factor;
+            ang = ang * (1.f - ramp) + theta_extrap * ramp;
+        }
+        if (inverse) ang = -ang;
         float cos_v, sin_v;
         __sincosf(ang, &sin_v, &cos_v);
 
@@ -739,13 +764,24 @@ __global__ void rope_partial_last_bf16_kernel(
             ? q + static_cast<long long>(n * num_q_heads + head_idx) * head_dim
             : k + static_cast<long long>(n * num_kv_heads + (head_idx - num_q_heads)) * head_dim;
 
-        const int i = offset + dim_pair;
-        const int j = offset + dim_pair + rope_half;
+        const int i = offset + 2 * dim_pair;
+        const int j = i + 1;
         const float a = __bfloat162float(base[i]);
         const float b = __bfloat162float(base[j]);
         base[i] = __float2bfloat16(a * cos_v - b * sin_v);
         base[j] = __float2bfloat16(b * cos_v + a * sin_v);
     }
+}
+
+// YaRN correction dim (same formula as the reference `rope_yarn_corr_dim`):
+// the rotary index at which a wavelength completes `n_rot` cycles over
+// `orig_ctx` tokens.
+float yarn_corr_dim(int rotary_dim, int orig_ctx, float n_rot, float base)
+{
+    return static_cast<float>(rotary_dim) *
+           std::log(static_cast<float>(orig_ctx) /
+                    (n_rot * 2.0f * 3.14159265358979323846f)) /
+           (2.0f * std::log(base));
 }
 
 }  // namespace
@@ -760,16 +796,34 @@ void launch_rope_partial_last_bf16(
     int rotary_dim,
     float theta,
     cudaStream_t stream,
-    bool inverse)
+    bool inverse,
+    float freq_scale,
+    float ext_factor,
+    float beta_fast,
+    float beta_slow,
+    int original_max_position)
 {
     constexpr int BLOCK = 256;
     dim3 grid(num_tokens);
     dim3 block(BLOCK);
+
+    float corr_low = 0.f;
+    float corr_high = 0.f;
+    if (ext_factor != 0.f) {
+        const float start = std::floor(
+            yarn_corr_dim(rotary_dim, original_max_position, beta_fast, theta));
+        const float end = std::ceil(
+            yarn_corr_dim(rotary_dim, original_max_position, beta_slow, theta));
+        corr_low = std::max(0.f, start);
+        corr_high = std::min(static_cast<float>(rotary_dim - 1), end);
+    }
+
     rope_partial_last_bf16_kernel<<<grid, block, 0, stream>>>(
         static_cast<__nv_bfloat16*>(q),
         static_cast<__nv_bfloat16*>(k),
         positions,
-        num_q_heads, num_kv_heads, head_dim, rotary_dim, theta, inverse);
+        num_q_heads, num_kv_heads, head_dim, rotary_dim, theta,
+        freq_scale, ext_factor, corr_low, corr_high, inverse);
 }
 
 }  // namespace pie_cuda_driver::kernels

--- a/driver/cuda/src/kernels/rope.hpp
+++ b/driver/cuda/src/kernels/rope.hpp
@@ -184,8 +184,16 @@ void launch_rope_partial_bf16_position_delta(
 
 // Partial rotary embedding on the LAST `rotary_dim` dimensions of each head.
 // Used by DeepSeek V4 where RoPE is applied to the trailing 64 dims of
-// head_dim=512. Pair convention: (offset+i, offset+i+rotary_dim/2)
-// where offset = head_dim - rotary_dim.
+// head_dim=512. Pair convention: ADJACENT dims (offset+2p, offset+2p+1)
+// — the GPT-J / interleaved layout that DeepSeek checkpoints are trained
+// with (reference `rope_tail_ext_inplace`), NOT the half/half NeoX split.
+//
+// Optional YaRN long-context interpolation (DSv4 compressed layers):
+// pass `freq_scale = 1/factor` and `ext_factor = 1` to blend each pair's
+// angle between interpolation and extrapolation with the beta_fast /
+// beta_slow correction ramp. The DSv4 reference cancels YaRN's magnitude
+// scale, so no attention factor is applied. Defaults (`freq_scale = 1`,
+// `ext_factor = 0`) give plain unscaled RoPE.
 void launch_rope_partial_last_bf16(
     void* q, void* k,
     const std::int32_t* positions,
@@ -196,6 +204,11 @@ void launch_rope_partial_last_bf16(
     int rotary_dim,
     float theta,
     cudaStream_t stream,
-    bool inverse = false);
+    bool inverse = false,
+    float freq_scale = 1.0f,
+    float ext_factor = 0.0f,
+    float beta_fast = 32.0f,
+    float beta_slow = 1.0f,
+    int original_max_position = 0);
 
 }  // namespace pie_cuda_driver::kernels

--- a/driver/cuda/src/kernels/swiglu.cu
+++ b/driver/cuda/src/kernels/swiglu.cu
@@ -21,6 +21,28 @@ __global__ void swiglu_bf16_kernel(
     y[idx] = __float2bfloat16(silu * u);
 }
 
+// DeepSeek-V4 `swiglu_limit` variant: upper-clamp gate, symmetric-clamp up,
+// then standard silu(gate) * up. The clamps happen *before* the activation
+// (matches DwarfStar's `swiglu(..., clamp)` reference). Distinct from the
+// GPT-OSS GLU below, which uses alpha = 1.702 and a `+1` up-shift.
+__global__ void swiglu_clamped_bf16_kernel(
+    const __nv_bfloat16* __restrict__ gate,
+    const __nv_bfloat16* __restrict__ up,
+    __nv_bfloat16* __restrict__ y,
+    int n,
+    float limit)
+{
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+
+    float g = __bfloat162float(gate[idx]);
+    float u = __bfloat162float(up[idx]);
+    g = fminf(g, limit);
+    u = fminf(fmaxf(u, -limit), limit);
+    const float silu = g / (1.f + expf(-g));
+    y[idx] = __float2bfloat16(silu * u);
+}
+
 __global__ void gpt_oss_glu_bf16_kernel(
     const __nv_bfloat16* __restrict__ gate,
     const __nv_bfloat16* __restrict__ up,
@@ -56,6 +78,23 @@ void launch_swiglu_bf16(
         static_cast<const __nv_bfloat16*>(up),
         static_cast<__nv_bfloat16*>(y),
         num_elements);
+}
+
+void launch_swiglu_clamped_bf16(
+    const void* gate, const void* up, void* y,
+    int num_elements, float limit, cudaStream_t stream)
+{
+    if (limit <= 1e-6f) {
+        launch_swiglu_bf16(gate, up, y, num_elements, stream);
+        return;
+    }
+    constexpr int BLOCK = 256;
+    const int grid = (num_elements + BLOCK - 1) / BLOCK;
+    swiglu_clamped_bf16_kernel<<<grid, BLOCK, 0, stream>>>(
+        static_cast<const __nv_bfloat16*>(gate),
+        static_cast<const __nv_bfloat16*>(up),
+        static_cast<__nv_bfloat16*>(y),
+        num_elements, limit);
 }
 
 void launch_gpt_oss_glu_bf16(

--- a/driver/cuda/src/kernels/swiglu.hpp
+++ b/driver/cuda/src/kernels/swiglu.hpp
@@ -22,6 +22,20 @@ void launch_swiglu_bf16(
     int num_elements,
     cudaStream_t stream);
 
+// SwiGLU with DeepSeek-V4's `swiglu_limit` pre-activation clamps:
+//     gate' = min(gate, +limit)
+//     up'   = clamp(up, -limit, +limit)
+//     y     = silu(gate') * up'
+// Falls back to plain SwiGLU when `limit <= 0` (config field unset).
+// Unlike GPT-OSS's GLU this keeps alpha = 1 and has no `+1` up-shift.
+void launch_swiglu_clamped_bf16(
+    const void* gate,
+    const void* up,
+    void* y,
+    int num_elements,
+    float limit,
+    cudaStream_t stream);
+
 // GeLU-tanh-glu (Gemma).
 void launch_geglu_tanh_bf16(
     const void* gate,

--- a/driver/cuda/src/model/deepseek_v4_forward.cpp
+++ b/driver/cuda/src/model/deepseek_v4_forward.cpp
@@ -204,6 +204,27 @@ void dsv4_forward_paged(
     const float hc_post_alpha = 2.0f;
     const int sinkhorn_iters = 20; // from config hc_sinkhorn_iters
 
+    // Per-layer RoPE parameters. Non-compressed layers use plain RoPE at
+    // the base theta. Compressed (C4/C128) layers use the long-context
+    // base (compress_rope_theta) with YaRN interpolation at 1/factor —
+    // reference `layer_rope_freq_base` / `layer_rope_freq_scale`.
+    const bool has_yarn = cfg.rope_factor > 1.f;
+    struct LayerRope {
+        float theta;
+        float freq_scale;
+        float ext_factor;
+    };
+    auto layer_rope = [&](int compress_ratio) -> LayerRope {
+        if (compress_ratio == 0) {
+            return {cfg.rope_theta, 1.f, 0.f};
+        }
+        const float base = cfg.dsv4_compress_rope_theta > 0.f
+            ? cfg.dsv4_compress_rope_theta
+            : cfg.rope_theta;
+        if (!has_yarn) return {base, 1.f, 0.f};
+        return {base, 1.f / cfg.rope_factor, 1.f};
+    };
+
     cudaStream_t stream = nullptr;  // default stream
 
     // TP all-reduce helper (safe: no-op when tp_comm is null)
@@ -315,11 +336,16 @@ void dsv4_forward_paged(
             ws.kv.data(), Lw.kv_norm->data(), ws.kv.data(),
             N, head_dim, eps, stream);
 
-        // Partial RoPE on last qk_rope dims of Q and KV
+        // Partial RoPE on last qk_rope dims of Q and KV (layer-dependent
+        // base + YaRN scaling on compressed layers)
+        const LayerRope lr = layer_rope(Lw.compress_ratio);
         kernels::launch_rope_partial_last_bf16(
             ws.q.data(), ws.kv.data(),
             positions, N, num_heads, 1, head_dim, qk_rope,
-            cfg.rope_theta, stream);
+            lr.theta, stream, /*inverse=*/false,
+            lr.freq_scale, lr.ext_factor,
+            cfg.rope_beta_fast, cfg.rope_beta_slow,
+            cfg.rope_original_max_position);
 
         {
             // SWA attention on ALL layers (every layer has a sliding window).
@@ -530,12 +556,9 @@ void dsv4_forward_paged(
                         static_cast<std::size_t>(total_comp) * sizeof(std::int32_t),
                         cudaMemcpyHostToDevice, stream));
 
-                    // Apply RoPE to compressed KV (single head, partial last dims)
-                    // Use compress_rope_theta if available, else base theta
-                    const float comp_theta =
-                        cfg.dsv4_compress_rope_theta > 0.f
-                            ? cfg.dsv4_compress_rope_theta
-                            : cfg.rope_theta;
+                    // Apply RoPE to compressed KV (single head, partial last
+                    // dims). Same layer params as the raw Q/KV rotation —
+                    // compressed layers use the long-context base + YaRN.
                     kernels::launch_rope_partial_last_bf16(
                         ws.comp_kv.data(),  // "q" — will be rotated
                         ws.comp_kv.data(),  // "k" — dummy (same buffer, 0 heads below)
@@ -545,8 +568,11 @@ void dsv4_forward_paged(
                         0,      // num_kv_heads: 0 means skip K rotation
                         head_dim,
                         qk_rope,
-                        comp_theta,
-                        stream);
+                        lr.theta,
+                        stream, /*inverse=*/false,
+                        lr.freq_scale, lr.ext_factor,
+                        cfg.rope_beta_fast, cfg.rope_beta_slow,
+                        cfg.rope_original_max_position);
 
                     // Step 5: Dense attention over compressed KV entries
                     // Build host-side qo_indptr as int for the compressed attention kernel
@@ -589,11 +615,16 @@ void dsv4_forward_paged(
                     N, num_heads, head_dim, stream);
             }
 
-            // Inverse RoPE on attention output (removes position info before projection)
+            // Inverse RoPE on attention output (removes position info before
+            // projection) — same layer-dependent params as the forward
+            // rotation.
             kernels::launch_rope_partial_last_bf16(
                 ws.attn_out.data(), ws.attn_out.data(),
                 positions, N, num_heads, 0, head_dim, qk_rope,
-                cfg.rope_theta, stream, /*inverse=*/true);
+                lr.theta, stream, /*inverse=*/true,
+                lr.freq_scale, lr.ext_factor,
+                cfg.rope_beta_fast, cfg.rope_beta_slow,
+                cfg.rope_original_max_position);
 
             // Grouped output projection: per-group GEMMs with strided I/O.
             //

--- a/driver/cuda/src/model/deepseek_v4_forward.cpp
+++ b/driver/cuda/src/model/deepseek_v4_forward.cpp
@@ -362,7 +362,7 @@ void dsv4_forward_paged(
                 ws.attn_out.data(),
                 qo_indptr, kv_page_indices, kv_page_indptr, kv_last_page_lens,
                 N, num_requests, num_heads, 1, head_dim, lv.page_size, stream,
-                /*window_left=*/-1, /*sm_scale=*/-1.f,
+                /*window_left=*/cfg.sliding_window, /*sm_scale=*/-1.f,
                 /*logits_soft_cap=*/0.f,
                 /*lse_out=*/static_cast<float*>(ws.attn_lse.data()));
 

--- a/driver/cuda/src/model/deepseek_v4_forward.cpp
+++ b/driver/cuda/src/model/deepseek_v4_forward.cpp
@@ -821,13 +821,17 @@ void dsv4_forward_paged(
 
         // MoE routing
         if (Lw.is_hash_layer && Lw.tid2eid != nullptr) {
+            // Experts are chosen by token-id hash, but weighted by the
+            // router's sqrtsoftplus probs (normalized over the selection,
+            // then scaled).
             kernels::launch_hash_route_lookup(
                 token_ids,
                 static_cast<const std::int64_t*>(Lw.tid2eid->data()),
+                ws.router_logits.data(),
                 static_cast<std::int32_t*>(ws.topk_idx.data()),
                 static_cast<float*>(ws.topk_weights.data()),
-                N, cfg.vocab_size, K,
-                1.0f / static_cast<float>(K),
+                N, cfg.vocab_size, E, K,
+                cfg.routed_scaling_factor,
                 stream);
         } else {
             kernels::launch_topk_sqrtsoftplus_bf16(

--- a/driver/cuda/src/model/deepseek_v4_forward.cpp
+++ b/driver/cuda/src/model/deepseek_v4_forward.cpp
@@ -905,10 +905,11 @@ void dsv4_forward_paged(
                     ws.expert_in.data(),
                     ops::WeightView::raw(ws.expert_up_w.data(), DType::BF16),
                     ws.expert_up.data(), Ne, local_moe_I, H);
-                kernels::launch_swiglu_bf16(
+                kernels::launch_swiglu_clamped_bf16(
                     ws.expert_gate.data(), ws.expert_up.data(),
                     ws.expert_gate.data(),
-                    static_cast<std::size_t>(Ne) * local_moe_I, stream);
+                    static_cast<std::size_t>(Ne) * local_moe_I,
+                    cfg.swiglu_limit, stream);
                 ops::gemm_act_x_w(cublas.handle(),
                     ws.expert_gate.data(),
                     ops::WeightView::raw(ws.expert_down_w.data(), DType::BF16),
@@ -930,10 +931,11 @@ void dsv4_forward_paged(
             ops::gemm_act_x_w(cublas.handle(),
                 ws.norm_y.data(), make_weight_view(Lw.shared_w3, Lw.shared_w3_quant), ws.shared_up.data(),
                 N, local_shared_I, H);
-            kernels::launch_swiglu_bf16(
+            kernels::launch_swiglu_clamped_bf16(
                 ws.shared_gate.data(), ws.shared_up.data(),
                 ws.shared_act.data(),
-                static_cast<std::size_t>(N) * local_shared_I, stream);
+                static_cast<std::size_t>(N) * local_shared_I,
+                cfg.swiglu_limit, stream);
             ops::gemm_act_x_w(cublas.handle(),
                 ws.shared_act.data(), make_weight_view(Lw.shared_w2, Lw.shared_w2_quant), ws.shared_out.data(),
                 N, H, local_shared_I);

--- a/runtime/src/model/tokenizer.rs
+++ b/runtime/src/model/tokenizer.rs
@@ -883,7 +883,7 @@ fn load_tiktoken_added_tokens(path: &std::path::Path) -> anyhow::Result<Vec<Adde
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     fn make_byte_tokenizer(
         vocab: &[(&str, u32)],
@@ -899,7 +899,13 @@ mod tests {
             .iter()
             .map(|(a, b)| (a.to_string(), b.to_string()))
             .collect();
-        let mut bpe = bpe::BpeTable::from_vocab_and_merges(&vocab_map, &merge_pairs, "", false);
+        let mut bpe = bpe::BpeTable::from_vocab_and_merges(
+            &vocab_map,
+            &merge_pairs,
+            "",
+            false,
+            &HashSet::new(),
+        );
         for at in &added_tokens {
             bpe.insert(at.content.as_bytes().to_vec(), at.id);
         }
@@ -927,7 +933,13 @@ mod tests {
             .iter()
             .map(|(a, b)| (a.to_string(), b.to_string()))
             .collect();
-        let bpe = bpe::BpeTable::from_vocab_and_merges(&vocab_map, &merge_pairs, "", false);
+        let bpe = bpe::BpeTable::from_vocab_and_merges(
+            &vocab_map,
+            &merge_pairs,
+            "",
+            false,
+            &HashSet::new(),
+        );
         Tokenizer::new(
             bpe,
             VocabType::CharLevel,
@@ -1137,7 +1149,10 @@ mod tests {
         let tok = Tokenizer::from_file(&model_path).unwrap();
         assert_eq!(tok.token_to_id("<|im_user|>"), Some(100));
         assert_eq!(tok.encode("<|im_user|>hi<|im_end|>"), vec![100, 0, 1, 101]);
-        assert_eq!(tok.decode(&[100, 0, 1, 101], false), "<|im_user|>hi<|im_end|>");
+        assert_eq!(
+            tok.decode(&[100, 0, 1, 101], false),
+            "<|im_user|>hi<|im_end|>"
+        );
         assert_eq!(tok.decode(&[100, 0, 1, 101], true), "hi");
     }
 }

--- a/runtime/src/model/tokenizer/bpe.rs
+++ b/runtime/src/model/tokenizer/bpe.rs
@@ -12,7 +12,7 @@
 
 use rustc_hash::FxHashMap;
 use smallvec::SmallVec;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Token ID (the value returned to the caller).
 pub type TokenId = u32;
@@ -93,19 +93,29 @@ impl BpeTable {
     /// converted to raw bytes via the inverse byte mapping.  This lets
     /// the encode path work directly on `&[u8]` without running
     /// `bytes_to_unicode()`.
+    ///
+    /// `skip_ids` are omitted here (HF `added_tokens` ids). Those are
+    /// literal content strings, not GPT-2 remapped BPE atoms, and must
+    /// be registered afterward with [`BpeTable::insert`] using raw UTF-8.
     pub fn from_vocab_and_merges(
         vocab: &HashMap<String, u32>,
         merge_pairs: &[(String, String)],
         continuing_subword_prefix: &str,
         raw_byte_keys: bool,
+        skip_ids: &HashSet<u32>,
     ) -> Self {
         let max_id = vocab.values().copied().max().unwrap_or(0) as usize;
         let mut id_to_bytes = vec![Vec::new(); max_id + 1];
         let mut token_to_id = FxHashMap::with_capacity_and_hasher(vocab.len(), Default::default());
         let mut merges = FxHashMap::default();
 
-        // First pass: register all symbols.
+        // First pass: register BPE symbols only. Added/special token ids
+        // are skipped so their vocab spellings never go through GPT-2
+        // inversion (DeepSeek's `<｜…｜>` keys are literal Unicode).
         for (token, &id) in vocab {
+            if skip_ids.contains(&id) {
+                continue;
+            }
             let key = if raw_byte_keys {
                 gpt2_unicode_to_raw_bytes(token)
             } else {
@@ -194,24 +204,17 @@ impl BpeTable {
         self.token_to_id.len()
     }
 
-    /// Insert a token (for added/special tokens).
+    /// Insert an added/special token with its literal content bytes.
     ///
     /// Does NOT add merge entries — added tokens are matched by AhoCorasick
     /// before BPE encoding, so they never participate in the merge algorithm.
-    /// Skips `token_to_id` insertion if the ID already exists in the base vocab
-    /// (some models list tokens in both `vocab` and `added_tokens`).
+    /// The content string is the canonical spelling (raw UTF-8), matching HF.
     pub fn insert(&mut self, bytes: Vec<u8>, id: TokenId) {
         if id as usize >= self.id_to_bytes.len() {
             self.id_to_bytes.resize(id as usize + 1, Vec::new());
         }
-        // Only insert if this ID doesn't already have a mapping.
-        // This prevents duplicate entries when added_tokens overlap the base
-        // vocab (e.g. DeepSeek-V3.2 where GPT-2 byte remapping produces
-        // different key bytes for the same token).
-        if self.id_to_bytes[id as usize].is_empty() {
-            self.id_to_bytes[id as usize] = bytes.clone();
-            self.token_to_id.entry(bytes).or_insert(id);
-        }
+        self.id_to_bytes[id as usize] = bytes.clone();
+        self.token_to_id.insert(bytes, id);
     }
 
     /// Pair-merge rank lookup: can (left, right) merge?
@@ -307,8 +310,10 @@ pub fn bytes_to_unicode() -> &'static [char; 256] {
 
 /// Convert a GPT-2 unicode token string to raw bytes.
 ///
-/// Used at load time to re-key the vocabulary.  Each GPT-2 unicode char
-/// maps 1:1 to a byte value.
+/// Used at load time to re-key **BPE atom** vocab entries. Each GPT-2
+/// alphabet char maps 1:1 to a byte. Added/special tokens must not be
+/// passed here — the HF loader skips their ids and registers them with
+/// literal UTF-8 via [`BpeTable::insert`].
 fn gpt2_unicode_to_raw_bytes(token: &str) -> Vec<u8> {
     token
         .chars()
@@ -317,8 +322,8 @@ fn gpt2_unicode_to_raw_bytes(token: &str) -> Vec<u8> {
             if idx < 324 {
                 CHAR_TO_BYTE[idx].unwrap_or(c as u8)
             } else {
-                // Non-GPT2 char: keep raw encoding.  Should not happen
-                // for well-formed GPT-2 vocabs.
+                // Not a GPT-2 alphabet char. Should not happen for BPE
+                // atoms; added tokens are excluded before this runs.
                 c as u8
             }
         })
@@ -720,6 +725,7 @@ fn fallback_into(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
 
     fn make_test_ranks() -> BpeTable {
         let mut map = HashMap::new();
@@ -773,7 +779,7 @@ mod tests {
             ("a".to_string(), "b".to_string()),
             ("ab".to_string(), "c".to_string()),
         ];
-        let bpe = BpeTable::from_vocab_and_merges(&vocab, &merges, "", false);
+        let bpe = BpeTable::from_vocab_and_merges(&vocab, &merges, "", false, &HashSet::new());
 
         let mut out = Vec::new();
         bpe_encode_bytes(b"abc", &bpe, false, None, &mut out);
@@ -797,6 +803,7 @@ mod tests {
             &[("h".to_string(), "i".to_string())],
             "",
             false,
+            &HashSet::new(),
         );
 
         let mut out = Vec::new();
@@ -821,11 +828,33 @@ mod tests {
             ("▁".to_string(), "H".to_string()),
             ("▁H".to_string(), "i".to_string()),
         ];
-        let bpe = BpeTable::from_vocab_and_merges(&vocab, &merges, "", false);
+        let bpe = BpeTable::from_vocab_and_merges(&vocab, &merges, "", false, &HashSet::new());
 
         let mut out = Vec::new();
         bpe_encode_chars("▁Hi", &bpe, false, None, &mut out);
         assert_eq!(out, vec![4]);
+    }
+
+    #[test]
+    fn test_added_token_ids_skip_gpt2_rekey() {
+        let mut vocab = HashMap::new();
+        // GPT-2 remapped space (Ġ → 0x20).
+        vocab.insert("Ġ".to_string(), 0u32);
+        // DeepSeek-style special listed in vocab with literal Unicode.
+        let eos = "<｜end▁of▁sentence｜>";
+        vocab.insert(eos.to_string(), 1u32);
+
+        let skip: HashSet<u32> = [1u32].into_iter().collect();
+        let mut bpe = BpeTable::from_vocab_and_merges(&vocab, &[], "", true, &skip);
+
+        // Skipped id is absent until insert registers literal UTF-8.
+        assert!(bpe.bytes_to_id(eos.as_bytes()).is_none());
+        assert!(bpe.id_to_bytes(1).is_none());
+        assert_eq!(bpe.bytes_to_id(&[0x20]), Some(0));
+
+        bpe.insert(eos.as_bytes().to_vec(), 1);
+        assert_eq!(bpe.bytes_to_id(eos.as_bytes()), Some(1));
+        assert_eq!(bpe.id_to_bytes(1), Some(eos.as_bytes()));
     }
 
     #[test]

--- a/runtime/src/model/tokenizer/hf_loader.rs
+++ b/runtime/src/model/tokenizer/hf_loader.rs
@@ -42,7 +42,7 @@
 //! `"pretokenizers"`, or `"decoders"` respectively.
 //! [`flatten_sequence`] handles this recursively.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use anyhow::{Context, Result, bail};
@@ -191,14 +191,19 @@ fn from_hf(hf: HfTokenizerJson) -> Result<Tokenizer> {
         build_pipeline(pre_tokenizer_val, normalizer_val)?;
 
     // Build BPE table.
-    // For ByteLevel models, vocab keys are GPT-2-remapped unicode (e.g. "Ġ" = 0x20).
-    // `raw_byte_keys=true` tells BpeTable to invert the GPT-2 mapping so that
-    // internal lookups work on raw bytes directly.
+    // For ByteLevel models, BPE atom vocab keys are GPT-2-remapped unicode
+    // (e.g. "Ġ" = 0x20). `raw_byte_keys=true` inverts that mapping.
+    //
+    // HF also lists added/special tokens inside `model.vocab`, but those
+    // keys are literal content strings (not GPT-2 remapped). Skip their
+    // ids here and register them below via `insert` with raw UTF-8.
+    let added_ids: HashSet<u32> = hf.added_tokens.iter().map(|t| t.id).collect();
     let mut bpe = BpeTable::from_vocab_and_merges(
         &hf.model.vocab,
         &merge_pairs,
         continuing_subword_prefix,
         is_byte_level, // raw_byte_keys
+        &added_ids,
     );
 
     let byte_fallback = hf.model.byte_fallback;
@@ -226,7 +231,9 @@ fn from_hf(hf: HfTokenizerJson) -> Result<Tokenizer> {
         build_decode_steps(decoder_val)?
     };
 
-    // Insert added tokens into the BPE vocab so they can be encoded/decoded.
+    // Insert added tokens with literal UTF-8 content. Their ids were
+    // skipped during GPT-2 vocab re-keying above, so this is the sole
+    // registration path (matches HF: added tokens are not ByteLevel atoms).
     let mut added_tokens = Vec::with_capacity(hf.added_tokens.len());
     for ht in &hf.added_tokens {
         bpe.insert(ht.content.as_bytes().to_vec(), ht.id);

--- a/server/src/cli/model_cmd.rs
+++ b/server/src/cli/model_cmd.rs
@@ -95,6 +95,8 @@ const HF_TO_PIE_ARCH: &[(&str, &str)] = &[
     ("gptoss", "gptoss"),
     ("gpt_oss", "gptoss"),
     ("nemotron_h", "nemotron_h"),
+    ("deepseek_v3", "deepseek_v3"),
+    ("deepseek_v4", "deepseek_v4"),
 ];
 
 /// Read `<repo_dir>/snapshots/<latest>/config.json` and look up its


### PR DESCRIPTION
The following fixes in this PR make DS4 work on CUDA. Each commit fixes one problem as summarized below:

- **Hash-layer MoE weights** — still select experts from `tid2eid`, but weight them with renormalized `sqrtsoftplus` router probs × `routed_scaling_factor` instead of uniform 1/K.
- **SwiGLU clamp** — apply `swiglu_limit=10` pre-activation clamps on routed and shared experts.
- **RoPE pairing** — rotate adjacent (GPT-J) dims; Pie had been using NeoX half/half.
- **Compressed-layer YaRN** — use `compress_rope_theta` with YaRN (`freq_scale=1/factor`) on C4/C128 layers for forward, inverse, and compressed-KV RoPE.
- **Sliding window** — raw attention honors `sliding_window` (128); longer context only via compressed attention.
- **EOS / stop tokens** — skip HF `added_tokens` during GPT-2 vocab re-key and register them as literal UTF-8 so `token_to_id` resolves stop strings.
- **HC RMSNorm** — replace cross-warp `atomicAdd` with a fixed-order reduction for run-to-run determinism.
- **CLI** — map HF `deepseek_v3` / `deepseek_v4` in `pie model download`’s arch table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for DeepSeek V3 and V4 model architectures.
  - Improved long-context RoPE behavior with YaRN interpolation.
  - Added clamped SwiGLU activation support for more stable inference.
  - Added router-logit-based expert weighting for MoE models.
  - Improved tokenizer handling for added and special tokens.

- **Improvements**
  - Made RMS normalization results deterministic across runs.
  - Updated sliding-window attention behavior for configured windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->