### PR TITLE
Fix AWQ->Marlin zero-point repack: add the 8-wide interleave

### DIFF
--- a/driver/cuda/CMakeLists.txt
+++ b/driver/cuda/CMakeLists.txt
@@ -569,6 +569,15 @@ target_compile_options(test_awq_repack_source_ordering PRIVATE
   $<$<COMPILE_LANGUAGE:CUDA>: --extended-lambda --expt-relaxed-constexpr >)
 target_link_libraries(test_awq_repack_source_ordering PRIVATE CUDA::cudart)
 
+add_executable(test_awq_marlin_zero_points
+  tests/test_awq_marlin_zero_points.cu
+  src/kernels/dtype_cast.cu)
+target_include_directories(test_awq_marlin_zero_points PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_compile_options(test_awq_marlin_zero_points PRIVATE
+  $<$<COMPILE_LANGUAGE:CUDA>: --extended-lambda --expt-relaxed-constexpr >)
+target_link_libraries(test_awq_marlin_zero_points PRIVATE CUDA::cudart)
+
 enable_testing()
 add_test(NAME brle COMMAND test_brle)
 add_test(NAME masked_distribution COMMAND test_masked_distribution)
@@ -580,6 +589,7 @@ add_test(NAME swap_pool COMMAND test_swap_pool)
 add_test(NAME mxfp4_marlin COMMAND test_mxfp4_marlin)
 add_test(NAME transcode_fused COMMAND test_transcode_fused)
 add_test(NAME awq_repack_source_ordering COMMAND test_awq_repack_source_ordering)
+add_test(NAME awq_marlin_zero_points COMMAND test_awq_marlin_zero_points)
 
 target_link_libraries(pie_driver_cuda_lib PUBLIC
   CLI11::CLI11

--- a/driver/cuda/src/kernels/dtype_cast.cu
+++ b/driver/cuda/src/kernels/dtype_cast.cu
@@ -141,7 +141,8 @@ namespace {
 //      8-element stride. Equivalent to "AWQ stored values with
 //      interleave [0,2,4,6,1,3,5,7]; argsort gives the inverse".
 //   3. marlin_zero_points: reshape [N, groups] flat → [-1, 64] and
-//      apply scale_perm (`perm[i*8+j] = i + 8*j`); reshape to
+//      apply scale_perm (`perm[i*8+j] = i + 8*j`), THEN reshape [-1, 8]
+//      and apply the 8-wide interleave [0,2,4,6,1,3,5,7]; reshape to
 //      [groups, N] and pack 8 nibbles per int32.
 //
 // The whole pipeline is pure index arithmetic — we read the source
@@ -172,11 +173,16 @@ __global__ void awq_qzero_to_marlin_w4_kernel(
     // = bit position in the AWQ-packed int32 holding slot j of the
     // unpacked array.
     constexpr int reverse_order[8] = {0, 4, 1, 5, 2, 6, 3, 7};
+    // marlin_zero_points applies an 8-wide column interleave
+    // (`zp.reshape(-1, 8)[:, [0,2,4,6,1,3,5,7]]`) AFTER the 64-wide
+    // scale_perm and before packing. Output nibble slot j therefore carries
+    // the logical column n8_out*8 + interleave[j], not the linear j.
+    constexpr int interleave[8] = {0, 2, 4, 6, 1, 3, 5, 7};
 
     std::uint32_t v = 0;
     #pragma unroll
     for (int j = 0; j < 8; ++j) {
-        const int n_out = n8_out * 8 + j;
+        const int n_out = n8_out * 8 + interleave[j];
         const int p = g_out * size_n + n_out;
         const int p_in_64 = p % 64;
         const int p_in_64_perm = (p_in_64 % 8) * 8 + (p_in_64 / 8);

--- a/driver/cuda/src/kernels/dtype_cast.hpp
+++ b/driver/cuda/src/kernels/dtype_cast.hpp
@@ -61,10 +61,12 @@ void launch_marlin_permute_scales_bf16(
 /// packed int4 in `[groups, N/8]` int32 (each int32 holds 8 nibbles
 /// along the N axis with the AWQ-specific [0,2,4,6,1,3,5,7] interleave).
 /// Marlin's W4 kernel expects them in `[groups, N/8]` int32 too, but
-/// with the SAME 64-wide column permutation that scales undergo
-/// (`marlin_permute_scales`) AFTER the AWQ undo-interleave. This kernel
-/// does the full pipeline: undo AWQ interleave → marlin scale_perm →
-/// repack int4. Verified to match vLLM's `awq_to_marlin_zero_points`.
+/// zero-points need BOTH the 64-wide column permutation that scales undergo
+/// (`marlin_permute_scales`) AND an additional 8-wide column interleave
+/// `[0,2,4,6,1,3,5,7]` (`marlin_zero_points`), applied AFTER the AWQ
+/// undo-interleave. This kernel does the full pipeline: undo AWQ interleave →
+/// 64-wide scale_perm → 8-wide interleave → repack int4. Verified to match
+/// vLLM's `awq_to_marlin_zero_points`.
 void launch_awq_qzero_to_marlin_w4(
     const void*   awq_qzeros_in,    // [groups, N/8] int32 (AWQ packing)
     void*         qzeros_marlin_out,// [groups, N/8] int32 (marlin packing)

--- a/driver/cuda/tests/test_awq_marlin_zero_points.cu
+++ b/driver/cuda/tests/test_awq_marlin_zero_points.cu
@@ -1,0 +1,185 @@
+// Direct-kernel regression for the AWQ -> Marlin weight-lowering that Pie's
+// cuda_native driver applies to asymmetric AWQ-INT4 checkpoints (quant_method
+// "awq", zero_point=true, e.g. Qwen2.5-72B-Instruct-AWQ).
+//
+// The zero-point kernel (launch_awq_qzero_to_marlin_w4) must reproduce vLLM's
+// `awq_to_marlin_zero_points`: AWQ undo-interleave, the 64-wide Marlin
+// scale permutation, the 8-wide Marlin interleave [0,2,4,6,1,3,5,7], then a
+// linear int4 repack. Omitting the 8-wide interleave silently corrupts every
+// group's zero-points -> (q - z)*s is wrong on every output channel and decode
+// collapses to a single token. This test allocates device AWQ qzeros, runs the
+// kernel, copies the result back, and compares against an INDEPENDENT host
+// reference of the same pipeline; it also asserts that the naive linear-slot
+// mapping (no 8-wide interleave) would differ, so a regression is caught.
+//
+// The AWQ qweight path (launch_awq_qweight_to_gptq_w4) is exercised against an
+// independent plain-GPTQ host reference by test_awq_repack_source_ordering, and
+// the scale path (launch_marlin_permute_scales_bf16) by test_transcode_fused; to
+// stay focused on the zero-point fix, neither is duplicated here.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "kernels/dtype_cast.hpp"
+
+namespace {
+
+int g_failures = 0;
+
+#define CHECK(cond)                                                         \
+    do {                                                                    \
+        if (!(cond)) {                                                      \
+            std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__,   \
+                         #cond);                                            \
+            ++g_failures;                                                   \
+        }                                                                   \
+    } while (0)
+
+#define CUDA_CHECK(expr)                                                     \
+    do {                                                                     \
+        cudaError_t _err = (expr);                                           \
+        if (_err != cudaSuccess) {                                           \
+            std::fprintf(stderr, "CUDA FAIL %s:%d: %s (%s)\n", __FILE__,    \
+                         __LINE__, #expr, cudaGetErrorString(_err));        \
+            std::exit(2);                                                    \
+        }                                                                    \
+    } while (0)
+
+template <typename T>
+T* device_from_host(const std::vector<T>& host) {
+    T* device = nullptr;
+    CUDA_CHECK(cudaMalloc(&device, host.size() * sizeof(T)));
+    CUDA_CHECK(cudaMemcpy(
+        device, host.data(), host.size() * sizeof(T), cudaMemcpyHostToDevice));
+    return device;
+}
+
+template <typename T>
+std::vector<T> host_from_device(const T* device, std::size_t count) {
+    std::vector<T> host(count);
+    CUDA_CHECK(cudaMemcpy(
+        host.data(), device, count * sizeof(T), cudaMemcpyDeviceToHost));
+    return host;
+}
+
+// Deterministic 4-bit fill packed 8 nibbles/int32 along N: shape [rows, cols/8].
+std::vector<std::uint32_t> make_packed(int rows, int cols, std::uint32_t seed) {
+    const int packed = cols / 8;
+    std::vector<std::uint32_t> out(static_cast<std::size_t>(rows) * packed, 0);
+    std::uint32_t s = seed;
+    auto next_nibble = [&]() -> std::uint32_t {
+        s = s * 1664525u + 1013904223u;
+        return (s >> 12) & 0xFu;
+    };
+    for (int r = 0; r < rows; ++r) {
+        for (int b = 0; b < packed; ++b) {
+            std::uint32_t v = 0;
+            for (int i = 0; i < 8; ++i) v |= next_nibble() << (4 * i);
+            out[static_cast<std::size_t>(r) * packed + b] = v;
+        }
+    }
+    return out;
+}
+
+// Independent host reference for vLLM `awq_to_marlin_zero_points`.
+// AWQ qzeros [groups, N/8] int32 -> marlin qzeros [groups, N/8] int32.
+// `marlin_interleave=false` reproduces the pre-fix linear-slot mapping.
+std::vector<std::uint32_t> ref_awq_qzero_to_marlin(
+    const std::vector<std::uint32_t>& in, int groups, int N,
+    bool marlin_interleave) {
+    const int n8 = N / 8;
+    const int total = groups * N;
+    static const int undo[8]  = {0, 4, 1, 5, 2, 6, 3, 7};  // undo AWQ interleave
+    static const int inter[8] = {0, 2, 4, 6, 1, 3, 5, 7};  // marlin_zero_points
+    // 1. unpack_cols (linear nibble order).
+    std::vector<std::uint8_t> q(total);
+    for (int r = 0; r < groups; ++r)
+        for (int col = 0; col < N; ++col)
+            q[r * N + col] =
+                (in[r * n8 + col / 8] >> (4 * (col % 8))) & 0xFu;
+    // 2. undo AWQ interleave over each 8-wide block.
+    std::vector<std::uint8_t> a(total);
+    for (int blk = 0; blk < total / 8; ++blk)
+        for (int m = 0; m < 8; ++m) a[blk * 8 + m] = q[blk * 8 + undo[m]];
+    // 3a. 64-wide scale_perm: perm[i*8+j] = i + 8*j.
+    int sp[64];
+    for (int i = 0; i < 8; ++i)
+        for (int j = 0; j < 8; ++j) sp[i * 8 + j] = i + 8 * j;
+    std::vector<std::uint8_t> b(total);
+    for (int blk = 0; blk < total / 64; ++blk)
+        for (int p = 0; p < 64; ++p) b[blk * 64 + p] = a[blk * 64 + sp[p]];
+    // 3b. 8-wide marlin interleave (or linear for the pre-fix reference).
+    std::vector<std::uint8_t> c(total);
+    for (int blk = 0; blk < total / 8; ++blk)
+        for (int m = 0; m < 8; ++m)
+            c[blk * 8 + m] = marlin_interleave ? b[blk * 8 + inter[m]]
+                                               : b[blk * 8 + m];
+    // 3c. pack_cols (linear).
+    std::vector<std::uint32_t> out(static_cast<std::size_t>(groups) * n8, 0);
+    for (int r = 0; r < groups; ++r)
+        for (int base = 0; base < n8; ++base) {
+            std::uint32_t v = 0;
+            for (int i = 0; i < 8; ++i)
+                v |= static_cast<std::uint32_t>(c[r * N + base * 8 + i] & 0xF)
+                     << (4 * i);
+            out[static_cast<std::size_t>(r) * n8 + base] = v;
+        }
+    return out;
+}
+
+// groups corresponds to K / group_size (e.g. groups=8 <-> K=1024 at gs=128).
+void run_zero_point(int groups, int N, std::uint32_t seed) {
+    const auto awq = make_packed(groups, N, seed);
+    std::uint32_t* d_in = device_from_host(awq);
+    std::uint32_t* d_out = nullptr;
+    CUDA_CHECK(cudaMalloc(&d_out, awq.size() * sizeof(std::uint32_t)));
+    CUDA_CHECK(cudaMemset(d_out, 0, awq.size() * sizeof(std::uint32_t)));
+    pie_cuda_driver::kernels::launch_awq_qzero_to_marlin_w4(
+        d_in, d_out, groups, N, /*stream=*/0);
+    CUDA_CHECK(cudaStreamSynchronize(0));
+    const auto got = host_from_device(d_out, awq.size());
+    const auto want = ref_awq_qzero_to_marlin(awq, groups, N, /*interleave=*/true);
+    const auto pre_fix = ref_awq_qzero_to_marlin(awq, groups, N, /*interleave=*/false);
+
+    bool eq = true;
+    std::size_t diff_words = 0;
+    for (std::size_t i = 0; i < want.size(); ++i) {
+        if (got[i] != want[i]) eq = false;
+        if (want[i] != pre_fix[i]) ++diff_words;
+    }
+    // Kernel output must match vLLM's awq_to_marlin_zero_points bit-for-bit.
+    CHECK(eq);
+    // The 8-wide interleave [0,2,4,6,1,3,5,7] relocates six of every eight
+    // lanes, so the correct layout must differ from the naive linear-slot
+    // mapping across most words. Requiring a large mismatch count both proves
+    // the interleave is load-bearing and confirms the deterministic inputs
+    // disambiguate the lanes (identical inputs would make this fail).
+    CHECK(diff_words >= want.size() / 2);
+    if (!eq)
+        std::fprintf(stderr, "  zero_point groups=%d N=%d mismatch\n", groups, N);
+    CUDA_CHECK(cudaFree(d_in));
+    CUDA_CHECK(cudaFree(d_out));
+}
+
+}  // namespace
+
+int main() {
+    // Deterministic shapes; N must be a multiple of 64 (Marlin). Includes the
+    // checkpoint-relevant group-size-128 geometry (groups = K / 128).
+    run_zero_point(/*groups=*/2, /*N=*/128, 1u);
+    run_zero_point(/*groups=*/4, /*N=*/256, 2u);
+    run_zero_point(/*groups=*/8, /*N=*/512, 3u);   // K=1024 @ gs=128
+    run_zero_point(/*groups=*/5, /*N=*/320, 4u);
+
+    if (g_failures) {
+        std::fprintf(stderr, "test_awq_marlin_zero_points: %d failure(s)\n",
+                     g_failures);
+        return 1;
+    }
+    std::printf("test_awq_marlin_zero_points: OK\n");
+    return 0;
+}


### PR DESCRIPTION
The cuda_native AWQ-INT4 zero-point converter (awq_qzero_to_marlin_w4_kernel in driver/cuda/src/kernels/dtype_cast.cu) applied the 64-wide Marlin scale permutation but omitted the subsequent 8-wide column interleave [0,2,4,6,1,3,5,7] that marlin_zero_points performs before packing. As a result every group's zero-points were mis-permuted, so dequantized weights (q - z) * s were wrong on every output channel and decode collapsed to a single repeated token for asymmetric AWQ checkpoints (e.g. Qwen2.5-72B-Instruct-AWQ). The qweight and scale paths were already correct.

The one-line kernel change emits output nibble slot j from logical column n8_out*8 + interleave[j] instead of the linear n8_out*8 + j, matching vLLM's awq_to_marlin_zero_points. A new direct-kernel CUDA regression test (driver/cuda/tests/test_awq_marlin_zero_points.cu, registered as the awq_marlin_zero_points CTest target) runs the actual kernel on device and compares bit-for-bit against an independent host reference of the full undo-interleave -> scale_perm -> interleave -> repack pipeline across several geometries including the group-size-128 case, and asserts the pre-fix linear mapping differs. The existing GPTQ-symmetric path never calls this kernel and is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CUDA AWQ quantized zero-point conversion for Marlin format by applying the required 8-wide interleave after the existing scale permutation.
  * Updated int4 zero-point repacking to match the expected output layout.

* **Tests**
  * Added a new CUDA regression test (`awq_marlin_zero_points`) that compares the device zero-point lowering against an independent CPU reference (and validates the interleave is actually applied).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->