### PR TITLE
Mark json_schema.rs as text for diff rendering

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# The JSON-schema converter's builtin grammar historically encoded a
+# control-character class with literal 0x00-0x1f bytes, so git/GitHub
+# misdetected the file as binary and hid its diff. The bytes are now
+# normalized to textual escapes; force a text diff so the file renders in
+# review even against the pre-normalization (binary) base blob.
+runtime/src/inference/structured/json_schema.rs diff

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,5 @@
-# The JSON-schema converter's builtin grammar historically encoded a
-# control-character class with literal 0x00-0x1f bytes, so git/GitHub
-# misdetected the file as binary and hid its diff. The bytes are now
-# normalized to textual escapes; force a text diff so the file renders in
-# review even against the pre-normalization (binary) base blob.
+# The JSON-schema converter's builtin grammar encodes a control-character
+# class with literal 0x00-0x1f bytes, so git and GitHub currently misdetect
+# this file as binary and render no diff for changes to it. Mark the path as
+# text for diffing so that changes to this file review as a proper text diff.
 runtime/src/inference/structured/json_schema.rs diff


### PR DESCRIPTION
runtime/src/inference/structured/json_schema.rs contains literal 0x00-0x1f control bytes in the builtin JSON grammar string char class, so git and GitHub misdetect the file as binary and render no diff for changes to it. This tiny prerequisite adds a path-specific diff attribute so the file is treated as text for diffing. Merging it first lets a follow-on change that normalizes those bytes to textual escapes review as a proper text diff. No code or behavior change.