### PR TITLE
Fix borrowed context destruction at the component boundary

### DIFF
--- a/runtime/src/api/context.rs
+++ b/runtime/src/api/context.rs
@@ -169,7 +169,11 @@ impl pie::core::context::HostContext for InstanceState {
         // (chain gone → output silently discarded).
         crate::inference::invalidate_speculation_for_ctx(model_id, context_id);
         let _ = context::destroy(model_id, context_id).await;
-        self.ctx().table.delete(this)?;
+        // `destroy` is a borrowed WIT resource method. Deleting `this` here
+        // attempts to remove a resource-table entry while the component call
+        // still holds its borrow, which traps at the component boundary. The
+        // guest method consumes its SDK wrapper, so its ordinary resource drop
+        // follows immediately and owns deletion of the table handle.
         Ok(())
     }
 

--- a/runtime/src/context.rs
+++ b/runtime/src/context.rs
@@ -536,6 +536,16 @@ pub async fn get_stats(model_idx: usize) -> Vec<(usize, usize)> {
     rx.await.unwrap_or_default()
 }
 
+#[doc(hidden)]
+pub async fn debug_process_context_count(model_idx: usize, pid: ProcessId) -> usize {
+    let (tx, rx) = oneshot::channel();
+    let _ = SERVICES.send(
+        model_idx,
+        Message::DebugProcessContextCount { pid, response: tx },
+    );
+    rx.await.unwrap_or_default()
+}
+
 pub async fn debug_context_state(model_idx: usize, id: ContextId) -> String {
     let (tx, rx) = oneshot::channel();
     let _ = SERVICES.send(model_idx, Message::DebugState { id, response: tx });
@@ -2382,6 +2392,10 @@ pub(crate) enum Message {
     GetStats {
         response: oneshot::Sender<Vec<(usize, usize)>>,
     },
+    DebugProcessContextCount {
+        pid: ProcessId,
+        response: oneshot::Sender<usize>,
+    },
 
     // Actor-routed write APIs
     TruncateWorkingPageTokens {
@@ -2590,6 +2604,13 @@ impl ServiceHandler for ContextManager {
             }
             Message::GetStats { response } => {
                 let _ = response.send(self.stats());
+            }
+            Message::DebugProcessContextCount { pid, response } => {
+                let count = self
+                    .processes
+                    .get(&pid)
+                    .map_or(0, |process| process.context_ids.len());
+                let _ = response.send(count);
             }
             Message::TruncateWorkingPageTokens {
                 id,

--- a/runtime/tests/e2e.rs
+++ b/runtime/tests/e2e.rs
@@ -114,7 +114,7 @@ fn explicit_destroy_releases_concurrent_forks_on_success_and_error() {
     s.rt.block_on(async {
         inferlets::add_and_install("context-lifecycle").await;
 
-        for (input, expect_error) in [("success", false), ("error", true)] {
+        for input in ["success", "error"] {
             let (result_tx, result_rx) = oneshot::channel();
             let pid = process::spawn(
                 "context-lifecycle-user".into(),
@@ -128,26 +128,39 @@ fn explicit_destroy_releases_concurrent_forks_on_success_and_error() {
             )
             .expect("spawn context lifecycle inferlet");
 
+            let ready = tokio::time::timeout(
+                PROCESS_TIMEOUT,
+                pie::messaging::pull("context-lifecycle-user:lifecycle-ready".into()),
+            )
+            .await
+            .expect("context lifecycle ready signal timed out")
+            .expect("context lifecycle ready signal failed");
+            assert_eq!(ready, input);
+            assert!(
+                process::list().contains(&pid),
+                "process exited before its live context ownership was inspected"
+            );
+            assert_eq!(
+                pie::context::debug_process_context_count(0, pid).await,
+                0,
+                "explicit destroy retained contexts while the process was alive"
+            );
+
+            pie::messaging::push(
+                "context-lifecycle-user:lifecycle-release".into(),
+                input.into(),
+            )
+            .expect("release context lifecycle inferlet");
+
             let result = tokio::time::timeout(PROCESS_TIMEOUT, result_rx)
                 .await
                 .expect("context lifecycle inferlet timed out")
                 .expect("context lifecycle result sender dropped");
-            assert_eq!(
-                result.is_err(),
-                expect_error,
-                "unexpected result for {input}"
-            );
-
-            tokio::time::timeout(PROCESS_TIMEOUT, async {
-                loop {
-                    if pie::context::debug_process_context_count(0, pid).await == 0 {
-                        break;
-                    }
-                    tokio::time::sleep(Duration::from_millis(10)).await;
-                }
-            })
-            .await
-            .expect("process teardown retained contexts");
+            match input {
+                "success" => assert_eq!(result, Ok("contexts released".into())),
+                "error" => assert_eq!(result, Err("injected context lifecycle error".into())),
+                _ => unreachable!(),
+            }
         }
     });
 }

--- a/runtime/tests/e2e.rs
+++ b/runtime/tests/e2e.rs
@@ -12,6 +12,7 @@ use common::{MockEnv, create_mock_env, inferlets, mock_device::EchoBehavior};
 
 use pie::process;
 use pie::program::ProgramName;
+use tokio::sync::oneshot;
 
 /// Timeout for a single process to complete.
 const PROCESS_TIMEOUT: Duration = Duration::from_secs(10);
@@ -105,6 +106,50 @@ fn context_inferlet_exercises_host_apis() {
         spawn_and_wait(s, "context", "{}".into()),
         "context inferlet should complete (exercises model, tokenizer, context host APIs)"
     );
+}
+
+#[test]
+fn explicit_destroy_releases_concurrent_forks_on_success_and_error() {
+    let s = state();
+    s.rt.block_on(async {
+        inferlets::add_and_install("context-lifecycle").await;
+
+        for (input, expect_error) in [("success", false), ("error", true)] {
+            let (result_tx, result_rx) = oneshot::channel();
+            let pid = process::spawn(
+                "context-lifecycle-user".into(),
+                program_name("context-lifecycle"),
+                input.into(),
+                None,
+                true,
+                Some(result_tx),
+                None,
+                None,
+            )
+            .expect("spawn context lifecycle inferlet");
+
+            let result = tokio::time::timeout(PROCESS_TIMEOUT, result_rx)
+                .await
+                .expect("context lifecycle inferlet timed out")
+                .expect("context lifecycle result sender dropped");
+            assert_eq!(
+                result.is_err(),
+                expect_error,
+                "unexpected result for {input}"
+            );
+
+            tokio::time::timeout(PROCESS_TIMEOUT, async {
+                loop {
+                    if pie::context::debug_process_context_count(0, pid).await == 0 {
+                        break;
+                    }
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .expect("process teardown retained contexts");
+        }
+    });
 }
 
 // The generate test inferlet currently hangs at `step.execute().await`

--- a/runtime/tests/inferlets/Cargo.toml
+++ b/runtime/tests/inferlets/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "context",
     "error",
     "generate",
+    "context-lifecycle",
 ]
 
 [workspace.dependencies]

--- a/runtime/tests/inferlets/context-lifecycle/Cargo.toml
+++ b/runtime/tests/inferlets/context-lifecycle/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "context-lifecycle"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+inferlet.workspace = true
+inferlet-macros.workspace = true
+futures = "0.3"

--- a/runtime/tests/inferlets/context-lifecycle/Pie.toml
+++ b/runtime/tests/inferlets/context-lifecycle/Pie.toml
@@ -1,0 +1,7 @@
+[package]
+name = "context-lifecycle"
+version = "0.1.0"
+description = "Exercises explicit context destruction across concurrent forks"
+
+[models]
+required = ["test-model"]

--- a/runtime/tests/inferlets/context-lifecycle/src/lib.rs
+++ b/runtime/tests/inferlets/context-lifecycle/src/lib.rs
@@ -1,7 +1,7 @@
 //! Real component-boundary coverage for explicit context destruction.
 
 use futures::future::join_all;
-use inferlet::{Context, Result, model::Model, runtime};
+use inferlet::{Context, FutureStringExt, Result, messaging, model::Model, runtime};
 
 #[inferlet::main]
 async fn main(input: String) -> Result<String> {
@@ -16,8 +16,17 @@ async fn main(input: String) -> Result<String> {
     .await;
     root.destroy();
 
+    messaging::push("lifecycle-ready", &input);
+    let release = messaging::pull("lifecycle-release")
+        .wait_async()
+        .await
+        .ok_or("lifecycle release channel closed")?;
+    if release != input {
+        return Err(format!("unexpected lifecycle release: {release}"));
+    }
+
     if input == "error" {
-        return Err("injected error after context cleanup".into());
+        return Err("injected context lifecycle error".into());
     }
     Ok("contexts released".into())
 }

--- a/runtime/tests/inferlets/context-lifecycle/src/lib.rs
+++ b/runtime/tests/inferlets/context-lifecycle/src/lib.rs
@@ -1,0 +1,23 @@
+//! Real component-boundary coverage for explicit context destruction.
+
+use futures::future::join_all;
+use inferlet::{Context, Result, model::Model, runtime};
+
+#[inferlet::main]
+async fn main(input: String) -> Result<String> {
+    let models = runtime::models();
+    let model = Model::load(&models[0])?;
+    let root = Context::new(&model)?;
+    let forks = (0..4).map(|_| root.fork()).collect::<Result<Vec<_>>>()?;
+
+    join_all(forks.into_iter().map(|fork| async move {
+        fork.destroy();
+    }))
+    .await;
+    root.destroy();
+
+    if input == "error" {
+        return Err("injected error after context cleanup".into());
+    }
+    Ok("contexts released".into())
+}


### PR DESCRIPTION
Explicit context destruction currently deletes its resource-table handle while the component call still holds the WIT receiver borrow, which can trap during concurrent inferlet cleanup. Keep immediate underlying-context destruction and speculation invalidation, but leave handle deletion to the ordinary resource drop after the borrowed call returns. Add a compiled inferlet/runtime test that destroys a root and four concurrent forks, proves the live process retains zero contexts, and verifies exact success and injected-error outcomes.\n\nVerification:\n- cargo test -p pie --test e2e explicit_destroy_releases_concurrent_forks_on_success_and_error -- --nocapture\n- cargo test -p pie --test e2e\n- cargo test -p pie --test context