### PR TITLE
feat(cuda): extend routed-expert streaming to GPT-OSS, Mixtral, and Qwen MoE

### DIFF
--- a/driver/cuda/src/config.hpp
+++ b/driver/cuda/src/config.hpp
@@ -36,10 +36,10 @@ struct ModelConfig {
     //   * "bf16" / "dequant" — eagerly dequantize experts to BF16 at load.
     //   * "native" — require a true MXFP4 MoE GEMM backend.
     std::string mxfp4_moe = "auto";
-    // SSD expert streaming (DeepSeek-V4 only, tp_size=1). When true, routed
-    // MoE expert weights are not materialized on the GPU at load time;
-    // instead they are paged on demand from the safetensors shards into a
-    // bounded LRU expert cache at forward time.
+    // SSD expert streaming (DeepSeek-V4 / GPT-OSS / Mixtral, tp_size=1). When
+    // true, routed MoE expert weights are not materialized on the GPU at load
+    // time; instead they are paged on demand from the safetensors shards into
+    // a bounded LRU expert cache at forward time.
     bool stream_routed_experts = false;
     // Expert stream cache budget in GiB. 0 (default) = auto: half of the
     // free device memory after resident weights, capped at the full routed

--- a/driver/cuda/src/config.hpp
+++ b/driver/cuda/src/config.hpp
@@ -36,10 +36,10 @@ struct ModelConfig {
     //   * "bf16" / "dequant" — eagerly dequantize experts to BF16 at load.
     //   * "native" — require a true MXFP4 MoE GEMM backend.
     std::string mxfp4_moe = "auto";
-    // SSD expert streaming (DeepSeek-V4 / GPT-OSS / Mixtral, tp_size=1). When
-    // true, routed MoE expert weights are not materialized on the GPU at load
-    // time; instead they are paged on demand from the safetensors shards into
-    // a bounded LRU expert cache at forward time.
+    // SSD expert streaming (DeepSeek-V4 / GPT-OSS / Mixtral / Qwen MoE,
+    // tp_size=1). When true, routed MoE expert weights are not materialized
+    // on the GPU at load time; instead they are paged on demand from the
+    // safetensors shards into a bounded LRU expert cache at forward time.
     bool stream_routed_experts = false;
     // Expert stream cache budget in GiB. 0 (default) = auto: half of the
     // free device memory after resident weights, capped at the full routed

--- a/driver/cuda/src/entry.cpp
+++ b/driver/cuda/src/entry.cpp
@@ -471,13 +471,16 @@ int run_impl(int argc,
         : 0;
     // SSD expert streaming: carve the bounded expert slab out of free VRAM
     // now, *before* the memory planner runs, so KV/workspace sizing adapts
-    // to the remaining budget automatically. DSv4, GPT-OSS, and Mixtral are
-    // wired; the Rust weight-loader compiler already rejected other archs.
+    // to the remaining budget automatically. DSv4, GPT-OSS, Mixtral, and
+    // Qwen3/3.5-MoE are wired; the Rust weight-loader compiler already
+    // rejected other archs.
     std::unique_ptr<pie_cuda_driver::ExpertStreamCache> expert_stream_cache;
     if (cfg.model.stream_routed_experts) {
-        if (!is_dsv4_arch && !is_gpt_oss_arch && !is_mixtral_arch) {
+        if (!is_dsv4_arch && !is_gpt_oss_arch && !is_mixtral_arch &&
+            !is_qwen3_5_moe_arch) {
             std::cerr << "[pie-driver-cuda] model.stream_routed_experts is only "
-                         "supported for deepseek_v4, gpt_oss, and mixtral (got '"
+                         "supported for deepseek_v4, gpt_oss, mixtral, and "
+                         "qwen3_moe/qwen3_5_moe (got '"
                       << engine.hf_config().model_type << "')\n";
             return 2;
         }
@@ -1257,7 +1260,8 @@ int run_impl(int argc,
             }(),
             /*supports_small_prefill_graph=*/
                 kv_cache.format().is_native_bf16() && !kv_cache.hnd_layout() &&
-                pie_cuda_driver::model::qwen35_small_spec_graph_tokens() > 0);
+                pie_cuda_driver::model::qwen35_small_spec_graph_tokens() > 0,
+            expert_stream_cache.get());
         forward_fn.attach_model(qwen3_5_moe_model.get());
         if (weights_qwen3_5_moe.mtp.has_value() && native_mtp_num_drafts > 0) {
             qwen3_5_moe_model->wire_system_drafter(

--- a/driver/cuda/src/entry.cpp
+++ b/driver/cuda/src/entry.cpp
@@ -361,6 +361,7 @@ int run_impl(int argc,
     const bool is_gemma4_arch = bound_model.is_gemma4();
     const bool is_gemma3n_arch = bound_model.is_gemma3n();
     const bool is_mixtral_arch = bound_model.is_mixtral();
+    const bool is_gpt_oss_arch = bound_model.is_gpt_oss();
     const bool is_qwen3_5_arch = bound_model.is_qwen3_5();
     const bool is_qwen3_5_moe_arch = bound_model.is_qwen3_5_moe();
     const bool is_nemotron_h_arch = bound_model.is_nemotron_h();
@@ -470,13 +471,13 @@ int run_impl(int argc,
         : 0;
     // SSD expert streaming: carve the bounded expert slab out of free VRAM
     // now, *before* the memory planner runs, so KV/workspace sizing adapts
-    // to the remaining budget automatically. Only DSv4 is wired up; the
-    // Rust weight-loader compiler already rejected other archs at load.
+    // to the remaining budget automatically. DSv4 and GPT-OSS are wired;
+    // the Rust weight-loader compiler already rejected other archs at load.
     std::unique_ptr<pie_cuda_driver::ExpertStreamCache> expert_stream_cache;
     if (cfg.model.stream_routed_experts) {
-        if (!is_dsv4_arch) {
+        if (!is_dsv4_arch && !is_gpt_oss_arch) {
             std::cerr << "[pie-driver-cuda] model.stream_routed_experts is only "
-                         "supported for deepseek_v4 (got '"
+                         "supported for deepseek_v4 and gpt_oss (got '"
                       << engine.hf_config().model_type << "')\n";
             return 2;
         }
@@ -954,6 +955,7 @@ int run_impl(int argc,
         fwd_cfg.tp_size = cfg.distributed.tp_size;
         fwd_cfg.tp_comm = tp_comm_ptr;
         fwd_cfg.emit_logits = (cfg.distributed.tp_rank == 0);
+        fwd_cfg.expert_cache = expert_stream_cache.get();
         {
             const int T = std::max(1, cfg.distributed.tp_size);
             const int local_q_heads = hf.num_attention_heads / T;
@@ -1199,7 +1201,7 @@ int run_impl(int argc,
         gemma2_model = std::make_unique<pie_cuda_driver::model::Gemma2Model>(
             weights_gemma, engine.hf_config(), gemma_fwd_cfg);
         forward_fn.attach_model(gemma2_model.get());
-    } else if (is_mixtral_arch) {
+    } else if (is_mixtral_arch || is_gpt_oss_arch) {
         mixtral_model = std::make_unique<pie_cuda_driver::model::MixtralModel>(
             weights_mixtral, engine.hf_config(), fwd_cfg,
             engine.hf_config().num_experts,

--- a/driver/cuda/src/entry.cpp
+++ b/driver/cuda/src/entry.cpp
@@ -471,13 +471,13 @@ int run_impl(int argc,
         : 0;
     // SSD expert streaming: carve the bounded expert slab out of free VRAM
     // now, *before* the memory planner runs, so KV/workspace sizing adapts
-    // to the remaining budget automatically. DSv4 and GPT-OSS are wired;
-    // the Rust weight-loader compiler already rejected other archs at load.
+    // to the remaining budget automatically. DSv4, GPT-OSS, and Mixtral are
+    // wired; the Rust weight-loader compiler already rejected other archs.
     std::unique_ptr<pie_cuda_driver::ExpertStreamCache> expert_stream_cache;
     if (cfg.model.stream_routed_experts) {
-        if (!is_dsv4_arch && !is_gpt_oss_arch) {
+        if (!is_dsv4_arch && !is_gpt_oss_arch && !is_mixtral_arch) {
             std::cerr << "[pie-driver-cuda] model.stream_routed_experts is only "
-                         "supported for deepseek_v4 and gpt_oss (got '"
+                         "supported for deepseek_v4, gpt_oss, and mixtral (got '"
                       << engine.hf_config().model_type << "')\n";
             return 2;
         }

--- a/driver/cuda/src/model/bound_model.cpp
+++ b/driver/cuda/src/model/bound_model.cpp
@@ -11,6 +11,7 @@ std::size_t BoundCudaModel::num_layers() const noexcept {
     case Kind::Gemma4: return gemma4.layers.size();
     case Kind::Gemma3n: return gemma3n.layers.size();
     case Kind::Mixtral: return mixtral.layers.size();
+    case Kind::GptOss: return mixtral.layers.size();
     case Kind::Qwen3_5: return qwen3_5.layers.size();
     case Kind::Qwen3_5Moe: return qwen3_5_moe.layers.size();
     case Kind::NemotronH: return nemotron_h.layers.size();
@@ -108,7 +109,7 @@ BoundCudaModel bind_cuda_model(LoadedModel& engine, bool verbose) {
         bound.kind = BoundCudaModel::Kind::Gemma3n;
         bound.gemma3n = bind_gemma3n(engine);
     } else if (is_gpt_oss) {
-        bound.kind = BoundCudaModel::Kind::Mixtral;
+        bound.kind = BoundCudaModel::Kind::GptOss;
         bound.mixtral = bind_gpt_oss(engine);
     } else if (mt == "mixtral") {
         bound.kind = BoundCudaModel::Kind::Mixtral;

--- a/driver/cuda/src/model/bound_model.hpp
+++ b/driver/cuda/src/model/bound_model.hpp
@@ -27,6 +27,7 @@ struct BoundCudaModel {
         Gemma4,
         Gemma3n,
         Mixtral,
+        GptOss,
         Qwen3_5,
         Qwen3_5Moe,
         NemotronH,
@@ -78,6 +79,7 @@ struct BoundCudaModel {
     bool is_gemma4() const noexcept { return kind == Kind::Gemma4; }
     bool is_gemma3n() const noexcept { return kind == Kind::Gemma3n; }
     bool is_mixtral() const noexcept { return kind == Kind::Mixtral; }
+    bool is_gpt_oss() const noexcept { return kind == Kind::GptOss; }
     bool is_qwen3_5() const noexcept { return kind == Kind::Qwen3_5; }
     bool is_qwen3_5_moe() const noexcept { return kind == Kind::Qwen3_5Moe; }
     bool is_nemotron_h() const noexcept { return kind == Kind::NemotronH; }

--- a/driver/cuda/src/model/dsv4_expert_sections.hpp
+++ b/driver/cuda/src/model/dsv4_expert_sections.hpp
@@ -3,7 +3,7 @@
 // DeepSeek-V4 section-index map for streamed experts.
 //
 // Order must match `DSV4_EXPERT_SECTIONS` in
-// `driver/weight_loader/src/abi.rs`:
+// `driver/weight_loader/src/stream_arch.rs`:
 //   w1.weight, w1.scale, w2.weight, w2.scale, w3.weight, w3.scale
 
 #include <cstdint>

--- a/driver/cuda/src/model/gpt_oss.cpp
+++ b/driver/cuda/src/model/gpt_oss.cpp
@@ -38,6 +38,8 @@ DeviceTensor tensor_view(
 
 constexpr int kViewsPerExpert = 8;
 constexpr int kNativeMxfp4HandlesPerExpert = 9;
+// Streaming keeps only biases resident (gate, up, down).
+constexpr int kStreamingBiasHandlesPerExpert = 3;
 
 int align_up_int(int value, int alignment) {
     return ((value + alignment - 1) / alignment) * alignment;
@@ -61,8 +63,14 @@ MixtralWeights bind_gpt_oss(const LoadedModel& engine) {
             "gpt_oss: intermediate_size must be divisible by tp_size");
     }
     const int I = I_full / T;
+    const bool streaming =
+        engine.streamed_expert_table().num_layers > 0;
     const bool native_mxfp4 =
         engine.mxfp4_moe_lowering() == Mxfp4MoeLowering::NativeGemm;
+    if (streaming && native_mxfp4) {
+        throw std::runtime_error(
+            "gpt_oss: stream_routed_experts is incompatible with native MXFP4");
+    }
     const int I_native = native_mxfp4 ? align_up_int(I, 128) : I;
     const int L = cfg.num_hidden_layers;
     const int Hq = (cfg.num_attention_heads * cfg.head_dim) / T;
@@ -85,10 +93,13 @@ MixtralWeights bind_gpt_oss(const LoadedModel& engine) {
     w.owned_expert_buffers.reserve(
         static_cast<std::size_t>(L) * E *
         static_cast<std::size_t>(
-            native_mxfp4 ? kNativeMxfp4HandlesPerExpert : kViewsPerExpert));
+            native_mxfp4 ? kNativeMxfp4HandlesPerExpert
+                         : (streaming ? kStreamingBiasHandlesPerExpert
+                                      : kViewsPerExpert)));
     w.layers.resize(static_cast<std::size_t>(L));
 
     const bool has_routed_mxfp4_experts =
+        !streaming &&
         engine.has("model.layers.0.mlp.experts.gate_up_proj.weight");
     const bool has_native_mxfp4_experts =
         engine.has("model.layers.0.mlp.experts.gate_proj.weight") &&
@@ -105,7 +116,7 @@ MixtralWeights bind_gpt_oss(const LoadedModel& engine) {
             "did not select native MXFP4");
     }
     const bool use_mxfp4_packed_experts =
-        has_routed_mxfp4_experts || has_native_mxfp4_experts;
+        streaming || has_routed_mxfp4_experts || has_native_mxfp4_experts;
     if (use_mxfp4_packed_experts) {
         if (H % 32 != 0 || I % 32 != 0) {
             throw std::runtime_error(
@@ -301,6 +312,47 @@ MixtralWeights bind_gpt_oss(const LoadedModel& engine) {
                         expert_idx * gate_up_bias_expert_bytes,
                         {I}));
                     Ew.b_up = &w.owned_expert_buffers.back();
+                    w.owned_expert_buffers.push_back(tensor_view(
+                        b_down_all,
+                        expert_idx * down_bias_expert_bytes,
+                        {H}));
+                    Ew.b_down = &w.owned_expert_buffers.back();
+                }
+            } else if (streaming) {
+                // Packed MXFP4 weights live in the stream cache; only biases
+                // are resident. Forward dequants from cache slot pointers.
+                const std::string gate_up_bias_name =
+                    p + "mlp.experts.gate_up_proj.bias";
+                const std::string down_bias_name =
+                    p + "mlp.experts.down_proj.bias";
+                const auto& b_gate_up_all = must(engine, gate_up_bias_name);
+                const auto& b_down_all = must(engine, down_bias_name);
+                const std::vector<std::int64_t> gate_up_bias_shape = {E, 2 * I};
+                const std::vector<std::int64_t> down_bias_shape = {E, H};
+                if (b_gate_up_all.dtype() != DType::BF16 ||
+                    b_down_all.dtype() != DType::BF16 ||
+                    b_gate_up_all.shape() != gate_up_bias_shape ||
+                    b_down_all.shape() != down_bias_shape) {
+                    throw std::runtime_error(
+                        "gpt_oss: streaming path bias shape mismatch at layer " +
+                        std::to_string(li));
+                }
+                for (int e = 0; e < E; ++e) {
+                    auto& Ew = Lw.experts[e];
+                    const auto expert_idx = static_cast<std::size_t>(e);
+                    Ew.format = MixtralExpertWeightFormat::Mxfp4RoutedDequant;
+
+                    auto gate_bias = DeviceTensor::allocate(DType::BF16, {I});
+                    auto up_bias = DeviceTensor::allocate(DType::BF16, {I});
+                    kernels::launch_deinterleave_vec_bf16(
+                        static_cast<const std::uint8_t*>(b_gate_up_all.data()) +
+                            expert_idx * mxfp4_gate_up_bias_expert_bytes,
+                        gate_bias.data(), up_bias.data(), I, /*stream=*/0);
+                    w.owned_expert_buffers.push_back(std::move(gate_bias));
+                    Ew.b_gate = &w.owned_expert_buffers.back();
+                    w.owned_expert_buffers.push_back(std::move(up_bias));
+                    Ew.b_up = &w.owned_expert_buffers.back();
+
                     w.owned_expert_buffers.push_back(tensor_view(
                         b_down_all,
                         expert_idx * down_bias_expert_bytes,

--- a/driver/cuda/src/model/gpt_oss_expert_sections.hpp
+++ b/driver/cuda/src/model/gpt_oss_expert_sections.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+// GPT-OSS section-index map for streamed experts (RoutedDequant path).
+//
+// Order must match `GPT_OSS_EXPERT_SECTIONS` in
+// `driver/weight_loader/src/stream_arch.rs`:
+//   gate_up.weight, gate_up.scale, down.weight, down.scale
+// Biases stay resident and are not streamed.
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include "expert_stream_cache.hpp"
+
+namespace pie_cuda_driver {
+namespace model {
+
+inline constexpr int kGptOssExpertSectionCount = 4;
+enum GptOssExpertSection : int {
+    kGptOssGateUp = 0,
+    kGptOssGateUpScale = 1,
+    kGptOssDown = 2,
+    kGptOssDownScale = 3,
+};
+
+inline void require_gpt_oss_sections(const ExpertSectionPointers& p)
+{
+    if (p.num_sections() != kGptOssExpertSectionCount) {
+        throw std::runtime_error(
+            "gpt_oss expert streaming: expected " +
+            std::to_string(kGptOssExpertSectionCount) + " sections, got " +
+            std::to_string(p.num_sections()));
+    }
+}
+
+inline const std::uint8_t* gpt_oss_gate_up(const ExpertSectionPointers& p)
+{
+    return p.at(kGptOssGateUp);
+}
+inline const std::uint8_t* gpt_oss_gate_up_scale(const ExpertSectionPointers& p)
+{
+    return p.at(kGptOssGateUpScale);
+}
+inline const std::uint8_t* gpt_oss_down(const ExpertSectionPointers& p)
+{
+    return p.at(kGptOssDown);
+}
+inline const std::uint8_t* gpt_oss_down_scale(const ExpertSectionPointers& p)
+{
+    return p.at(kGptOssDownScale);
+}
+
+}  // namespace model
+}  // namespace pie_cuda_driver

--- a/driver/cuda/src/model/llama_like.hpp
+++ b/driver/cuda/src/model/llama_like.hpp
@@ -23,6 +23,10 @@
 #include "ops/attention_flashinfer.hpp"
 #include "ops/attention_xqa.hpp"
 
+namespace pie_cuda_driver {
+class ExpertStreamCache;
+}
+
 namespace pie_cuda_driver::model {
 
 enum class RopeKind {
@@ -100,6 +104,11 @@ struct LlamaLikeForwardCfg {
     int mrope_section_t = 0;
     int mrope_section_h = 0;
     int mrope_section_w = 0;
+
+    // SSD expert streaming (GPT-OSS RoutedDequant): non-null when routed
+    // expert packs are paged on demand. Mixtral BF16 / native MXFP4 leave
+    // this null and use resident WeightStore tensors.
+    ExpertStreamCache* expert_cache = nullptr;
 };
 
 // Per-fire Qwen3-VL multimodal side-inputs threaded into the shared

--- a/driver/cuda/src/model/llama_like.hpp
+++ b/driver/cuda/src/model/llama_like.hpp
@@ -105,9 +105,9 @@ struct LlamaLikeForwardCfg {
     int mrope_section_h = 0;
     int mrope_section_w = 0;
 
-    // SSD expert streaming (GPT-OSS RoutedDequant): non-null when routed
-    // expert packs are paged on demand. Mixtral BF16 / native MXFP4 leave
-    // this null and use resident WeightStore tensors.
+    // SSD expert streaming: non-null when routed experts are paged on demand
+    // (GPT-OSS MXFP4 RoutedDequant and Mixtral BF16). Resident Mixtral /
+    // native MXFP4 leave this null and use WeightStore tensors.
     ExpertStreamCache* expert_cache = nullptr;
 };
 

--- a/driver/cuda/src/model/llama_like_model.cpp
+++ b/driver/cuda/src/model/llama_like_model.cpp
@@ -23,7 +23,10 @@ LlamaLikeModel::LlamaLikeModel(
     // dequant launch shape depends on the live page count, while decode
     // graph keys only bucket request count/layout — replay would leave
     // newly-active pages stale, so we gate graph_safe on native BF16.
-    caps_.graph_safe = kv_cache_.format().is_native_bf16();
+    // SSD expert streaming also needs host routing / page-ins that graphs
+    // cannot capture (Mixtral / GPT-OSS).
+    caps_.graph_safe = kv_cache_.format().is_native_bf16() &&
+                       fwd_cfg_.expert_cache == nullptr;
     caps_.supports_compact_logits = true;
     caps_.supports_tp_greedy_argmax = supports_tp_greedy_argmax;
 }

--- a/driver/cuda/src/model/mixtral.cpp
+++ b/driver/cuda/src/model/mixtral.cpp
@@ -26,6 +26,7 @@
 #include "kernels/swiglu.hpp"
 #include "kernels/topk_softmax.hpp"
 #include "model/gpt_oss_expert_sections.hpp"
+#include "model/mixtral_expert_sections.hpp"
 #include "ops/gemm.hpp"
 #include "ops/attention_flashinfer.hpp"
 
@@ -49,6 +50,7 @@ MixtralWeights bind_mixtral(const LoadedModel& engine) {
         throw std::runtime_error(
             "mixtral: hf_config.num_experts must be > 0; check the loader");
     }
+    const bool streaming = engine.streamed_expert_table().num_layers > 0;
 
     MixtralWeights w;
     w.embed      = &must(engine, "model.embed_tokens.weight");
@@ -75,13 +77,20 @@ MixtralWeights bind_mixtral(const LoadedModel& engine) {
 
         L.router    = &must(engine, p + "block_sparse_moe.gate.weight");
         L.experts.resize(static_cast<std::size_t>(E));
-        for (int e = 0; e < E; ++e) {
-            const std::string ep = p + "block_sparse_moe.experts." +
-                                   std::to_string(e) + ".";
-            // HF Mixtral expert weight layout: w1=gate, w2=down, w3=up.
-            L.experts[e].w_gate = &must(engine, ep + "w1.weight");
-            L.experts[e].w_down = &must(engine, ep + "w2.weight");
-            L.experts[e].w_up   = &must(engine, ep + "w3.weight");
+        if (streaming) {
+            // Expert BF16 weights live in the stream cache; leave w_* null.
+            for (int e = 0; e < E; ++e) {
+                L.experts[e].format = MixtralExpertWeightFormat::Bf16;
+            }
+        } else {
+            for (int e = 0; e < E; ++e) {
+                const std::string ep = p + "block_sparse_moe.experts." +
+                                       std::to_string(e) + ".";
+                // HF Mixtral expert weight layout: w1=gate, w2=down, w3=up.
+                L.experts[e].w_gate = &must(engine, ep + "w1.weight");
+                L.experts[e].w_down = &must(engine, ep + "w2.weight");
+                L.experts[e].w_up   = &must(engine, ep + "w3.weight");
+            }
         }
     }
     return w;
@@ -374,15 +383,21 @@ void mixtral_forward_paged(
         }
 
         // 3. Per-expert dispatch. GPT-OSS may page MXFP4 packs through
-        // ExpertStreamCache (RoutedDequant); plain Mixtral stays resident.
+        // ExpertStreamCache (RoutedDequant); Mixtral BF16 streaming pages
+        // w1/w2/w3 directly; otherwise experts stay resident.
         ExpertStreamCache* const expert_cache = fwd_cfg.expert_cache;
         const bool stream_mxfp4 =
             expert_cache != nullptr &&
             !layer.experts.empty() &&
             layer.experts[0].format ==
                 MixtralExpertWeightFormat::Mxfp4RoutedDequant;
+        const bool stream_bf16 =
+            expert_cache != nullptr &&
+            !layer.experts.empty() &&
+            layer.experts[0].format == MixtralExpertWeightFormat::Bf16 &&
+            layer.experts[0].w_gate == nullptr;
 
-        auto run_bf16_mlp = [&](int e,
+        auto dequant_mxfp4_and_run_expert = [&](int e,
                                 const std::uint8_t* gate_up_mxfp4,
                                 const std::uint8_t* gate_up_scale,
                                 const std::uint8_t* down_mxfp4,
@@ -454,6 +469,45 @@ void mixtral_forward_paged(
                 Ne, H, stream);
         };
 
+        auto run_bf16_expert = [&](int e,
+                                         const void* gate_w,
+                                         const void* up_w,
+                                         const void* down_w) {
+            const auto& tok_idx = routing.token_idx[static_cast<std::size_t>(e)];
+            const auto& weights = routing.weights[static_cast<std::size_t>(e)];
+            const int Ne = static_cast<int>(tok_idx.size());
+
+            CUDA_CHECK(cudaMemcpyAsync(
+                d_expert_idx.data(), tok_idx.data(),
+                Ne * sizeof(std::int32_t), cudaMemcpyHostToDevice, stream));
+            CUDA_CHECK(cudaMemcpyAsync(
+                d_expert_w.data(), weights.data(),
+                Ne * sizeof(float), cudaMemcpyHostToDevice, stream));
+            kernels::launch_gather_bf16_rows(
+                static_cast<const std::uint16_t*>(ws.norm_y.data()),
+                d_expert_idx.data(),
+                d_expert_in.data(),
+                Ne, H, stream);
+
+            ops::gemm_act_x_wt_bf16(cublas.handle(),
+                d_expert_in.data(), gate_w,
+                d_expert_gate.data(), Ne, I, H);
+            ops::gemm_act_x_wt_bf16(cublas.handle(),
+                d_expert_in.data(), up_w,
+                d_expert_up.data(), Ne, I, H);
+            kernels::launch_swiglu_bf16(
+                d_expert_gate.data(), d_expert_up.data(),
+                d_expert_gate.data(),
+                static_cast<std::size_t>(Ne) * I, stream);
+            ops::gemm_act_x_wt_bf16(cublas.handle(),
+                d_expert_gate.data(), down_w,
+                d_expert_out.data(), Ne, H, I);
+            kernels::launch_scatter_add_weighted_bf16(
+                moe_target, d_expert_out.data(),
+                d_expert_idx.data(), d_expert_w.data(),
+                Ne, H, stream);
+        };
+
         if (stream_mxfp4) {
             if (w.mxfp4_gate_up_bf16_scratch.empty() ||
                 w.mxfp4_gate_bf16_scratch.empty() ||
@@ -482,9 +536,36 @@ void mixtral_forward_paged(
                 for (std::size_t j = 0; j < chunk; ++j) {
                     const auto& p = ptrs[j];
                     require_gpt_oss_sections(p);
-                    run_bf16_mlp(selected[off + j],
+                    dequant_mxfp4_and_run_expert(selected[off + j],
                                  gpt_oss_gate_up(p), gpt_oss_gate_up_scale(p),
                                  gpt_oss_down(p), gpt_oss_down_scale(p));
+                }
+            }
+        } else if (stream_bf16) {
+            std::vector<int> selected;
+            selected.reserve(static_cast<std::size_t>(num_experts));
+            for (int e = 0; e < num_experts; ++e) {
+                if (!routing.token_idx[static_cast<std::size_t>(e)].empty()) {
+                    selected.push_back(e);
+                }
+            }
+            std::vector<ExpertSectionPointers> ptrs;
+            const std::size_t max_batch =
+                static_cast<std::size_t>(expert_cache->num_slots());
+            for (std::size_t off = 0; off < selected.size(); off += max_batch) {
+                const std::size_t chunk =
+                    std::min(max_batch, selected.size() - off);
+                expert_cache->ensure_resident(
+                    L,
+                    std::span<const int>(selected.data() + off, chunk),
+                    stream, ptrs);
+                for (std::size_t j = 0; j < chunk; ++j) {
+                    const auto& p = ptrs[j];
+                    require_mixtral_sections(p);
+                    // HF: w1=gate, w2=down, w3=up.
+                    run_bf16_expert(selected[off + j],
+                                         mixtral_w1(p), mixtral_w3(p),
+                                         mixtral_w2(p));
                 }
             }
         } else for (int e = 0; e < num_experts; ++e) {

--- a/driver/cuda/src/model/mixtral.cpp
+++ b/driver/cuda/src/model/mixtral.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <span>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -10,6 +11,7 @@
 
 #include "cuda_check.hpp"
 #include "device_buffer.hpp"
+#include "expert_stream_cache.hpp"
 #include "kernels/add_bias.hpp"
 #include "kernels/attn_sink.hpp"
 #include "kernels/dequant_fp4.hpp"
@@ -23,6 +25,7 @@
 #include "kernels/rope.hpp"
 #include "kernels/swiglu.hpp"
 #include "kernels/topk_softmax.hpp"
+#include "model/gpt_oss_expert_sections.hpp"
 #include "ops/gemm.hpp"
 #include "ops/attention_flashinfer.hpp"
 
@@ -370,8 +373,121 @@ void mixtral_forward_paged(
             moe_target = ws.norm_x.data();
         }
 
-        // 3. Per-expert dispatch.
-        for (int e = 0; e < num_experts; ++e) {
+        // 3. Per-expert dispatch. GPT-OSS may page MXFP4 packs through
+        // ExpertStreamCache (RoutedDequant); plain Mixtral stays resident.
+        ExpertStreamCache* const expert_cache = fwd_cfg.expert_cache;
+        const bool stream_mxfp4 =
+            expert_cache != nullptr &&
+            !layer.experts.empty() &&
+            layer.experts[0].format ==
+                MixtralExpertWeightFormat::Mxfp4RoutedDequant;
+
+        auto run_bf16_mlp = [&](int e,
+                                const std::uint8_t* gate_up_mxfp4,
+                                const std::uint8_t* gate_up_scale,
+                                const std::uint8_t* down_mxfp4,
+                                const std::uint8_t* down_scale) {
+            const auto& tok_idx = routing.token_idx[static_cast<std::size_t>(e)];
+            const auto& weights = routing.weights[static_cast<std::size_t>(e)];
+            const int Ne = static_cast<int>(tok_idx.size());
+            const auto& expert = layer.experts[static_cast<std::size_t>(e)];
+
+            CUDA_CHECK(cudaMemcpyAsync(
+                d_expert_idx.data(), tok_idx.data(),
+                Ne * sizeof(std::int32_t), cudaMemcpyHostToDevice, stream));
+            CUDA_CHECK(cudaMemcpyAsync(
+                d_expert_w.data(), weights.data(),
+                Ne * sizeof(float), cudaMemcpyHostToDevice, stream));
+            kernels::launch_gather_bf16_rows(
+                static_cast<const std::uint16_t*>(ws.norm_y.data()),
+                d_expert_idx.data(),
+                d_expert_in.data(),
+                Ne, H, stream);
+
+            kernels::launch_dequant_mxfp4_to_bf16(
+                gate_up_mxfp4, gate_up_scale,
+                w.mxfp4_gate_up_bf16_scratch.data(),
+                2 * I, H, stream);
+            kernels::launch_dequant_mxfp4_to_bf16(
+                down_mxfp4, down_scale,
+                w.mxfp4_down_bf16_scratch.data(),
+                H, I, stream);
+            kernels::launch_deinterleave_rows_bf16(
+                w.mxfp4_gate_up_bf16_scratch.data(),
+                w.mxfp4_gate_bf16_scratch.data(),
+                w.mxfp4_up_bf16_scratch.data(),
+                I, H, stream);
+            const void* gate_w = w.mxfp4_gate_bf16_scratch.data();
+            const void* up_w = w.mxfp4_up_bf16_scratch.data();
+            const void* down_w = w.mxfp4_down_bf16_scratch.data();
+
+            ops::gemm_act_x_wt_bf16(cublas.handle(),
+                d_expert_in.data(), gate_w,
+                d_expert_gate.data(), Ne, I, H);
+            ops::gemm_act_x_wt_bf16(cublas.handle(),
+                d_expert_in.data(), up_w,
+                d_expert_up.data(), Ne, I, H);
+            if (expert.b_gate) kernels::launch_add_bias_bf16(
+                d_expert_gate.data(), expert.b_gate->data(), Ne, I, stream);
+            if (expert.b_up) kernels::launch_add_bias_bf16(
+                d_expert_up.data(), expert.b_up->data(), Ne, I, stream);
+            if (cfg.swiglu_limit > 0.f) {
+                kernels::launch_gpt_oss_glu_bf16(
+                    d_expert_gate.data(), d_expert_up.data(),
+                    d_expert_gate.data(),
+                    static_cast<int>(static_cast<std::size_t>(Ne) * I), stream,
+                    /*limit=*/cfg.swiglu_limit);
+            } else {
+                kernels::launch_swiglu_bf16(
+                    d_expert_gate.data(), d_expert_up.data(),
+                    d_expert_gate.data(),
+                    static_cast<std::size_t>(Ne) * I, stream);
+            }
+            ops::gemm_act_x_wt_bf16(cublas.handle(),
+                d_expert_gate.data(), down_w,
+                d_expert_out.data(), Ne, H, I);
+            if (expert.b_down && tp_is_leader) kernels::launch_add_bias_bf16(
+                d_expert_out.data(), expert.b_down->data(), Ne, H, stream);
+            kernels::launch_scatter_add_weighted_bf16(
+                moe_target, d_expert_out.data(),
+                d_expert_idx.data(), d_expert_w.data(),
+                Ne, H, stream);
+        };
+
+        if (stream_mxfp4) {
+            if (w.mxfp4_gate_up_bf16_scratch.empty() ||
+                w.mxfp4_gate_bf16_scratch.empty() ||
+                w.mxfp4_up_bf16_scratch.empty() ||
+                w.mxfp4_down_bf16_scratch.empty()) {
+                throw std::runtime_error(
+                    "mixtral/gpt_oss: streaming MXFP4 path missing BF16 scratch");
+            }
+            std::vector<int> selected;
+            selected.reserve(static_cast<std::size_t>(num_experts));
+            for (int e = 0; e < num_experts; ++e) {
+                if (!routing.token_idx[static_cast<std::size_t>(e)].empty()) {
+                    selected.push_back(e);
+                }
+            }
+            std::vector<ExpertSectionPointers> ptrs;
+            const std::size_t max_batch =
+                static_cast<std::size_t>(expert_cache->num_slots());
+            for (std::size_t off = 0; off < selected.size(); off += max_batch) {
+                const std::size_t chunk =
+                    std::min(max_batch, selected.size() - off);
+                expert_cache->ensure_resident(
+                    L,
+                    std::span<const int>(selected.data() + off, chunk),
+                    stream, ptrs);
+                for (std::size_t j = 0; j < chunk; ++j) {
+                    const auto& p = ptrs[j];
+                    require_gpt_oss_sections(p);
+                    run_bf16_mlp(selected[off + j],
+                                 gpt_oss_gate_up(p), gpt_oss_gate_up_scale(p),
+                                 gpt_oss_down(p), gpt_oss_down_scale(p));
+                }
+            }
+        } else for (int e = 0; e < num_experts; ++e) {
             const auto& tok_idx = routing.token_idx[e];
             const auto& weights = routing.weights[e];
             const int Ne = static_cast<int>(tok_idx.size());

--- a/driver/cuda/src/model/mixtral_expert_sections.hpp
+++ b/driver/cuda/src/model/mixtral_expert_sections.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+// Mixtral section-index map for streamed BF16 experts.
+//
+// Order must match `MIXTRAL_EXPERT_SECTIONS` in
+// `driver/weight_loader/src/stream_arch.rs`:
+//   w1.weight, w2.weight, w3.weight
+// HF layout: w1=gate, w2=down, w3=up. Router stays resident.
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include "expert_stream_cache.hpp"
+
+namespace pie_cuda_driver {
+namespace model {
+
+inline constexpr int kMixtralExpertSectionCount = 3;
+enum MixtralExpertSection : int {
+    kMixtralW1 = 0,  // gate
+    kMixtralW2 = 1,  // down
+    kMixtralW3 = 2,  // up
+};
+
+inline void require_mixtral_sections(const ExpertSectionPointers& p)
+{
+    if (p.num_sections() != kMixtralExpertSectionCount) {
+        throw std::runtime_error(
+            "mixtral expert streaming: expected " +
+            std::to_string(kMixtralExpertSectionCount) + " sections, got " +
+            std::to_string(p.num_sections()));
+    }
+}
+
+inline const std::uint8_t* mixtral_w1(const ExpertSectionPointers& p)
+{
+    return p.at(kMixtralW1);
+}
+inline const std::uint8_t* mixtral_w2(const ExpertSectionPointers& p)
+{
+    return p.at(kMixtralW2);
+}
+inline const std::uint8_t* mixtral_w3(const ExpertSectionPointers& p)
+{
+    return p.at(kMixtralW3);
+}
+
+}  // namespace model
+}  // namespace pie_cuda_driver

--- a/driver/cuda/src/model/qwen3_5_forward.hpp
+++ b/driver/cuda/src/model/qwen3_5_forward.hpp
@@ -17,6 +17,10 @@
 #include "ops/gemm.hpp"
 #include "recurrent_state_cache.hpp"
 
+namespace pie_cuda_driver {
+class ExpertStreamCache;
+}
+
 namespace pie_cuda_driver::model {
 
 // Per-linear-attention-layer extra workspace. Allocated once and
@@ -87,6 +91,10 @@ struct Qwen3_5ForwardCfg {
     // cache lookup should stay pinned to the verified source prefix while
     // draft positions advance for RoPE and history masking.
     bool mtp_global_cache_uses_prefix_position = false;
+
+    // SSD expert streaming (Qwen3-MoE / Qwen3.5-MoE): non-null when routed
+    // experts are paged on demand. Shared expert / router stay resident.
+    ExpertStreamCache* expert_cache = nullptr;
 };
 
 // Persistent decode-plan cache. Owned by main.cpp's serving setup so

--- a/driver/cuda/src/model/qwen3_5_moe.cpp
+++ b/driver/cuda/src/model/qwen3_5_moe.cpp
@@ -250,6 +250,7 @@ Qwen3_5MoeWeights bind_qwen3_5_moe(const LoadedModel& engine) {
 
     const int T = std::max(1, engine.distributed().tp_size);
     const int rank = engine.distributed().tp_rank;
+    const bool streaming = engine.streamed_expert_table().num_layers > 0;
     int kv_slot = 0;
     for (int li = 0; li < L; ++li) {
         const std::string lp = p + "layers." + std::to_string(li) + ".";
@@ -342,8 +343,14 @@ Qwen3_5MoeWeights bind_qwen3_5_moe(const LoadedModel& engine) {
         // The moe_forward block emits a single all-reduce on the
         // combined routed+shared partial sum.
         Lw.moe_router       = &must(engine, lp + "mlp.gate.weight");
-        Lw.moe_gate_up_proj = &must(engine, lp + "mlp.experts.gate_up_proj");
-        Lw.moe_down_proj    = &must(engine, lp + "mlp.experts.down_proj");
+        if (streaming) {
+            // Routed expert BF16 weights live in the stream cache.
+            Lw.moe_gate_up_proj = nullptr;
+            Lw.moe_down_proj = nullptr;
+        } else {
+            Lw.moe_gate_up_proj = &must(engine, lp + "mlp.experts.gate_up_proj");
+            Lw.moe_down_proj    = &must(engine, lp + "mlp.experts.down_proj");
+        }
         if (has_shared_expert) {
             Lw.shared_gate_proj = &must(engine, lp + "mlp.shared_expert.gate_proj.weight");
             Lw.shared_up_proj   = &must(engine, lp + "mlp.shared_expert.up_proj.weight");

--- a/driver/cuda/src/model/qwen3_5_moe_forward.cpp
+++ b/driver/cuda/src/model/qwen3_5_moe_forward.cpp
@@ -29,6 +29,8 @@
 #include "ops/attention_naive.hpp"
 #include "ops/attention_naive_paged.hpp"
 #include "ops/gemm.hpp"
+#include "expert_stream_cache.hpp"
+#include "model/qwen_moe_expert_sections.hpp"
 
 namespace pie_cuda_driver::model {
 
@@ -1129,6 +1131,7 @@ bool moe_block(
     const Qwen3_5ForwardCfg& fwd_cfg,
     Qwen3Workspace& ws,
     Qwen3_5MoeMlpWorkspace& moe_ws,
+    int layer,
     int N,
     bool is_pure_decode,
     ops::CublasHandle& cublas, cudaStream_t stream,
@@ -1148,9 +1151,14 @@ bool moe_block(
     const int Im = cfg.moe_intermediate_size / T;            // routed: sharded
     const int Is = cfg.shared_expert_intermediate_size / T;  // shared: sharded
     NcclComm* tp = (T > 1) ? fwd_cfg.tp_comm : nullptr;
+    ExpertStreamCache* const expert_cache = fwd_cfg.expert_cache;
+    const bool stream_experts =
+        expert_cache != nullptr && Lw.moe_gate_up_proj == nullptr;
+    // SSD page-ins need host routing; CUDA graphs cannot capture them.
     const bool use_decode_fast_path =
-        is_pure_decode ||
-        (N > 0 && N <= qwen35_moe_decode_fast_max_tokens());
+        !stream_experts &&
+        (is_pure_decode ||
+         (N > 0 && N <= qwen35_moe_decode_fast_max_tokens()));
     const bool add_to_residual = (T == 1) && use_decode_fast_path;
     void* moe_out = add_to_residual ? ws.y.data() : ws.norm_y.data();
 
@@ -1195,7 +1203,116 @@ bool moe_block(
     const std::size_t expert_stride_dn =
         static_cast<std::size_t>(H) * Im;       // bf16 elements per expert in down_proj
 
-    if (use_decode_fast_path) {
+    if (stream_experts) {
+        // Host-routed SSD path: page selected experts, then GEMM from
+        // cache-slot section pointers (fused 2-section or named 3-section).
+        profile_cuda_stage(profile, profile ? &profile->moe_routed_ms : nullptr,
+            stream, [&] {
+                CUDA_CHECK(cudaMemsetAsync(ws.norm_y.data(), 0,
+                    (std::size_t)N * H * sizeof(std::uint16_t), stream));
+                const auto routing = build_routing(topk_idx_h, topk_w_h, N, K, E);
+                std::vector<int> selected;
+                selected.reserve(static_cast<std::size_t>(E));
+                for (int e = 0; e < E; ++e) {
+                    if (!routing.token_idx[static_cast<std::size_t>(e)].empty()) {
+                        selected.push_back(e);
+                    }
+                }
+                const bool named_layout =
+                    expert_cache->sections_per_expert() ==
+                    kQwen3MoeExpertSectionCount;
+                const bool fused_layout =
+                    expert_cache->sections_per_expert() ==
+                    kQwen35MoeExpertSectionCount;
+                if (!named_layout && !fused_layout) {
+                    throw std::runtime_error(
+                        "qwen moe streaming: unexpected sections_per_expert=" +
+                        std::to_string(expert_cache->sections_per_expert()));
+                }
+
+                auto run_expert = [&](int e,
+                                      const void* gate_up_or_gate,
+                                      const void* up_or_null,
+                                      const void* down_w) {
+                    const auto& tok_idx =
+                        routing.token_idx[static_cast<std::size_t>(e)];
+                    const auto& wts =
+                        routing.weights[static_cast<std::size_t>(e)];
+                    const int Ne = static_cast<int>(tok_idx.size());
+                    CUDA_CHECK(cudaMemcpyAsync(
+                        moe_ws.expert_idx.data(), tok_idx.data(),
+                        Ne * sizeof(std::int32_t), cudaMemcpyHostToDevice,
+                        stream));
+                    CUDA_CHECK(cudaMemcpyAsync(
+                        moe_ws.expert_w.data(), wts.data(),
+                        Ne * sizeof(float), cudaMemcpyHostToDevice, stream));
+                    kernels::launch_gather_bf16_rows(
+                        static_cast<const std::uint16_t*>(ws.norm_x.data()),
+                        moe_ws.expert_idx.data(),
+                        moe_ws.expert_in.data(),
+                        Ne, H, stream);
+
+                    if (up_or_null == nullptr) {
+                        ops::gemm_act_x_wt_bf16(cublas.handle(),
+                            moe_ws.expert_in.data(), gate_up_or_gate,
+                            moe_ws.expert_gate_up.data(), Ne, 2 * Im, H);
+                        kernels::launch_chunked_swiglu_bf16(
+                            moe_ws.expert_gate_up.data(),
+                            moe_ws.expert_act.data(),
+                            Ne, Im, stream);
+                    } else {
+                        // Named gate/up: park temps in the two halves of
+                        // expert_gate_up ([Ne*Im] each), then SwiGLU.
+                        auto* gate_tmp = moe_ws.expert_gate_up.data();
+                        auto* up_tmp = moe_ws.expert_gate_up.data() +
+                            static_cast<std::size_t>(Ne) * Im;
+                        ops::gemm_act_x_wt_bf16(cublas.handle(),
+                            moe_ws.expert_in.data(), gate_up_or_gate,
+                            gate_tmp, Ne, Im, H);
+                        ops::gemm_act_x_wt_bf16(cublas.handle(),
+                            moe_ws.expert_in.data(), up_or_null,
+                            up_tmp, Ne, Im, H);
+                        kernels::launch_swiglu_bf16(
+                            gate_tmp, up_tmp, moe_ws.expert_act.data(),
+                            static_cast<std::size_t>(Ne) * Im, stream);
+                    }
+                    ops::gemm_act_x_wt_bf16(cublas.handle(),
+                        moe_ws.expert_act.data(), down_w,
+                        moe_ws.expert_out.data(), Ne, H, Im);
+                    kernels::launch_scatter_add_weighted_bf16(
+                        ws.norm_y.data(), moe_ws.expert_out.data(),
+                        moe_ws.expert_idx.data(), moe_ws.expert_w.data(),
+                        Ne, H, stream);
+                };
+
+                std::vector<ExpertSectionPointers> ptrs;
+                const std::size_t max_batch =
+                    static_cast<std::size_t>(expert_cache->num_slots());
+                for (std::size_t off = 0; off < selected.size();
+                     off += max_batch) {
+                    const std::size_t chunk =
+                        std::min(max_batch, selected.size() - off);
+                    expert_cache->ensure_resident(
+                        layer,
+                        std::span<const int>(selected.data() + off, chunk),
+                        stream, ptrs);
+                    for (std::size_t j = 0; j < chunk; ++j) {
+                        const auto& p = ptrs[j];
+                        if (fused_layout) {
+                            require_qwen35_moe_sections(p);
+                            run_expert(selected[off + j],
+                                       qwen35_moe_gate_up(p), nullptr,
+                                       qwen35_moe_down(p));
+                        } else {
+                            require_qwen3_moe_sections(p);
+                            run_expert(selected[off + j],
+                                       qwen3_moe_gate(p), qwen3_moe_up(p),
+                                       qwen3_moe_down(p));
+                        }
+                    }
+                }
+            });
+    } else if (use_decode_fast_path) {
         // Decode fast-path. Fully on-device pipeline (graph-capturable):
         //   1. Build gate_up/down cuBLAS pointer arrays for every
         //      token/expert route (N*K rows) with no D2H sync.
@@ -1763,7 +1880,7 @@ void qwen3_5_moe_forward_paged(
         });
         ++profile.moe_layers;
         const bool moe_added_to_residual = moe_block(
-            Lw, cfg, fwd_cfg, ws, moe_ws, N, is_pure_decode,
+            Lw, cfg, fwd_cfg, ws, moe_ws, static_cast<int>(L), N, is_pure_decode,
             cublas, stream, &profile);
         if (!moe_added_to_residual) {
             profile_cuda_stage(&profile, &profile.residual_ms, stream, [&] {
@@ -2150,7 +2267,7 @@ void qwen3_5_moe_mtp_forward(
     bool add_moe_residual = false;
     if (mode == MtpMoeMode::Full) {
         const bool moe_added_to_residual = moe_block(
-            Lw, cfg, fwd_cfg, ws, moe_ws, num_tokens,
+            Lw, cfg, fwd_cfg, ws, moe_ws, /*layer=*/0, num_tokens,
             /*is_pure_decode=*/true, cublas, stream, /*profile=*/nullptr);
         add_moe_residual = !moe_added_to_residual;
     } else if (mode == MtpMoeMode::SharedOnly) {

--- a/driver/cuda/src/model/qwen3_5_moe_model.cpp
+++ b/driver/cuda/src/model/qwen3_5_moe_model.cpp
@@ -1,5 +1,7 @@
 #include "model/qwen3_5_moe_model.hpp"
 
+#include "expert_stream_cache.hpp"
+
 namespace pie_cuda_driver::model {
 
 Qwen35MoeModel::Qwen35MoeModel(
@@ -15,7 +17,8 @@ Qwen35MoeModel::Qwen35MoeModel(
     bool force_prefill_path,
     int small_prefill_naive_attention_max_tokens,
     bool graph_safe,
-    bool supports_small_prefill_graph)
+    bool supports_small_prefill_graph,
+    ExpertStreamCache* expert_cache)
     : weights_(weights),
       hf_config_(hf_config),
       la_ws_(la_ws),
@@ -29,10 +32,15 @@ Qwen35MoeModel::Qwen35MoeModel(
         small_prefill_naive_attention_max_tokens;
     fwd_cfg_.tp_size = tp_size;
     fwd_cfg_.tp_comm = tp_comm;
+    fwd_cfg_.expert_cache = expert_cache;
 
-    caps_.graph_safe                   = graph_safe;
+    // SSD expert page-ins need host routing + D2H sync; CUDA graphs cannot
+    // capture that path (cudaErrorStreamCaptureUnsupported).
+    const bool streaming = expert_cache != nullptr;
+    caps_.graph_safe                   = graph_safe && !streaming;
     caps_.supports_compact_logits      = true;
-    caps_.supports_small_prefill_graph = supports_small_prefill_graph;
+    caps_.supports_small_prefill_graph =
+        supports_small_prefill_graph && !streaming;
 }
 
 void Qwen35MoeModel::prepare(AttentionWorkspace& attn_ws,

--- a/driver/cuda/src/model/qwen3_5_moe_model.hpp
+++ b/driver/cuda/src/model/qwen3_5_moe_model.hpp
@@ -8,6 +8,10 @@
 #include "model/qwen3_5_moe_forward.hpp"
 #include "recurrent_state_cache.hpp"
 
+namespace pie_cuda_driver {
+class ExpertStreamCache;
+}
+
 namespace pie_cuda_driver::model {
 
 // Qwen3.5-MoE IModel (covers Qwen3.6-35B-A3B). Façade over the existing
@@ -32,7 +36,8 @@ public:
         bool force_prefill_path,
         int small_prefill_naive_attention_max_tokens,
         bool graph_safe,
-        bool supports_small_prefill_graph);
+        bool supports_small_prefill_graph,
+        ExpertStreamCache* expert_cache = nullptr);
 
     void prepare(AttentionWorkspace& attn_ws,
                  const ForwardFn::PrepareInputs& in) override;

--- a/driver/cuda/src/model/qwen_moe_expert_sections.hpp
+++ b/driver/cuda/src/model/qwen_moe_expert_sections.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+// Qwen MoE section-index maps for streamed BF16 experts.
+//
+// Orders must match `QWEN3_MOE_EXPERT_SECTIONS` / `QWEN35_MOE_EXPERT_SECTIONS`
+// in `driver/weight_loader/src/stream_arch.rs`.
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+#include "expert_stream_cache.hpp"
+
+namespace pie_cuda_driver {
+namespace model {
+
+// Plain Qwen3-MoE: per-expert gate / up / down.
+inline constexpr int kQwen3MoeExpertSectionCount = 3;
+enum Qwen3MoeExpertSection : int {
+    kQwen3MoeGate = 0,
+    kQwen3MoeUp = 1,
+    kQwen3MoeDown = 2,
+};
+
+inline void require_qwen3_moe_sections(const ExpertSectionPointers& p)
+{
+    if (p.num_sections() != kQwen3MoeExpertSectionCount) {
+        throw std::runtime_error(
+            "qwen3_moe expert streaming: expected " +
+            std::to_string(kQwen3MoeExpertSectionCount) + " sections, got " +
+            std::to_string(p.num_sections()));
+    }
+}
+
+inline const std::uint8_t* qwen3_moe_gate(const ExpertSectionPointers& p)
+{
+    return p.at(kQwen3MoeGate);
+}
+inline const std::uint8_t* qwen3_moe_up(const ExpertSectionPointers& p)
+{
+    return p.at(kQwen3MoeUp);
+}
+inline const std::uint8_t* qwen3_moe_down(const ExpertSectionPointers& p)
+{
+    return p.at(kQwen3MoeDown);
+}
+
+// Qwen3.5/3.6-MoE: fused gate_up + down banks.
+inline constexpr int kQwen35MoeExpertSectionCount = 2;
+enum Qwen35MoeExpertSection : int {
+    kQwen35MoeGateUp = 0,
+    kQwen35MoeDown = 1,
+};
+
+inline void require_qwen35_moe_sections(const ExpertSectionPointers& p)
+{
+    if (p.num_sections() != kQwen35MoeExpertSectionCount) {
+        throw std::runtime_error(
+            "qwen3_5_moe expert streaming: expected " +
+            std::to_string(kQwen35MoeExpertSectionCount) + " sections, got " +
+            std::to_string(p.num_sections()));
+    }
+}
+
+inline const std::uint8_t* qwen35_moe_gate_up(const ExpertSectionPointers& p)
+{
+    return p.at(kQwen35MoeGateUp);
+}
+inline const std::uint8_t* qwen35_moe_down(const ExpertSectionPointers& p)
+{
+    return p.at(kQwen35MoeDown);
+}
+
+}  // namespace model
+}  // namespace pie_cuda_driver

--- a/driver/weight_loader/spec/storage_program.md
+++ b/driver/weight_loader/spec/storage_program.md
@@ -33,11 +33,12 @@ They are described by `StorageProgram.stream`:
   `schedule`. These are `ExtentWrite`s whose `dest.offset` is relative to a
   cache-slot base and whose `dest.buffer` is the sentinel `BufferId(u32::MAX)`.
   Section count is arch-defined (DeepSeek-V4: 6; GPT-OSS RoutedDequant: 4;
-  Mixtral: 3 BF16 `w1/w2/w3.weight`).
+  Mixtral: 3 BF16 `w1/w2/w3.weight`; Qwen3-MoE: 3 named `gate/up/down_proj`;
+  Qwen3.5-MoE: 2 fused `gate_up`/`down`).
 - `stream.bindings`: flat `[num_layers × num_experts × sections]` source
   extents that instantiate the template at decode time. An arch plugin may
-  map one checkpoint tensor per cell (DSv4, Mixtral) or slice fused `[E, …]`
-  banks into per-expert extents (GPT-OSS).
+  map one checkpoint tensor per cell (DSv4, Mixtral, Qwen3-MoE) or slice
+  fused `[E, …]` banks into per-expert extents (GPT-OSS, Qwen3.5-MoE).
 - `stream.files` / `section_offsets` / `section_bytes` / `slot_bytes`: layout
   the driver's expert stream cache needs to open shards and size the slab.
 
@@ -45,5 +46,6 @@ Boot execution runs `schedule` only. On a cache miss the driver executes the
 template into `slot_base` with sources taken from `bindings` for that
 `(layer, expert)` — deferred loader execution, not a parallel I/O path.
 
-Supported arches today: `deepseek_v4`, `gpt_oss`, `mixtral` (plain ExtentWrite;
-GPT-OSS RoutedDequant only — biases stay resident).
+Supported arches today: `deepseek_v4`, `gpt_oss`, `mixtral`, `qwen3_moe`,
+`qwen3_5_moe` (plain ExtentWrite; GPT-OSS RoutedDequant only — biases stay
+resident; Qwen shared expert / router stay resident).

--- a/driver/weight_loader/spec/storage_program.md
+++ b/driver/weight_loader/spec/storage_program.md
@@ -30,14 +30,19 @@ excluded from the resident `schedule` (and from `memory.persistent_bytes`).
 They are described by `StorageProgram.stream`:
 
 - `stream.template`: instruction IDs into `instrs` that are **not** on
-  `schedule`. For DeepSeek-V4 these are six `ExtentWrite`s whose
-  `dest.offset` is relative to a cache-slot base and whose
-  `dest.buffer` is the sentinel `BufferId(u32::MAX)`.
+  `schedule`. These are `ExtentWrite`s whose `dest.offset` is relative to a
+  cache-slot base and whose `dest.buffer` is the sentinel `BufferId(u32::MAX)`.
+  Section count is arch-defined (DeepSeek-V4: 6; GPT-OSS RoutedDequant: 4).
 - `stream.bindings`: flat `[num_layers × num_experts × sections]` source
-  extents that instantiate the template at decode time.
+  extents that instantiate the template at decode time. An arch plugin may
+  map one checkpoint tensor per cell (DSv4) or slice fused `[E, …]` banks
+  into per-expert extents (GPT-OSS).
 - `stream.files` / `section_offsets` / `section_bytes` / `slot_bytes`: layout
   the driver's expert stream cache needs to open shards and size the slab.
 
 Boot execution runs `schedule` only. On a cache miss the driver executes the
 template into `slot_base` with sources taken from `bindings` for that
 `(layer, expert)` — deferred loader execution, not a parallel I/O path.
+
+Supported arches today: `deepseek_v4`, `gpt_oss` (plain ExtentWrite / RoutedDequant
+only; biases stay resident for GPT-OSS).

--- a/driver/weight_loader/spec/storage_program.md
+++ b/driver/weight_loader/spec/storage_program.md
@@ -32,11 +32,12 @@ They are described by `StorageProgram.stream`:
 - `stream.template`: instruction IDs into `instrs` that are **not** on
   `schedule`. These are `ExtentWrite`s whose `dest.offset` is relative to a
   cache-slot base and whose `dest.buffer` is the sentinel `BufferId(u32::MAX)`.
-  Section count is arch-defined (DeepSeek-V4: 6; GPT-OSS RoutedDequant: 4).
+  Section count is arch-defined (DeepSeek-V4: 6; GPT-OSS RoutedDequant: 4;
+  Mixtral: 3 BF16 `w1/w2/w3.weight`).
 - `stream.bindings`: flat `[num_layers × num_experts × sections]` source
   extents that instantiate the template at decode time. An arch plugin may
-  map one checkpoint tensor per cell (DSv4) or slice fused `[E, …]` banks
-  into per-expert extents (GPT-OSS).
+  map one checkpoint tensor per cell (DSv4, Mixtral) or slice fused `[E, …]`
+  banks into per-expert extents (GPT-OSS).
 - `stream.files` / `section_offsets` / `section_bytes` / `slot_bytes`: layout
   the driver's expert stream cache needs to open shards and size the slab.
 
@@ -44,5 +45,5 @@ Boot execution runs `schedule` only. On a cache miss the driver executes the
 template into `slot_base` with sources taken from `bindings` for that
 `(layer, expert)` — deferred loader execution, not a parallel I/O path.
 
-Supported arches today: `deepseek_v4`, `gpt_oss` (plain ExtentWrite / RoutedDequant
-only; biases stay resident for GPT-OSS).
+Supported arches today: `deepseek_v4`, `gpt_oss`, `mixtral` (plain ExtentWrite;
+GPT-OSS RoutedDequant only — biases stay resident).

--- a/driver/weight_loader/src/abi.rs
+++ b/driver/weight_loader/src/abi.rs
@@ -517,7 +517,7 @@ const ARCH_PROFILES: &[(&[&str], ArchProfile)] = &[
         &["deepseek_v4"],
         ArchProfile {
             shard_axis_fn: dsv4_shard_axis,
-            stream: Some(DSV4_STREAM_ARCH),
+            stream: Some(crate::stream_arch::DSV4_STREAM_ARCH),
             ..GENERIC_ARCH
         },
     ),
@@ -528,7 +528,14 @@ const ARCH_PROFILES: &[(&[&str], ArchProfile)] = &[
     ),
     (
         &["gpt_oss", "gpt-oss", "gptoss"],
-        ArchProfile { gpt_oss_mxfp4_groups: true, ..GENERIC_ARCH },
+        ArchProfile {
+            gpt_oss_mxfp4_groups: true,
+            // bind_gpt_oss reads separate q/k/v (and biases); the generic
+            // dense QKV join would consume them into qkv_proj.fused.weight.
+            skip_dense_qkv_fusion: true,
+            stream: Some(crate::stream_arch::GPT_OSS_STREAM_ARCH),
+            ..GENERIC_ARCH
+        },
     ),
     (
         &["glm_moe_dsa"],
@@ -616,7 +623,7 @@ impl DefaultAbiBuilder<'_> {
         let Some(arch) = self.profile().stream else {
             return Err(CompileError::InvalidInput(format!(
                 "stream_routed_experts is not supported for model_type='{}' \
-                 (supported: deepseek_v4)",
+                 (supported: deepseek_v4, gpt_oss)",
                 self.cfg.model_type
             )));
         };
@@ -626,6 +633,22 @@ impl DefaultAbiBuilder<'_> {
                  are strided file extents, which streaming does not support yet)"
                     .to_string(),
             ));
+        }
+        // GPT-OSS streaming copies packed MXFP4 extents only (RoutedDequant).
+        // Native Marlin / eager BF16 need different stream templates.
+        if self.profile().gpt_oss_mxfp4_groups {
+            match self.target.mxfp4_moe {
+                crate::types::Mxfp4MoePolicy::NativeGemm
+                | crate::types::Mxfp4MoePolicy::EagerBf16 => {
+                    return Err(CompileError::InvalidInput(
+                        "stream_routed_experts for gpt_oss requires \
+                         mxfp4_moe=auto|routed_dequant (plain ExtentWrite of \
+                         packed MXFP4); native and eager_bf16 are unsupported"
+                            .to_string(),
+                    ));
+                }
+                crate::types::Mxfp4MoePolicy::RoutedDecode => {}
+            }
         }
         let mut skipped = 0usize;
         for raw in &self.metadata.tensors {
@@ -1607,6 +1630,12 @@ impl DefaultAbiBuilder<'_> {
             };
             if native {
                 self.add_gpt_oss_native_mxfp4_group(block, scale, bias, base)?;
+            } else if self.target.stream_routed_experts
+                && crate::stream_arch::is_gpt_oss_streamed_expert_tensor(&block.name)
+            {
+                // Packed weight/scale are deferred to the stream plan; keep
+                // the BF16 bias resident for bind-time deinterleave.
+                self.push_direct(bias, format!("{base}.bias"), None);
             } else {
                 self.push_direct(block, format!("{base}.weight"), None);
                 self.push_direct(scale, format!("{base}.weight_scale"), None);
@@ -2118,79 +2147,6 @@ fn dsv4_shard_axis(name: &str) -> Option<Axis> {
     }
     // Everything else replicated (avoids TP communication in main path).
     None
-}
-
-/// Fixed DSv4 section order — must match `dsv4_expert_sections.hpp` in the
-/// CUDA driver (`w1/w2/w3` × weight/scale).
-pub const DSV4_EXPERT_SECTIONS: &[&str] = &[
-    "w1.weight",
-    "w1.scale",
-    "w2.weight",
-    "w2.scale",
-    "w3.weight",
-    "w3.scale",
-];
-
-/// DeepSeek-V4 main-stack routed experts:
-/// `layers.{L}.ffn.experts.{E}.{w1,w2,w3}.{weight,scale}`.
-///
-/// Shared experts (`.ffn.shared_experts.`), routers (`ffn.gate.*`), and MTP
-/// modules (`mtp.*.ffn.experts.*`) are **not** streamable — only the primary
-/// layer MoE bank is paged by the expert stream cache today.
-pub(crate) fn is_dsv4_routed_expert_tensor(name: &str) -> bool {
-    // Require the main-stack prefix so MTP / other modules stay resident.
-    let Some(rest) = name.strip_prefix("layers.") else {
-        return false;
-    };
-    let Some((_, rest)) = rest.split_once('.') else {
-        return false;
-    };
-    rest.starts_with("ffn.experts.")
-        && ends_with_any(
-            name,
-            &[
-                ".w1.weight",
-                ".w1.scale",
-                ".w2.weight",
-                ".w2.scale",
-                ".w3.weight",
-                ".w3.scale",
-            ],
-        )
-}
-
-/// Parse `layers.{L}.ffn.experts.{E}.{section}` → (layer, expert, section_idx).
-pub(crate) fn parse_dsv4_expert_section(name: &str) -> Option<(u32, u32, usize)> {
-    let rest = name.strip_prefix("layers.")?;
-    let (layer_str, rest) = rest.split_once('.')?;
-    let rest = rest.strip_prefix("ffn.experts.")?;
-    let (expert_str, section) = rest.split_once('.')?;
-    let layer: u32 = layer_str.parse().ok()?;
-    let expert: u32 = expert_str.parse().ok()?;
-    let section_idx = DSV4_EXPERT_SECTIONS.iter().position(|s| *s == section)?;
-    Some((layer, expert, section_idx))
-}
-
-const DSV4_STREAM_ARCH: crate::stream::StreamArchDesc = crate::stream::StreamArchDesc {
-    sections: DSV4_EXPERT_SECTIONS,
-    is_streamed: is_dsv4_routed_expert_tensor,
-    parse: parse_dsv4_expert_section,
-};
-
-#[cfg(test)]
-mod stream_tests {
-    use super::*;
-
-    #[test]
-    fn parse_dsv4_names() {
-        assert_eq!(
-            parse_dsv4_expert_section("layers.3.ffn.experts.12.w2.scale"),
-            Some((3, 12, 3))
-        );
-        assert!(parse_dsv4_expert_section("layers.0.ffn.shared_experts.w1.weight").is_none());
-        assert!(parse_dsv4_expert_section("layers.0.ffn.gate.weight").is_none());
-        assert!(parse_dsv4_expert_section("mtp.0.ffn.experts.0.w1.scale").is_none());
-    }
 }
 
 fn ends_with_any(value: &str, suffixes: &[&str]) -> bool {

--- a/driver/weight_loader/src/abi.rs
+++ b/driver/weight_loader/src/abi.rs
@@ -557,14 +557,25 @@ const ARCH_PROFILES: &[(&[&str], ArchProfile)] = &[
         },
     ),
     (
-        // Plain Qwen3-MoE (Qwen3-30B-A3B) and Qwen3.5-MoE: their bind path reads
-        // attention q/k/v separately and never a fused qkv, so opt out of the
-        // dense projection join that would otherwise consume q_proj/k_proj/v_proj.
-        &["qwen3_moe", "qwen3_5_moe", "qwen3_5_moe_text"],
+        // Plain Qwen3-MoE (Qwen3-30B-A3B): per-expert gate/up/down; bind reads
+        // separate q/k/v. Stack to fused banks unless SSD streaming is on.
+        &["qwen3_moe"],
         ArchProfile {
             bf16_runtime_quant: true,
             skip_dense_qkv_fusion: true,
             stack_per_expert_moe: true,
+            stream: Some(crate::stream_arch::QWEN3_MOE_STREAM_ARCH),
+            ..GENERIC_ARCH
+        },
+    ),
+    (
+        // Qwen3.5/3.6-MoE: pre-fused BF16 expert banks + optional shared expert.
+        &["qwen3_5_moe", "qwen3_5_moe_text"],
+        ArchProfile {
+            bf16_runtime_quant: true,
+            skip_dense_qkv_fusion: true,
+            stack_per_expert_moe: true,
+            stream: Some(crate::stream_arch::QWEN35_MOE_STREAM_ARCH),
             ..GENERIC_ARCH
         },
     ),
@@ -633,7 +644,7 @@ impl DefaultAbiBuilder<'_> {
         let Some(arch) = self.profile().stream else {
             return Err(CompileError::InvalidInput(format!(
                 "stream_routed_experts is not supported for model_type='{}' \
-                 (supported: deepseek_v4, gpt_oss, mixtral)",
+                 (supported: deepseek_v4, gpt_oss, mixtral, qwen3_moe, qwen3_5_moe)",
                 self.cfg.model_type
             )));
         };
@@ -1241,6 +1252,11 @@ impl DefaultAbiBuilder<'_> {
         if !self.profile().stack_per_expert_moe || self.target.tp_size != 1 {
             // TP>1 per-expert sharding is not wired yet; the bind then fails
             // loudly on the missing fused tensor rather than loading silently wrong.
+            return Ok(());
+        }
+        // SSD streaming pages per-expert (or fused-bank) extents directly;
+        // stacking would also emit resident fused contracts from the same sources.
+        if self.target.stream_routed_experts {
             return Ok(());
         }
         let num_experts = self.cfg.num_experts as i64;

--- a/driver/weight_loader/src/abi.rs
+++ b/driver/weight_loader/src/abi.rs
@@ -538,6 +538,16 @@ const ARCH_PROFILES: &[(&[&str], ArchProfile)] = &[
         },
     ),
     (
+        // Plain Mixtral: per-expert BF16 w1/w2/w3 under block_sparse_moe.
+        // bind_mixtral reads separate q/k/v, so opt out of dense QKV fusion.
+        &["mixtral"],
+        ArchProfile {
+            skip_dense_qkv_fusion: true,
+            stream: Some(crate::stream_arch::MIXTRAL_STREAM_ARCH),
+            ..GENERIC_ARCH
+        },
+    ),
+    (
         &["glm_moe_dsa"],
         ArchProfile {
             shard_embed_tokens: true,
@@ -623,7 +633,7 @@ impl DefaultAbiBuilder<'_> {
         let Some(arch) = self.profile().stream else {
             return Err(CompileError::InvalidInput(format!(
                 "stream_routed_experts is not supported for model_type='{}' \
-                 (supported: deepseek_v4, gpt_oss)",
+                 (supported: deepseek_v4, gpt_oss, mixtral)",
                 self.cfg.model_type
             )));
         };

--- a/driver/weight_loader/src/lib.rs
+++ b/driver/weight_loader/src/lib.rs
@@ -22,6 +22,7 @@ pub mod source;
 pub mod storage;
 pub mod storage_compiler;
 pub mod stream;
+pub mod stream_arch;
 pub mod typecheck;
 pub mod types;
 

--- a/driver/weight_loader/src/storage_compiler.rs
+++ b/driver/weight_loader/src/storage_compiler.rs
@@ -41,7 +41,7 @@ pub fn compile_storage_program(
         let Some(arch) = crate::abi::stream_arch_for(&cfg.model_type) else {
             return Err(CompileError::InvalidInput(format!(
                 "stream_routed_experts is not supported for model_type='{}' \
-                 (supported: deepseek_v4, gpt_oss)",
+                 (supported: deepseek_v4, gpt_oss, mixtral)",
                 cfg.model_type
             )));
         };

--- a/driver/weight_loader/src/storage_compiler.rs
+++ b/driver/weight_loader/src/storage_compiler.rs
@@ -41,7 +41,7 @@ pub fn compile_storage_program(
         let Some(arch) = crate::abi::stream_arch_for(&cfg.model_type) else {
             return Err(CompileError::InvalidInput(format!(
                 "stream_routed_experts is not supported for model_type='{}' \
-                 (supported: deepseek_v4)",
+                 (supported: deepseek_v4, gpt_oss)",
                 cfg.model_type
             )));
         };

--- a/driver/weight_loader/src/storage_compiler.rs
+++ b/driver/weight_loader/src/storage_compiler.rs
@@ -41,7 +41,7 @@ pub fn compile_storage_program(
         let Some(arch) = crate::abi::stream_arch_for(&cfg.model_type) else {
             return Err(CompileError::InvalidInput(format!(
                 "stream_routed_experts is not supported for model_type='{}' \
-                 (supported: deepseek_v4, gpt_oss, mixtral)",
+                 (supported: deepseek_v4, gpt_oss, mixtral, qwen3_moe, qwen3_5_moe)",
                 cfg.model_type
             )));
         };

--- a/driver/weight_loader/src/stream.rs
+++ b/driver/weight_loader/src/stream.rs
@@ -7,8 +7,8 @@
 //! driver executes the template into a cache slot — the same IR as boot loads,
 //! with a different destination binding.
 //!
-//! Arch-specific naming (which tensors stream, section order, name parsing)
-//! lives in [`StreamArchDesc`], registered per model on `ArchProfile`.
+//! Arch-specific naming (which tensors stream, section order, binding grid)
+//! lives in [`crate::stream_arch`] plugins, registered per model on `ArchProfile`.
 
 use crate::error::CompileError;
 use crate::source::{CheckpointMetadata, RawTensor};
@@ -22,14 +22,22 @@ use crate::types::{BufferId, InstrId, TensorId};
 ///
 /// Each streaming-capable model registers one of these on its `ArchProfile`.
 /// The generic builder never hardcodes section names or tensor-name patterns.
+///
+/// [`Self::collect_bindings`] may slice fused `[E, …]` banks into per-expert
+/// extents (GPT-OSS) or map one checkpoint tensor per cell (DeepSeek-V4).
 #[derive(Clone, Copy, Debug)]
 pub struct StreamArchDesc {
-    /// Ordered section suffixes; length = `sections_per_expert`.
+    /// Ordered section labels; length = `sections_per_expert`.
     pub sections: &'static [&'static str],
     /// Which checkpoint tensors are streamed (and skipped from the resident ABI).
     pub is_streamed: fn(&str) -> bool,
-    /// `name` → `(layer, expert, section_idx)` indexing [`Self::sections`].
-    pub parse: fn(&str) -> Option<(u32, u32, usize)>,
+    /// Build flat bindings `[L * E * sections.len()]` in layer-major, then
+    /// expert, then section order.
+    pub collect_bindings: fn(
+        &CheckpointMetadata,
+        num_layers: u32,
+        num_experts: u32,
+    ) -> Result<Vec<StreamBinding>, CompileError>,
 }
 
 const SECTION_ALIGN: u64 = 256;
@@ -48,6 +56,75 @@ fn compact_stride(span_bytes: u64) -> StridedExtent {
             dst_stride: 1,
         }],
     }
+}
+
+/// Helper for arches where each grid cell is a distinct checkpoint tensor.
+///
+/// `is_streamed` / `parse` identify tensors; each matching tensor fills exactly
+/// one `(layer, expert, section)` cell. Used by DeepSeek-V4 and unit tests.
+pub fn collect_bindings_from_named_tensors(
+    metadata: &CheckpointMetadata,
+    num_layers: u32,
+    num_experts: u32,
+    sections_len: usize,
+    is_streamed: fn(&str) -> bool,
+    parse: fn(&str) -> Option<(u32, u32, usize)>,
+) -> Result<Vec<StreamBinding>, CompileError> {
+    let expected = (num_layers as usize) * (num_experts as usize) * sections_len;
+    let mut grid: Vec<Option<&RawTensor>> = vec![None; expected];
+    let mut found = 0usize;
+    for raw in &metadata.tensors {
+        if !is_streamed(&raw.name) {
+            continue;
+        }
+        let Some((layer, expert, section)) = parse(&raw.name) else {
+            return Err(CompileError::InvalidInput(format!(
+                "stream_routed_experts: cannot parse expert tensor name '{}'",
+                raw.name
+            )));
+        };
+        if layer >= num_layers || expert >= num_experts {
+            return Err(CompileError::InvalidInput(format!(
+                "stream_routed_experts: tensor '{}' is outside the \
+                 {num_layers}x{num_experts} expert grid",
+                raw.name
+            )));
+        }
+        if section >= sections_len {
+            return Err(CompileError::InvalidInput(format!(
+                "stream_routed_experts: tensor '{}' has section index {section} \
+                 but arch defines only {sections_len} sections",
+                raw.name
+            )));
+        }
+        let idx = ((layer as usize) * (num_experts as usize) + (expert as usize)) * sections_len
+            + section;
+        if grid[idx].is_some() {
+            return Err(CompileError::InvalidInput(format!(
+                "stream_routed_experts: duplicate expert tensor '{}'",
+                raw.name
+            )));
+        }
+        grid[idx] = Some(raw);
+        found += 1;
+    }
+    if found != expected {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: expected {expected} routed-expert tensors \
+             (layers×experts×sections), found {found}"
+        )));
+    }
+    Ok(grid
+        .into_iter()
+        .map(|slot| {
+            let raw = slot.expect("grid filled");
+            StreamBinding {
+                file_id: raw.file_id,
+                file_offset: raw.file_offset,
+                span_bytes: raw.span_bytes,
+            }
+        })
+        .collect())
 }
 
 /// Attach a deferred expert-load plan to `program`. Appends template
@@ -72,70 +149,33 @@ pub fn attach_stream_plan(
     let num_layers = num_hidden_layers;
     let num_experts_u = num_experts;
     let sections = arch.sections.len();
-
-    // Collect streamed tensors by (layer, expert, section).
-    let mut grid: Vec<Option<&RawTensor>> =
-        vec![None; (num_layers as usize) * (num_experts_u as usize) * sections];
-    let mut found = 0usize;
-    for raw in &metadata.tensors {
-        if !(arch.is_streamed)(&raw.name) {
-            continue;
-        }
-        let Some((layer, expert, section)) = (arch.parse)(&raw.name) else {
-            return Err(CompileError::InvalidInput(format!(
-                "stream_routed_experts: cannot parse expert tensor name '{}'",
-                raw.name
-            )));
-        };
-        if layer >= num_layers || expert >= num_experts_u {
-            return Err(CompileError::InvalidInput(format!(
-                "stream_routed_experts: tensor '{}' is outside the \
-                 {num_layers}x{num_experts_u} expert grid",
-                raw.name
-            )));
-        }
-        if section >= sections {
-            return Err(CompileError::InvalidInput(format!(
-                "stream_routed_experts: tensor '{}' has section index {section} \
-                 but arch defines only {sections} sections",
-                raw.name
-            )));
-        }
-        let idx = ((layer as usize) * (num_experts_u as usize) + (expert as usize)) * sections
-            + section;
-        if grid[idx].is_some() {
-            return Err(CompileError::InvalidInput(format!(
-                "stream_routed_experts: duplicate expert tensor '{}'",
-                raw.name
-            )));
-        }
-        grid[idx] = Some(raw);
-        found += 1;
-    }
     let expected = (num_layers as usize) * (num_experts_u as usize) * sections;
-    if found != expected {
+
+    let bindings = (arch.collect_bindings)(metadata, num_layers, num_experts_u)?;
+    if bindings.len() != expected {
         return Err(CompileError::InvalidInput(format!(
-            "stream_routed_experts: expected {expected} routed-expert tensors \
-             (layers×experts×sections), found {found}"
+            "stream_routed_experts: collect_bindings returned {} entries, \
+             expected {expected} (layers×experts×sections)",
+            bindings.len()
         )));
     }
 
     // Uniform section sizes from expert (0, 0).
     let mut section_bytes = vec![0u64; sections];
     for s in 0..sections {
-        let raw = grid[s].expect("grid filled");
-        section_bytes[s] = raw.span_bytes;
+        section_bytes[s] = bindings[s].span_bytes;
     }
     for layer in 0..num_layers as usize {
         for expert in 0..num_experts_u as usize {
             for s in 0..sections {
                 let idx = (layer * (num_experts_u as usize) + expert) * sections + s;
-                let raw = grid[idx].expect("grid filled");
-                if raw.span_bytes != section_bytes[s] {
+                let span = bindings[idx].span_bytes;
+                if span != section_bytes[s] {
                     return Err(CompileError::InvalidInput(format!(
-                        "stream_routed_experts: non-uniform section size for '{}' \
+                        "stream_routed_experts: non-uniform section size at \
+                         layer={layer} expert={expert} section={s} \
                          ({} vs {} bytes)",
-                        raw.name, raw.span_bytes, section_bytes[s]
+                        span, section_bytes[s]
                     )));
                 }
             }
@@ -160,16 +200,6 @@ pub fn attach_stream_plan(
     let mut files = vec![String::new(); (max_file_id as usize) + 1];
     for f in &metadata.files {
         files[f.id.0 as usize] = f.path.clone();
-    }
-
-    let mut bindings = Vec::with_capacity(expected);
-    for slot in &grid {
-        let raw = slot.expect("grid filled");
-        bindings.push(StreamBinding {
-            file_id: raw.file_id,
-            file_offset: raw.file_offset,
-            span_bytes: raw.span_bytes,
-        });
     }
 
     // Template: one ExtentWrite per section, dest offset slot-relative.
@@ -258,10 +288,25 @@ mod tests {
         Some((layer, expert, section_idx))
     }
 
+    fn fake_collect(
+        metadata: &CheckpointMetadata,
+        num_layers: u32,
+        num_experts: u32,
+    ) -> Result<Vec<StreamBinding>, CompileError> {
+        collect_bindings_from_named_tensors(
+            metadata,
+            num_layers,
+            num_experts,
+            FAKE_SECTIONS.len(),
+            fake_is_streamed,
+            fake_parse,
+        )
+    }
+
     const FAKE_ARCH: StreamArchDesc = StreamArchDesc {
         sections: FAKE_SECTIONS,
         is_streamed: fake_is_streamed,
-        parse: fake_parse,
+        collect_bindings: fake_collect,
     };
 
     #[test]

--- a/driver/weight_loader/src/stream_arch.rs
+++ b/driver/weight_loader/src/stream_arch.rs
@@ -240,6 +240,168 @@ pub(crate) const MIXTRAL_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
     collect_bindings: mixtral_collect_bindings,
 };
 
+/// Plain Qwen3-MoE per-expert BF16 weights — must match `qwen_moe_expert_sections.hpp`.
+pub const QWEN3_MOE_EXPERT_SECTIONS: &[&str] = &[
+    "gate_proj.weight",
+    "up_proj.weight",
+    "down_proj.weight",
+];
+
+/// Qwen3-MoE routed experts:
+/// `model.layers.{L}.mlp.experts.{E}.{gate,up,down}_proj.weight`.
+pub(crate) fn is_qwen3_moe_routed_expert_tensor(name: &str) -> bool {
+    let Some(rest) = name.strip_prefix("model.layers.") else {
+        return false;
+    };
+    let Some((_, rest)) = rest.split_once('.') else {
+        return false;
+    };
+    rest.starts_with("mlp.experts.")
+        && ends_with_any(
+            name,
+            &[
+                ".gate_proj.weight",
+                ".up_proj.weight",
+                ".down_proj.weight",
+            ],
+        )
+        // Exclude fused bank names used by Qwen3.5-MoE.
+        && !name.ends_with("mlp.experts.gate_up_proj")
+        && !name.ends_with("mlp.experts.down_proj")
+}
+
+/// Parse `model.layers.{L}.mlp.experts.{E}.{section}`.
+pub(crate) fn parse_qwen3_moe_expert_section(name: &str) -> Option<(u32, u32, usize)> {
+    let rest = name.strip_prefix("model.layers.")?;
+    let (layer_str, rest) = rest.split_once('.')?;
+    let rest = rest.strip_prefix("mlp.experts.")?;
+    let (expert_str, section) = rest.split_once('.')?;
+    // Reject fused bank names (no expert index).
+    if expert_str == "gate_up_proj" || expert_str == "down_proj" {
+        return None;
+    }
+    let layer: u32 = layer_str.parse().ok()?;
+    let expert: u32 = expert_str.parse().ok()?;
+    let section_idx = QWEN3_MOE_EXPERT_SECTIONS.iter().position(|s| *s == section)?;
+    Some((layer, expert, section_idx))
+}
+
+fn qwen3_moe_collect_bindings(
+    metadata: &CheckpointMetadata,
+    num_layers: u32,
+    num_experts: u32,
+) -> Result<Vec<StreamBinding>, CompileError> {
+    collect_bindings_from_named_tensors(
+        metadata,
+        num_layers,
+        num_experts,
+        QWEN3_MOE_EXPERT_SECTIONS.len(),
+        is_qwen3_moe_routed_expert_tensor,
+        parse_qwen3_moe_expert_section,
+    )
+}
+
+pub(crate) const QWEN3_MOE_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
+    sections: QWEN3_MOE_EXPERT_SECTIONS,
+    is_streamed: is_qwen3_moe_routed_expert_tensor,
+    collect_bindings: qwen3_moe_collect_bindings,
+};
+
+/// Qwen3.5/3.6-MoE fused BF16 banks — must match `qwen_moe_expert_sections.hpp`.
+pub const QWEN35_MOE_EXPERT_SECTIONS: &[&str] = &["gate_up.weight", "down.weight"];
+
+fn qwen35_moe_layers_prefix(name: &str) -> Option<&str> {
+    name.strip_prefix("model.language_model.layers.")
+        .or_else(|| name.strip_prefix("model.layers."))
+}
+
+/// Qwen3.5-MoE fused expert packs (not shared expert / router).
+pub(crate) fn is_qwen35_moe_streamed_expert_tensor(name: &str) -> bool {
+    let Some(rest) = qwen35_moe_layers_prefix(name) else {
+        return false;
+    };
+    let Some((_, rest)) = rest.split_once('.') else {
+        return false;
+    };
+    matches!(
+        rest,
+        "mlp.experts.gate_up_proj" | "mlp.experts.down_proj"
+    )
+}
+
+fn qwen35_moe_find_tensor<'a>(
+    metadata: &'a CheckpointMetadata,
+    name: &str,
+) -> Result<&'a RawTensor, CompileError> {
+    metadata
+        .tensors
+        .iter()
+        .find(|t| t.name == name)
+        .ok_or_else(|| {
+            CompileError::InvalidInput(format!(
+                "stream_routed_experts: missing Qwen3.5-MoE expert tensor '{name}'"
+            ))
+        })
+}
+
+fn qwen35_moe_collect_bindings(
+    metadata: &CheckpointMetadata,
+    num_layers: u32,
+    num_experts: u32,
+) -> Result<Vec<StreamBinding>, CompileError> {
+    let e = num_experts as u64;
+    if e == 0 {
+        return Err(CompileError::InvalidInput(
+            "stream_routed_experts: Qwen3.5-MoE num_experts must be > 0".to_string(),
+        ));
+    }
+    // Prefer language_model prefix when present (multimodal checkpoints).
+    let prefix_root = if metadata
+        .tensors
+        .iter()
+        .any(|t| t.name.starts_with("model.language_model.layers."))
+    {
+        "model.language_model.layers."
+    } else {
+        "model.layers."
+    };
+    let mut bindings = Vec::with_capacity(
+        (num_layers as usize) * (num_experts as usize) * QWEN35_MOE_EXPERT_SECTIONS.len(),
+    );
+    for layer in 0..num_layers {
+        let prefix = format!("{prefix_root}{layer}.mlp.experts.");
+        let gate_up = qwen35_moe_find_tensor(metadata, &format!("{prefix}gate_up_proj"))?;
+        let down = qwen35_moe_find_tensor(metadata, &format!("{prefix}down_proj"))?;
+        let gu_span = gate_up.span_bytes / e;
+        let dn_span = down.span_bytes / e;
+        if gu_span * e != gate_up.span_bytes || dn_span * e != down.span_bytes {
+            return Err(CompileError::InvalidInput(format!(
+                "stream_routed_experts: Qwen3.5-MoE fused expert spans at layer \
+                 {layer} are not divisible by num_experts={num_experts}"
+            )));
+        }
+        for expert in 0..e {
+            bindings.push(StreamBinding {
+                file_id: gate_up.file_id,
+                file_offset: gate_up.file_offset + expert * gu_span,
+                span_bytes: gu_span,
+            });
+            bindings.push(StreamBinding {
+                file_id: down.file_id,
+                file_offset: down.file_offset + expert * dn_span,
+                span_bytes: dn_span,
+            });
+        }
+    }
+    Ok(bindings)
+}
+
+pub(crate) const QWEN35_MOE_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
+    sections: QWEN35_MOE_EXPERT_SECTIONS,
+    is_streamed: is_qwen35_moe_streamed_expert_tensor,
+    collect_bindings: qwen35_moe_collect_bindings,
+};
+
 fn ends_with_any(value: &str, suffixes: &[&str]) -> bool {
     suffixes.iter().any(|suffix| value.ends_with(suffix))
 }
@@ -293,5 +455,44 @@ mod tests {
             "model.layers.0.block_sparse_moe.gate.weight"
         )
         .is_none());
+    }
+
+    #[test]
+    fn parse_qwen3_moe_names() {
+        assert_eq!(
+            parse_qwen3_moe_expert_section(
+                "model.layers.2.mlp.experts.5.up_proj.weight"
+            ),
+            Some((2, 5, 1))
+        );
+        assert!(is_qwen3_moe_routed_expert_tensor(
+            "model.layers.0.mlp.experts.0.gate_proj.weight"
+        ));
+        assert!(!is_qwen3_moe_routed_expert_tensor(
+            "model.layers.0.mlp.experts.gate_up_proj"
+        ));
+        assert!(parse_qwen3_moe_expert_section(
+            "model.layers.0.mlp.experts.gate_up_proj"
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn qwen35_moe_fused_matcher() {
+        assert!(is_qwen35_moe_streamed_expert_tensor(
+            "model.layers.0.mlp.experts.gate_up_proj"
+        ));
+        assert!(is_qwen35_moe_streamed_expert_tensor(
+            "model.language_model.layers.1.mlp.experts.down_proj"
+        ));
+        assert!(!is_qwen35_moe_streamed_expert_tensor(
+            "model.layers.0.mlp.shared_expert.gate_proj.weight"
+        ));
+        assert!(!is_qwen35_moe_streamed_expert_tensor(
+            "model.layers.0.mlp.gate.weight"
+        ));
+        assert!(!is_qwen35_moe_streamed_expert_tensor(
+            "model.layers.0.mlp.experts.0.gate_proj.weight"
+        ));
     }
 }

--- a/driver/weight_loader/src/stream_arch.rs
+++ b/driver/weight_loader/src/stream_arch.rs
@@ -1,0 +1,225 @@
+//! Arch-specific [`StreamArchDesc`] plugins for SSD expert streaming.
+//!
+//! Generic plan construction lives in [`crate::stream`]. This module owns
+//! checkpoint naming, section order, and binding-grid collectors, registered
+//! on each model's `ArchProfile` in [`crate::abi`].
+
+use crate::error::CompileError;
+use crate::source::{CheckpointMetadata, RawTensor};
+use crate::storage::StreamBinding;
+use crate::stream::{StreamArchDesc, collect_bindings_from_named_tensors};
+
+/// Fixed DSv4 section order — must match `dsv4_expert_sections.hpp` in the
+/// CUDA driver (`w1/w2/w3` × weight/scale).
+pub const DSV4_EXPERT_SECTIONS: &[&str] = &[
+    "w1.weight",
+    "w1.scale",
+    "w2.weight",
+    "w2.scale",
+    "w3.weight",
+    "w3.scale",
+];
+
+/// DeepSeek-V4 main-stack routed experts:
+/// `layers.{L}.ffn.experts.{E}.{w1,w2,w3}.{weight,scale}`.
+///
+/// Shared experts (`.ffn.shared_experts.`), routers (`ffn.gate.*`), and MTP
+/// modules (`mtp.*.ffn.experts.*`) are **not** streamable — only the primary
+/// layer MoE bank is paged by the expert stream cache today.
+pub(crate) fn is_dsv4_routed_expert_tensor(name: &str) -> bool {
+    // Require the main-stack prefix so MTP / other modules stay resident.
+    let Some(rest) = name.strip_prefix("layers.") else {
+        return false;
+    };
+    let Some((_, rest)) = rest.split_once('.') else {
+        return false;
+    };
+    rest.starts_with("ffn.experts.")
+        && ends_with_any(
+            name,
+            &[
+                ".w1.weight",
+                ".w1.scale",
+                ".w2.weight",
+                ".w2.scale",
+                ".w3.weight",
+                ".w3.scale",
+            ],
+        )
+}
+
+/// Parse `layers.{L}.ffn.experts.{E}.{section}` → (layer, expert, section_idx).
+pub(crate) fn parse_dsv4_expert_section(name: &str) -> Option<(u32, u32, usize)> {
+    let rest = name.strip_prefix("layers.")?;
+    let (layer_str, rest) = rest.split_once('.')?;
+    let rest = rest.strip_prefix("ffn.experts.")?;
+    let (expert_str, section) = rest.split_once('.')?;
+    let layer: u32 = layer_str.parse().ok()?;
+    let expert: u32 = expert_str.parse().ok()?;
+    let section_idx = DSV4_EXPERT_SECTIONS.iter().position(|s| *s == section)?;
+    Some((layer, expert, section_idx))
+}
+
+fn dsv4_collect_bindings(
+    metadata: &CheckpointMetadata,
+    num_layers: u32,
+    num_experts: u32,
+) -> Result<Vec<StreamBinding>, CompileError> {
+    collect_bindings_from_named_tensors(
+        metadata,
+        num_layers,
+        num_experts,
+        DSV4_EXPERT_SECTIONS.len(),
+        is_dsv4_routed_expert_tensor,
+        parse_dsv4_expert_section,
+    )
+}
+
+pub(crate) const DSV4_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
+    sections: DSV4_EXPERT_SECTIONS,
+    is_streamed: is_dsv4_routed_expert_tensor,
+    collect_bindings: dsv4_collect_bindings,
+};
+
+/// Fixed GPT-OSS section order — must match `gpt_oss_expert_sections.hpp`.
+/// Biases stay resident and are not part of the stream plan.
+pub const GPT_OSS_EXPERT_SECTIONS: &[&str] = &[
+    "gate_up.weight",
+    "gate_up.scale",
+    "down.weight",
+    "down.scale",
+];
+
+/// GPT-OSS fused MXFP4 expert packs/scales (not biases).
+/// Checkpoint names: `…mlp.experts.{gate_up,down}_proj_{blocks,scales}`.
+pub(crate) fn is_gpt_oss_streamed_expert_tensor(name: &str) -> bool {
+    let Some(rest) = name.split_once("mlp.experts.").map(|(_, r)| r) else {
+        return false;
+    };
+    matches!(
+        rest,
+        "gate_up_proj_blocks"
+            | "gate_up_proj_scales"
+            | "down_proj_blocks"
+            | "down_proj_scales"
+    )
+}
+
+fn gpt_oss_find_tensor<'a>(
+    metadata: &'a CheckpointMetadata,
+    name: &str,
+) -> Result<&'a RawTensor, CompileError> {
+    metadata
+        .tensors
+        .iter()
+        .find(|t| t.name == name)
+        .ok_or_else(|| {
+            CompileError::InvalidInput(format!(
+                "stream_routed_experts: missing GPT-OSS expert tensor '{name}'"
+            ))
+        })
+}
+
+fn gpt_oss_collect_bindings(
+    metadata: &CheckpointMetadata,
+    num_layers: u32,
+    num_experts: u32,
+) -> Result<Vec<StreamBinding>, CompileError> {
+    let e = num_experts as u64;
+    if e == 0 {
+        return Err(CompileError::InvalidInput(
+            "stream_routed_experts: GPT-OSS num_experts must be > 0".to_string(),
+        ));
+    }
+    let mut bindings = Vec::with_capacity(
+        (num_layers as usize) * (num_experts as usize) * GPT_OSS_EXPERT_SECTIONS.len(),
+    );
+    for layer in 0..num_layers {
+        let prefix = format!("model.layers.{layer}.mlp.experts.");
+        let gate_up_w = gpt_oss_find_tensor(metadata, &format!("{prefix}gate_up_proj_blocks"))?;
+        let gate_up_s = gpt_oss_find_tensor(metadata, &format!("{prefix}gate_up_proj_scales"))?;
+        let down_w = gpt_oss_find_tensor(metadata, &format!("{prefix}down_proj_blocks"))?;
+        let down_s = gpt_oss_find_tensor(metadata, &format!("{prefix}down_proj_scales"))?;
+
+        let gu_w_span = gate_up_w.span_bytes / e;
+        let gu_s_span = gate_up_s.span_bytes / e;
+        let dn_w_span = down_w.span_bytes / e;
+        let dn_s_span = down_s.span_bytes / e;
+        if gu_w_span * e != gate_up_w.span_bytes
+            || gu_s_span * e != gate_up_s.span_bytes
+            || dn_w_span * e != down_w.span_bytes
+            || dn_s_span * e != down_s.span_bytes
+        {
+            return Err(CompileError::InvalidInput(format!(
+                "stream_routed_experts: GPT-OSS fused expert spans at layer \
+                 {layer} are not divisible by num_experts={num_experts}"
+            )));
+        }
+
+        for expert in 0..num_experts as u64 {
+            bindings.push(StreamBinding {
+                file_id: gate_up_w.file_id,
+                file_offset: gate_up_w.file_offset + expert * gu_w_span,
+                span_bytes: gu_w_span,
+            });
+            bindings.push(StreamBinding {
+                file_id: gate_up_s.file_id,
+                file_offset: gate_up_s.file_offset + expert * gu_s_span,
+                span_bytes: gu_s_span,
+            });
+            bindings.push(StreamBinding {
+                file_id: down_w.file_id,
+                file_offset: down_w.file_offset + expert * dn_w_span,
+                span_bytes: dn_w_span,
+            });
+            bindings.push(StreamBinding {
+                file_id: down_s.file_id,
+                file_offset: down_s.file_offset + expert * dn_s_span,
+                span_bytes: dn_s_span,
+            });
+        }
+    }
+    Ok(bindings)
+}
+
+pub(crate) const GPT_OSS_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
+    sections: GPT_OSS_EXPERT_SECTIONS,
+    is_streamed: is_gpt_oss_streamed_expert_tensor,
+    collect_bindings: gpt_oss_collect_bindings,
+};
+
+fn ends_with_any(value: &str, suffixes: &[&str]) -> bool {
+    suffixes.iter().any(|suffix| value.ends_with(suffix))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_dsv4_names() {
+        assert_eq!(
+            parse_dsv4_expert_section("layers.3.ffn.experts.12.w2.scale"),
+            Some((3, 12, 3))
+        );
+        assert!(parse_dsv4_expert_section("layers.0.ffn.shared_experts.w1.weight").is_none());
+        assert!(parse_dsv4_expert_section("layers.0.ffn.gate.weight").is_none());
+        assert!(parse_dsv4_expert_section("mtp.0.ffn.experts.0.w1.scale").is_none());
+    }
+
+    #[test]
+    fn gpt_oss_streamed_matcher() {
+        assert!(is_gpt_oss_streamed_expert_tensor(
+            "model.layers.0.mlp.experts.gate_up_proj_blocks"
+        ));
+        assert!(is_gpt_oss_streamed_expert_tensor(
+            "model.layers.1.mlp.experts.down_proj_scales"
+        ));
+        assert!(!is_gpt_oss_streamed_expert_tensor(
+            "model.layers.0.mlp.experts.gate_up_proj_bias"
+        ));
+        assert!(!is_gpt_oss_streamed_expert_tensor(
+            "model.layers.0.mlp.experts.down_proj_bias"
+        ));
+    }
+}

--- a/driver/weight_loader/src/stream_arch.rs
+++ b/driver/weight_loader/src/stream_arch.rs
@@ -188,6 +188,58 @@ pub(crate) const GPT_OSS_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
     collect_bindings: gpt_oss_collect_bindings,
 };
 
+/// Fixed Mixtral section order — must match `mixtral_expert_sections.hpp`.
+/// HF layout: w1=gate, w2=down, w3=up (BF16, no scales).
+pub const MIXTRAL_EXPERT_SECTIONS: &[&str] = &["w1.weight", "w2.weight", "w3.weight"];
+
+/// Mixtral routed experts:
+/// `model.layers.{L}.block_sparse_moe.experts.{E}.w{1,2,3}.weight`.
+///
+/// The router (`…block_sparse_moe.gate.weight`) stays resident.
+pub(crate) fn is_mixtral_routed_expert_tensor(name: &str) -> bool {
+    let Some(rest) = name.strip_prefix("model.layers.") else {
+        return false;
+    };
+    let Some((_, rest)) = rest.split_once('.') else {
+        return false;
+    };
+    rest.starts_with("block_sparse_moe.experts.")
+        && ends_with_any(name, &[".w1.weight", ".w2.weight", ".w3.weight"])
+}
+
+/// Parse `model.layers.{L}.block_sparse_moe.experts.{E}.{section}`.
+pub(crate) fn parse_mixtral_expert_section(name: &str) -> Option<(u32, u32, usize)> {
+    let rest = name.strip_prefix("model.layers.")?;
+    let (layer_str, rest) = rest.split_once('.')?;
+    let rest = rest.strip_prefix("block_sparse_moe.experts.")?;
+    let (expert_str, section) = rest.split_once('.')?;
+    let layer: u32 = layer_str.parse().ok()?;
+    let expert: u32 = expert_str.parse().ok()?;
+    let section_idx = MIXTRAL_EXPERT_SECTIONS.iter().position(|s| *s == section)?;
+    Some((layer, expert, section_idx))
+}
+
+fn mixtral_collect_bindings(
+    metadata: &CheckpointMetadata,
+    num_layers: u32,
+    num_experts: u32,
+) -> Result<Vec<StreamBinding>, CompileError> {
+    collect_bindings_from_named_tensors(
+        metadata,
+        num_layers,
+        num_experts,
+        MIXTRAL_EXPERT_SECTIONS.len(),
+        is_mixtral_routed_expert_tensor,
+        parse_mixtral_expert_section,
+    )
+}
+
+pub(crate) const MIXTRAL_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
+    sections: MIXTRAL_EXPERT_SECTIONS,
+    is_streamed: is_mixtral_routed_expert_tensor,
+    collect_bindings: mixtral_collect_bindings,
+};
+
 fn ends_with_any(value: &str, suffixes: &[&str]) -> bool {
     suffixes.iter().any(|suffix| value.ends_with(suffix))
 }
@@ -221,5 +273,25 @@ mod tests {
         assert!(!is_gpt_oss_streamed_expert_tensor(
             "model.layers.0.mlp.experts.down_proj_bias"
         ));
+    }
+
+    #[test]
+    fn parse_mixtral_names() {
+        assert_eq!(
+            parse_mixtral_expert_section(
+                "model.layers.3.block_sparse_moe.experts.7.w2.weight"
+            ),
+            Some((3, 7, 1))
+        );
+        assert!(is_mixtral_routed_expert_tensor(
+            "model.layers.0.block_sparse_moe.experts.0.w1.weight"
+        ));
+        assert!(!is_mixtral_routed_expert_tensor(
+            "model.layers.0.block_sparse_moe.gate.weight"
+        ));
+        assert!(parse_mixtral_expert_section(
+            "model.layers.0.block_sparse_moe.gate.weight"
+        )
+        .is_none());
     }
 }

--- a/driver/weight_loader/tests/storage_compiler.rs
+++ b/driver/weight_loader/tests/storage_compiler.rs
@@ -1624,3 +1624,297 @@ fn gpt_oss_stream_rejects_native_mxfp4() {
     );
 }
 
+#[test]
+fn qwen35_moe_stream_routed_experts_fused_plan() {
+    // Minimal Qwen3.5-MoE fused banks: 1 layer × 2 experts + shared expert.
+    let mut offset = 0u64;
+    let mut tensors = Vec::new();
+    let mut push = |id: u32, name: &str, shape: Vec<i64>, dtype: DType| {
+        let bytes = shape.iter().fold(dtype.bytes(), |acc, d| acc * *d as u64);
+        tensors.push(RawTensor {
+            id: TensorId(id),
+            name: name.to_string(),
+            file_id: FileId(0),
+            file_offset: offset,
+            span_bytes: bytes,
+            shape,
+            encoding: Encoding::Raw(dtype),
+            layout: Layout::dense(1),
+        });
+        offset += bytes;
+    };
+    let mut id = 0u32;
+    let mut next = || {
+        let v = id;
+        id += 1;
+        v
+    };
+    push(next(), "model.embed_tokens.weight", vec![64], DType::BF16);
+    push(next(), "model.layers.0.input_layernorm.weight", vec![64], DType::BF16);
+    push(next(), "model.layers.0.mlp.gate.weight", vec![2, 64], DType::BF16);
+    // Fused [E, 2I, H] / [E, H, I] with E=2, I=32, H=64.
+    push(
+        next(),
+        "model.layers.0.mlp.experts.gate_up_proj",
+        vec![2, 64, 64],
+        DType::BF16,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.down_proj",
+        vec![2, 64, 32],
+        DType::BF16,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.shared_expert.gate_proj.weight",
+        vec![32, 64],
+        DType::BF16,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.shared_expert.up_proj.weight",
+        vec![32, 64],
+        DType::BF16,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.shared_expert.down_proj.weight",
+        vec![64, 32],
+        DType::BF16,
+    );
+    let meta = CheckpointMetadata {
+        files: vec![CheckpointFile {
+            id: FileId(0),
+            path: "qwen35-moe.safetensors".into(),
+            size_bytes: offset,
+            format: CheckpointFormat::Safetensors,
+        }],
+        tensors,
+    };
+    let cfg = pie_weight_loader::config::ModelConfig {
+        model_type: "qwen3_5_moe".to_string(),
+        num_hidden_layers: 1,
+        num_experts: 2,
+        num_experts_per_tok: 2,
+        ..pie_weight_loader::config::ModelConfig::default()
+    };
+    let target = StorageTarget {
+        backend: BackendKind::Cuda,
+        stream_routed_experts: true,
+        ..StorageTarget::default()
+    };
+    let abi =
+        pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target).unwrap();
+    let streamed = compile_storage_program(&meta, &cfg, &abi, target).unwrap();
+
+    assert!(
+        !streamed
+            .tensors
+            .iter()
+            .any(|t| t.name.contains("mlp.experts.gate_up_proj")
+                || t.name.contains("mlp.experts.down_proj")),
+        "streamed fused expert banks must not be resident; got: {:?}",
+        streamed.tensors.iter().map(|t| &t.name).collect::<Vec<_>>()
+    );
+    assert!(
+        streamed
+            .tensors
+            .iter()
+            .any(|t| t.name.contains("mlp.gate.weight")),
+        "router must remain resident; got: {:?}",
+        streamed.tensors.iter().map(|t| &t.name).collect::<Vec<_>>()
+    );
+    assert!(
+        streamed
+            .tensors
+            .iter()
+            .any(|t| t.name.contains("mlp.shared_expert.")),
+        "shared expert must remain resident; got: {:?}",
+        streamed.tensors.iter().map(|t| &t.name).collect::<Vec<_>>()
+    );
+
+    assert!(!streamed.stream.is_empty());
+    assert_eq!(streamed.stream.num_layers, 1);
+    assert_eq!(streamed.stream.num_experts, 2);
+    assert_eq!(streamed.stream.sections_per_expert, 2);
+    assert_eq!(streamed.stream.template.len(), 2);
+    assert_eq!(streamed.stream.bindings.len(), 1 * 2 * 2);
+    // Per-expert slices: gate_up 2*I*H*2 bytes, down H*I*2 bytes.
+    assert_eq!(streamed.stream.section_bytes, vec![8192, 4096]);
+}
+
+#[test]
+fn qwen35_moe_stream_routed_experts_rejects_tensor_parallel() {
+    let meta = CheckpointMetadata {
+        files: vec![CheckpointFile {
+            id: FileId(0),
+            path: "qwen35-moe.safetensors".into(),
+            size_bytes: 64,
+            format: CheckpointFormat::Safetensors,
+        }],
+        tensors: vec![RawTensor {
+            id: TensorId(0),
+            name: "model.layers.0.mlp.experts.gate_up_proj".into(),
+            file_id: FileId(0),
+            file_offset: 0,
+            span_bytes: 64,
+            shape: vec![32, 1],
+            encoding: Encoding::Raw(DType::BF16),
+            layout: Layout::dense(1),
+        }],
+    };
+    let cfg = pie_weight_loader::config::ModelConfig {
+        model_type: "qwen3_5_moe".to_string(),
+        num_hidden_layers: 1,
+        num_experts: 2,
+        num_experts_per_tok: 2,
+        ..pie_weight_loader::config::ModelConfig::default()
+    };
+    let target = StorageTarget {
+        backend: BackendKind::Cuda,
+        tp_rank: 0,
+        tp_size: 2,
+        stream_routed_experts: true,
+        ..StorageTarget::default()
+    };
+    let err = pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("tp_size=1"), "unexpected error: {err}");
+}
+
+#[test]
+fn qwen3_moe_stream_routed_experts_named_plan() {
+    // Plain Qwen3-MoE: 1 layer × 2 experts × gate/up/down (no fused stack).
+    let mut offset = 0u64;
+    let mut tensors = Vec::new();
+    let mut push = |id: u32, name: &str, shape: Vec<i64>, dtype: DType| {
+        let bytes = shape.iter().fold(dtype.bytes(), |acc, d| acc * *d as u64);
+        tensors.push(RawTensor {
+            id: TensorId(id),
+            name: name.to_string(),
+            file_id: FileId(0),
+            file_offset: offset,
+            span_bytes: bytes,
+            shape,
+            encoding: Encoding::Raw(dtype),
+            layout: Layout::dense(1),
+        });
+        offset += bytes;
+    };
+    let mut id = 0u32;
+    let mut next = || {
+        let v = id;
+        id += 1;
+        v
+    };
+    push(next(), "model.embed_tokens.weight", vec![64], DType::BF16);
+    push(next(), "model.layers.0.input_layernorm.weight", vec![64], DType::BF16);
+    push(next(), "model.layers.0.mlp.gate.weight", vec![2, 64], DType::BF16);
+    for e in 0..2 {
+        for w in ["gate_proj", "up_proj", "down_proj"] {
+            let shape = if w == "down_proj" {
+                vec![64, 32]
+            } else {
+                vec![32, 64]
+            };
+            push(
+                next(),
+                &format!("model.layers.0.mlp.experts.{e}.{w}.weight"),
+                shape,
+                DType::BF16,
+            );
+        }
+    }
+    let meta = CheckpointMetadata {
+        files: vec![CheckpointFile {
+            id: FileId(0),
+            path: "qwen3-moe.safetensors".into(),
+            size_bytes: offset,
+            format: CheckpointFormat::Safetensors,
+        }],
+        tensors,
+    };
+    let cfg = pie_weight_loader::config::ModelConfig {
+        model_type: "qwen3_moe".to_string(),
+        num_hidden_layers: 1,
+        num_experts: 2,
+        num_experts_per_tok: 2,
+        ..pie_weight_loader::config::ModelConfig::default()
+    };
+    let target = StorageTarget {
+        backend: BackendKind::Cuda,
+        stream_routed_experts: true,
+        ..StorageTarget::default()
+    };
+    let abi =
+        pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target).unwrap();
+    let streamed = compile_storage_program(&meta, &cfg, &abi, target).unwrap();
+
+    assert!(
+        !streamed.tensors.iter().any(|t| t.name.contains("mlp.experts.")),
+        "streamed program must not declare Qwen3-MoE expert tensors (named or stacked); got: {:?}",
+        streamed.tensors.iter().map(|t| &t.name).collect::<Vec<_>>()
+    );
+    assert!(
+        streamed
+            .tensors
+            .iter()
+            .any(|t| t.name.contains("mlp.gate.weight")),
+        "router must remain resident; got: {:?}",
+        streamed.tensors.iter().map(|t| &t.name).collect::<Vec<_>>()
+    );
+
+    assert!(!streamed.stream.is_empty());
+    assert_eq!(streamed.stream.num_layers, 1);
+    assert_eq!(streamed.stream.num_experts, 2);
+    assert_eq!(streamed.stream.sections_per_expert, 3);
+    assert_eq!(streamed.stream.template.len(), 3);
+    assert_eq!(streamed.stream.bindings.len(), 1 * 2 * 3);
+    for id in &streamed.stream.template {
+        assert!(!streamed.schedule.contains(id));
+        assert!(streamed.instrs.iter().any(|instr| instr_id(instr) == *id));
+    }
+}
+
+#[test]
+fn qwen3_moe_stream_routed_experts_rejects_tensor_parallel() {
+    let meta = CheckpointMetadata {
+        files: vec![CheckpointFile {
+            id: FileId(0),
+            path: "qwen3-moe.safetensors".into(),
+            size_bytes: 64,
+            format: CheckpointFormat::Safetensors,
+        }],
+        tensors: vec![RawTensor {
+            id: TensorId(0),
+            name: "model.layers.0.mlp.experts.0.gate_proj.weight".into(),
+            file_id: FileId(0),
+            file_offset: 0,
+            span_bytes: 64,
+            shape: vec![32, 1],
+            encoding: Encoding::Raw(DType::BF16),
+            layout: Layout::dense(1),
+        }],
+    };
+    let cfg = pie_weight_loader::config::ModelConfig {
+        model_type: "qwen3_moe".to_string(),
+        num_hidden_layers: 1,
+        num_experts: 2,
+        num_experts_per_tok: 2,
+        ..pie_weight_loader::config::ModelConfig::default()
+    };
+    let target = StorageTarget {
+        backend: BackendKind::Cuda,
+        tp_rank: 0,
+        tp_size: 2,
+        stream_routed_experts: true,
+        ..StorageTarget::default()
+    };
+    let err = pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("tp_size=1"), "unexpected error: {err}");
+}
+

--- a/driver/weight_loader/tests/storage_compiler.rs
+++ b/driver/weight_loader/tests/storage_compiler.rs
@@ -1097,7 +1097,8 @@ fn mla_q_kv_a_fusion_produces_joined_tensor() {
 
 // ── SSD expert streaming (DeepSeek-V4) ──────────────────────────────
 
-fn dsv4_streaming_metadata() -> CheckpointMetadata {
+#[test]
+fn dsv4_stream_routed_experts_excludes_expert_tensors_from_program() {
     // Minimal DSv4-shaped checkpoint: one layer with a norm, a router, a
     // shared expert, and two routed experts (w1/w2/w3 weight+scale each).
     let mut offset = 0u64;
@@ -1159,32 +1160,22 @@ fn dsv4_streaming_metadata() -> CheckpointMetadata {
             DType::U8,
         );
     }
-    let size_bytes = offset;
-    CheckpointMetadata {
+    let meta = CheckpointMetadata {
         files: vec![CheckpointFile {
             id: FileId(0),
             path: "model.safetensors".to_string(),
-            size_bytes,
+            size_bytes: offset,
             format: CheckpointFormat::Safetensors,
         }],
         tensors,
-    }
-}
-
-fn dsv4_cfg() -> pie_weight_loader::config::ModelConfig {
-    pie_weight_loader::config::ModelConfig {
+    };
+    let cfg = pie_weight_loader::config::ModelConfig {
         model_type: "deepseek_v4".to_string(),
         num_hidden_layers: 1,
         num_experts: 2,
         num_experts_per_tok: 2,
         ..pie_weight_loader::config::ModelConfig::default()
-    }
-}
-
-#[test]
-fn dsv4_stream_routed_experts_excludes_expert_tensors_from_program() {
-    let meta = dsv4_streaming_metadata();
-    let cfg = dsv4_cfg();
+    };
 
     let compile = |stream: bool| {
         let target = StorageTarget {
@@ -1271,8 +1262,32 @@ fn dsv4_stream_routed_experts_excludes_expert_tensors_from_program() {
 
 #[test]
 fn dsv4_stream_routed_experts_rejects_tensor_parallel() {
-    let meta = dsv4_streaming_metadata();
-    let cfg = dsv4_cfg();
+    // Enough of a streamed tensor for skip_streamed to fire before the TP check.
+    let meta = CheckpointMetadata {
+        files: vec![CheckpointFile {
+            id: FileId(0),
+            path: "model.safetensors".into(),
+            size_bytes: 32,
+            format: CheckpointFormat::Safetensors,
+        }],
+        tensors: vec![RawTensor {
+            id: TensorId(0),
+            name: "layers.0.ffn.experts.0.w1.weight".into(),
+            file_id: FileId(0),
+            file_offset: 0,
+            span_bytes: 32,
+            shape: vec![32],
+            encoding: Encoding::Raw(DType::U8),
+            layout: Layout::dense(1),
+        }],
+    };
+    let cfg = pie_weight_loader::config::ModelConfig {
+        model_type: "deepseek_v4".to_string(),
+        num_hidden_layers: 1,
+        num_experts: 2,
+        num_experts_per_tok: 2,
+        ..pie_weight_loader::config::ModelConfig::default()
+    };
     let target = StorageTarget {
         backend: BackendKind::Cuda,
         tp_rank: 0,
@@ -1288,7 +1303,24 @@ fn dsv4_stream_routed_experts_rejects_tensor_parallel() {
 
 #[test]
 fn stream_routed_experts_rejects_unsupported_arch() {
-    let meta = dsv4_streaming_metadata();
+    let meta = CheckpointMetadata {
+        files: vec![CheckpointFile {
+            id: FileId(0),
+            path: "model.safetensors".into(),
+            size_bytes: 8,
+            format: CheckpointFormat::Safetensors,
+        }],
+        tensors: vec![RawTensor {
+            id: TensorId(0),
+            name: "layers.0.ffn.experts.0.w1.weight".into(),
+            file_id: FileId(0),
+            file_offset: 0,
+            span_bytes: 8,
+            shape: vec![8],
+            encoding: Encoding::Raw(DType::U8),
+            layout: Layout::dense(1),
+        }],
+    };
     let cfg = pie_weight_loader::config::ModelConfig {
         model_type: "llama".to_string(),
         num_hidden_layers: 1,
@@ -1318,3 +1350,143 @@ fn instr_id(instr: &StorageInstr) -> pie_weight_loader::types::InstrId {
         | StorageInstr::Finalize { id, .. } => *id,
     }
 }
+
+#[test]
+fn gpt_oss_stream_routed_experts_fused_plan() {
+    // Minimal fused-bank fixture: 1 layer × 2 experts (not the real 32).
+    let mut offset = 0u64;
+    let mut tensors = Vec::new();
+    let mut push = |id: u32, name: &str, span: u64| {
+        tensors.push(RawTensor {
+            id: TensorId(id),
+            name: name.to_string(),
+            file_id: FileId(0),
+            file_offset: offset,
+            span_bytes: span,
+            shape: vec![span as i64],
+            encoding: Encoding::Raw(DType::U8),
+            layout: Layout::dense(1),
+        });
+        offset += span;
+    };
+    let mut id = 0u32;
+    let mut next = || {
+        let v = id;
+        id += 1;
+        v
+    };
+    push(next(), "model.embed_tokens.weight", 64);
+    push(next(), "model.layers.0.input_layernorm.weight", 32);
+    push(next(), "model.layers.0.mlp.router.weight", 64);
+    push(next(), "model.layers.0.mlp.router.bias", 4);
+    push(next(), "model.layers.0.mlp.experts.gate_up_proj_blocks", 200);
+    push(next(), "model.layers.0.mlp.experts.gate_up_proj_scales", 40);
+    push(next(), "model.layers.0.mlp.experts.gate_up_proj_bias", 16);
+    push(next(), "model.layers.0.mlp.experts.down_proj_blocks", 100);
+    push(next(), "model.layers.0.mlp.experts.down_proj_scales", 20);
+    push(next(), "model.layers.0.mlp.experts.down_proj_bias", 8);
+    let meta = CheckpointMetadata {
+        files: vec![CheckpointFile {
+            id: FileId(0),
+            path: "gpt-oss.safetensors".into(),
+            size_bytes: offset,
+            format: CheckpointFormat::Safetensors,
+        }],
+        tensors,
+    };
+    let cfg = pie_weight_loader::config::ModelConfig {
+        model_type: "gpt_oss".to_string(),
+        num_hidden_layers: 1,
+        num_experts: 2,
+        num_experts_per_tok: 2,
+        ..pie_weight_loader::config::ModelConfig::default()
+    };
+    let target = StorageTarget {
+        backend: BackendKind::Cuda,
+        stream_routed_experts: true,
+        mxfp4_moe: pie_weight_loader::types::Mxfp4MoePolicy::RoutedDecode,
+        ..StorageTarget::default()
+    };
+    let abi =
+        pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target).unwrap();
+    let streamed = compile_storage_program(&meta, &cfg, &abi, target).unwrap();
+
+    // Biases stay resident; packs/scales do not.
+    assert!(
+        streamed
+            .tensors
+            .iter()
+            .any(|t| t.name.contains("gate_up_proj.bias")),
+        "biases must remain resident; got: {:?}",
+        streamed.tensors.iter().map(|t| &t.name).collect::<Vec<_>>()
+    );
+    assert!(
+        !streamed
+            .tensors
+            .iter()
+            .any(|t| t.name.contains("gate_up_proj.weight")
+                || t.name.contains("down_proj.weight")
+                || t.name.contains("weight_scale")),
+        "streamed packs/scales must not be resident; got: {:?}",
+        streamed.tensors.iter().map(|t| &t.name).collect::<Vec<_>>()
+    );
+
+    assert!(!streamed.stream.is_empty());
+    assert_eq!(streamed.stream.num_layers, 1);
+    assert_eq!(streamed.stream.num_experts, 2);
+    assert_eq!(streamed.stream.sections_per_expert, 4);
+    assert_eq!(streamed.stream.template.len(), 4);
+    assert_eq!(streamed.stream.bindings.len(), 1 * 2 * 4);
+    // Per-expert slices: gate_up weight 100, scale 20, down weight 50, scale 10.
+    assert_eq!(streamed.stream.section_bytes, vec![100, 20, 50, 10]);
+    assert_eq!(streamed.stream.bindings[0].span_bytes, 100);
+    assert_eq!(
+        streamed.stream.bindings[4].file_offset,
+        streamed.stream.bindings[0].file_offset + 100
+    );
+}
+
+#[test]
+fn gpt_oss_stream_rejects_native_mxfp4() {
+    // Enough of a streamed tensor for skip_streamed to fire before the policy check.
+    let meta = CheckpointMetadata {
+        files: vec![CheckpointFile {
+            id: FileId(0),
+            path: "gpt-oss.safetensors".into(),
+            size_bytes: 8,
+            format: CheckpointFormat::Safetensors,
+        }],
+        tensors: vec![RawTensor {
+            id: TensorId(0),
+            name: "model.layers.0.mlp.experts.gate_up_proj_blocks".into(),
+            file_id: FileId(0),
+            file_offset: 0,
+            span_bytes: 8,
+            shape: vec![8],
+            encoding: Encoding::Raw(DType::U8),
+            layout: Layout::dense(1),
+        }],
+    };
+    let cfg = pie_weight_loader::config::ModelConfig {
+        model_type: "gpt_oss".to_string(),
+        num_hidden_layers: 1,
+        num_experts: 2,
+        num_experts_per_tok: 2,
+        ..pie_weight_loader::config::ModelConfig::default()
+    };
+    let target = StorageTarget {
+        backend: BackendKind::Cuda,
+        stream_routed_experts: true,
+        mxfp4_moe: pie_weight_loader::types::Mxfp4MoePolicy::NativeGemm,
+        native_mxfp4_moe: true,
+        ..StorageTarget::default()
+    };
+    let err = pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target)
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("routed_dequant") || err.contains("ExtentWrite"),
+        "unexpected error: {err}"
+    );
+}
+

--- a/driver/weight_loader/tests/storage_compiler.rs
+++ b/driver/weight_loader/tests/storage_compiler.rs
@@ -1352,6 +1352,140 @@ fn instr_id(instr: &StorageInstr) -> pie_weight_loader::types::InstrId {
 }
 
 #[test]
+fn mixtral_stream_routed_experts_excludes_expert_tensors_from_program() {
+    // Minimal Mixtral-shaped checkpoint: 1 layer × 2 experts × w1/w2/w3 BF16.
+    let mut offset = 0u64;
+    let mut tensors = Vec::new();
+    let mut push = |id: u32, name: &str, shape: Vec<i64>, dtype: DType| {
+        let bytes = shape.iter().fold(dtype.bytes(), |acc, d| acc * *d as u64);
+        tensors.push(RawTensor {
+            id: TensorId(id),
+            name: name.to_string(),
+            file_id: FileId(0),
+            file_offset: offset,
+            span_bytes: bytes,
+            shape,
+            encoding: Encoding::Raw(dtype),
+            layout: Layout::dense(1),
+        });
+        offset += bytes;
+    };
+    let mut id = 0u32;
+    let mut next = || {
+        let v = id;
+        id += 1;
+        v
+    };
+    push(next(), "model.embed_tokens.weight", vec![64], DType::BF16);
+    push(next(), "model.layers.0.input_layernorm.weight", vec![64], DType::BF16);
+    push(
+        next(),
+        "model.layers.0.block_sparse_moe.gate.weight",
+        vec![2, 64],
+        DType::BF16,
+    );
+    for e in 0..2 {
+        for w in ["w1", "w2", "w3"] {
+            push(
+                next(),
+                &format!("model.layers.0.block_sparse_moe.experts.{e}.{w}.weight"),
+                vec![32, 32],
+                DType::BF16,
+            );
+        }
+    }
+    let meta = CheckpointMetadata {
+        files: vec![CheckpointFile {
+            id: FileId(0),
+            path: "mixtral.safetensors".into(),
+            size_bytes: offset,
+            format: CheckpointFormat::Safetensors,
+        }],
+        tensors,
+    };
+    let cfg = pie_weight_loader::config::ModelConfig {
+        model_type: "mixtral".to_string(),
+        num_hidden_layers: 1,
+        num_experts: 2,
+        num_experts_per_tok: 2,
+        ..pie_weight_loader::config::ModelConfig::default()
+    };
+    let target = StorageTarget {
+        backend: BackendKind::Cuda,
+        stream_routed_experts: true,
+        ..StorageTarget::default()
+    };
+    let abi =
+        pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target).unwrap();
+    let streamed = compile_storage_program(&meta, &cfg, &abi, target).unwrap();
+
+    assert!(
+        !streamed.tensors.iter().any(|t| t.name.contains("block_sparse_moe.experts.")),
+        "streamed program must not declare Mixtral expert tensors; got: {:?}",
+        streamed.tensors.iter().map(|t| &t.name).collect::<Vec<_>>()
+    );
+    assert!(
+        streamed
+            .tensors
+            .iter()
+            .any(|t| t.name.contains("block_sparse_moe.gate.weight")),
+        "router must remain resident; got: {:?}",
+        streamed.tensors.iter().map(|t| &t.name).collect::<Vec<_>>()
+    );
+
+    assert!(!streamed.stream.is_empty());
+    assert_eq!(streamed.stream.num_layers, 1);
+    assert_eq!(streamed.stream.num_experts, 2);
+    assert_eq!(streamed.stream.sections_per_expert, 3);
+    assert_eq!(streamed.stream.template.len(), 3);
+    assert_eq!(streamed.stream.bindings.len(), 1 * 2 * 3);
+    for id in &streamed.stream.template {
+        assert!(!streamed.schedule.contains(id));
+        assert!(streamed.instrs.iter().any(|instr| instr_id(instr) == *id));
+    }
+}
+
+#[test]
+fn mixtral_stream_routed_experts_rejects_tensor_parallel() {
+    let meta = CheckpointMetadata {
+        files: vec![CheckpointFile {
+            id: FileId(0),
+            path: "mixtral.safetensors".into(),
+            size_bytes: 64,
+            format: CheckpointFormat::Safetensors,
+        }],
+        tensors: vec![RawTensor {
+            id: TensorId(0),
+            name: "model.layers.0.block_sparse_moe.experts.0.w1.weight".into(),
+            file_id: FileId(0),
+            file_offset: 0,
+            span_bytes: 64,
+            shape: vec![32, 1],
+            encoding: Encoding::Raw(DType::BF16),
+            layout: Layout::dense(1),
+        }],
+    };
+    let cfg = pie_weight_loader::config::ModelConfig {
+        model_type: "mixtral".to_string(),
+        num_hidden_layers: 1,
+        num_experts: 2,
+        num_experts_per_tok: 2,
+        ..pie_weight_loader::config::ModelConfig::default()
+    };
+    let target = StorageTarget {
+        backend: BackendKind::Cuda,
+        tp_rank: 0,
+        tp_size: 2,
+        stream_routed_experts: true,
+        ..StorageTarget::default()
+    };
+    let err = pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target)
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("tp_size=1"), "unexpected error: {err}");
+}
+
+#[test]
 fn gpt_oss_stream_routed_experts_fused_plan() {
     // Minimal fused-bank fixture: 1 layer × 2 experts (not the real 32).
     let mut offset = 0u64;

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -817,7 +817,7 @@ pub struct CudaNativeDriverOptions {
     /// latency-regime win (helps at low batch, costs at compute saturation), so
     /// it's off unless explicitly enabled — matching vLLM/SGLang convention.
     pub enable_system_speculation: bool,
-    /// SSD expert streaming (DeepSeek-V4 only, tensor_parallel_size = 1):
+    /// SSD expert streaming (DeepSeek-V4 / GPT-OSS, tensor_parallel_size = 1):
     /// keep routed MoE expert weights on disk and page them into a bounded
     /// LRU GPU cache on demand at forward time instead of materializing
     /// them in VRAM at startup.


### PR DESCRIPTION
This PR extends SSD routed-expert streaming beyond DeepSeek-V4 to GPT-OSS (fused MXFP4 banks), Mixtral (named BF16 w1/w2/w3), and Qwen3 / Qwen3.5-MoE (named gate/up/down vs fused gate_up/down). The weight-loader `StreamArchDesc` plugin surface is generalized in `stream_arch.rs` so each arch owns section layout, tensor matching, and binding collection, while routers, shared experts, and biases stay resident as appropriate. Each arch’s MoE forward pages experts through `ExpertStreamCache::ensure_resident`, and CUDA-graph capture is disabled when streaming so host routing and SSD page-ins are not captured.

#### Current limitations / later follow-ups
- **TP = 1 only** — no tensor-parallel expert streaming yet (`tp_size > 1` is rejected).
- **Plain extent copies only** — cache load cannot transform weights on the way in (no FP8/runtime-quant / reshape during page-in beyond what’s already in the stream plan, e.g. GPT-OSS RoutedDequant after load).
- **Linear eviction search** — victim selection walks the cache linearly; a better policy (heap / clock / frequency) is future work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added routed-expert streaming support for GPT-OSS, Mixtral, Qwen3-MoE, and Qwen3.5-MoE models.
  * Improved handling of streamed expert weights, including fused and BF16 formats.
  * Added architecture-specific validation and clearer configuration support details.

* **Bug Fixes**
  * Corrected GPT-OSS model classification and layer-count handling.
  * Prevented incompatible streaming and native MXFP4 configurations.
  * Disabled CUDA graph paths when expert streaming requires host-side routing.

* **Documentation**
  * Expanded streaming documentation to cover all supported model families and residency behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->