### PR TITLE
Order transient AWQ repack/cast source uploads on stream 0

### DIFF
--- a/driver/cuda/CMakeLists.txt
+++ b/driver/cuda/CMakeLists.txt
@@ -560,6 +560,15 @@ target_compile_options(test_transcode_fused PRIVATE
   $<$<COMPILE_LANGUAGE:CUDA>: --extended-lambda --expt-relaxed-constexpr >)
 target_link_libraries(test_transcode_fused PRIVATE CUDA::cudart)
 
+add_executable(test_awq_repack_source_ordering
+  tests/test_awq_repack_source_ordering.cu
+  src/kernels/dtype_cast.cu)
+target_include_directories(test_awq_repack_source_ordering PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/src)
+target_compile_options(test_awq_repack_source_ordering PRIVATE
+  $<$<COMPILE_LANGUAGE:CUDA>: --extended-lambda --expt-relaxed-constexpr >)
+target_link_libraries(test_awq_repack_source_ordering PRIVATE CUDA::cudart)
+
 enable_testing()
 add_test(NAME brle COMMAND test_brle)
 add_test(NAME masked_distribution COMMAND test_masked_distribution)
@@ -570,6 +579,7 @@ add_test(NAME kv_cache_quant COMMAND test_kv_cache_quant)
 add_test(NAME swap_pool COMMAND test_swap_pool)
 add_test(NAME mxfp4_marlin COMMAND test_mxfp4_marlin)
 add_test(NAME transcode_fused COMMAND test_transcode_fused)
+add_test(NAME awq_repack_source_ordering COMMAND test_awq_repack_source_ordering)
 
 target_link_libraries(pie_driver_cuda_lib PUBLIC
   CLI11::CLI11

--- a/driver/cuda/src/loader/transcode_engine.hpp
+++ b/driver/cuda/src/loader/transcode_engine.hpp
@@ -178,11 +178,25 @@ private:
                 throw std::runtime_error(
                     "rust storage executor: Cast source byte size mismatch");
             }
+#if PIE_CUDA_TRANSCODE_ENGINE_HAS_CUDA
+            // Stream-0 H2D, ordered before the cast kernel (also stream 0) below.
+            // Like the repack source, this `scratch` is transient and consumed
+            // immediately, so it must not use the deferred queue() (which executes
+            // only at the next flush, after the cast reads it and after scratch is
+            // freed). Mirrors the encode/fp8/repack materialize paths.
+            copy_engine_.queue_on_stream(
+                instr.source.file_id,
+                instr.source.file_offset,
+                instr.source.span_bytes,
+                scratch.data(),
+                /*stream=*/0);
+#else
             copy_engine_.queue(
                 instr.source.file_id,
                 instr.source.file_offset,
                 instr.source.span_bytes,
                 scratch.data());
+#endif
             cast_tensor_to_ptr(scratch, dst, out.dtype());
             return;
         }
@@ -906,11 +920,30 @@ private:
                     scratch.data(),
                     wl_cpp::extent_shape(instr.source.stride));
             } else {
+#if PIE_CUDA_TRANSCODE_ENGINE_HAS_CUDA
+                // Stream-0 H2D so the repack kernel that reads this scratch (also
+                // stream 0, launched immediately below) sees the fully uploaded
+                // source via implicit stream ordering — exactly as the encode/fp8
+                // materialize paths do. The plain copy_engine_.queue() defers the
+                // copy to the next copy_engine_.flush(), which runs only AFTER the
+                // repack kernel has launched AND after this `scratch` DeviceTensor
+                // is freed on return: the kernel would read uninitialized device
+                // memory and the deferred reader-lane copy would later write to
+                // freed memory. queue_on_stream(0) issues the copy synchronously on
+                // stream 0 so both hazards are ordered away.
+                copy_engine_.queue_on_stream(
+                    instr.source.file_id,
+                    instr.source.file_offset + instr.source.stride.base_offset,
+                    instr.source.span_bytes,
+                    scratch.data(),
+                    /*stream=*/0);
+#else
                 copy_engine_.queue(
                     instr.source.file_id,
                     instr.source.file_offset + instr.source.stride.base_offset,
                     instr.source.span_bytes,
                     scratch.data());
+#endif
             }
             return scratch;
         }

--- a/driver/cuda/tests/test_awq_repack_source_ordering.cu
+++ b/driver/cuda/tests/test_awq_repack_source_ordering.cu
@@ -1,0 +1,176 @@
+// Ordering regression for the AWQ repack-source materialization in
+// TranscodeEngine::repack_tile_map / materialize_repack_source.
+//
+// The repack kernels (e.g. launch_awq_qweight_to_gptq_w4) run on stream 0 and
+// read a device "scratch" buffer that materialize_repack_source uploads from the
+// checkpoint. That upload MUST be ordered before the kernel. The original code
+// used the deferred, cross-stream copy_engine_.queue(), which only executes at
+// the next copy_engine_.flush() -- after the kernel has launched and after the
+// scratch DeviceTensor is freed. The kernel therefore read uninitialized device
+// memory (compute-sanitizer initcheck: "Uninitialized __global__ memory read" in
+// awq_qweight_to_gptq_w4_kernel), producing corrupted weights, and the deferred
+// reader-lane copy later wrote to freed memory (a pre-readiness SIGSEGV). The fix
+// issues the upload with copy_engine_.queue_on_stream(..., /*stream=*/0) so the
+// stream-0 kernel sees the fully uploaded source via implicit stream ordering,
+// mirroring the encode/fp8 materialize paths.
+//
+// This test reproduces that ordering invariant deterministically with the REAL
+// kernel: when the H2D upload is ordered before the kernel on stream 0 the output
+// matches an independent host reference; when the kernel is (mis)ordered ahead of
+// the upload it reads the poison the scratch was left with and the output is
+// wrong. The exact call-site fails-before/passes-after is additionally covered by
+// the compute-sanitizer initcheck re-gate on the real 72B load.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#include <cuda_runtime.h>
+
+#include "kernels/dtype_cast.hpp"
+
+namespace {
+
+int g_failures = 0;
+
+#define CHECK(cond)                                                         \
+    do {                                                                    \
+        if (!(cond)) {                                                      \
+            std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__,   \
+                         #cond);                                            \
+            ++g_failures;                                                   \
+        }                                                                   \
+    } while (0)
+
+#define CUDA_CHECK(expr)                                                     \
+    do {                                                                     \
+        cudaError_t _err = (expr);                                           \
+        if (_err != cudaSuccess) {                                           \
+            std::fprintf(stderr, "CUDA FAIL %s:%d: %s (%s)\n", __FILE__,    \
+                         __LINE__, #expr, cudaGetErrorString(_err));        \
+            std::exit(2);                                                    \
+        }                                                                    \
+    } while (0)
+
+template <typename T>
+std::vector<T> host_from_device(const T* device, std::size_t count) {
+    std::vector<T> host(count);
+    CUDA_CHECK(cudaMemcpy(
+        host.data(), device, count * sizeof(T), cudaMemcpyDeviceToHost));
+    return host;
+}
+
+// Deterministic 4-bit fill packed 8 nibbles/int32 along N: shape [rows, cols/8].
+std::vector<std::uint32_t> make_packed(int rows, int cols, std::uint32_t seed) {
+    const int packed = cols / 8;
+    std::vector<std::uint32_t> out(static_cast<std::size_t>(rows) * packed, 0);
+    std::uint32_t s = seed;
+    auto next_nibble = [&]() -> std::uint32_t {
+        s = s * 1664525u + 1013904223u;
+        return (s >> 12) & 0xFu;
+    };
+    for (int r = 0; r < rows; ++r)
+        for (int b = 0; b < packed; ++b) {
+            std::uint32_t v = 0;
+            for (int i = 0; i < 8; ++i) v |= next_nibble() << (4 * i);
+            out[static_cast<std::size_t>(r) * packed + b] = v;
+        }
+    return out;
+}
+
+// Independent host reference for AWQ qweight [K, N/8] -> plain-GPTQ [K/8, N],
+// matching awq_qweight_to_gptq_w4_kernel.
+std::vector<std::uint32_t> ref_awq_qweight_to_gptq(
+    const std::vector<std::uint32_t>& in, int K, int N) {
+    const int n8 = N / 8;
+    static const int reverse[8] = {0, 4, 1, 5, 2, 6, 3, 7};
+    std::vector<std::uint32_t> out(static_cast<std::size_t>(K / 8) * N, 0);
+    for (int k8 = 0; k8 < K / 8; ++k8)
+        for (int n = 0; n < N; ++n) {
+            std::uint32_t v = 0;
+            for (int i = 0; i < 8; ++i) {
+                const int k = k8 * 8 + i;
+                const std::uint32_t w =
+                    (in[static_cast<std::size_t>(k) * n8 + n / 8] >>
+                     (4 * reverse[n % 8])) & 0xFu;
+                v |= w << (4 * i);
+            }
+            out[static_cast<std::size_t>(k8) * N + n] = v;
+        }
+    return out;
+}
+
+// The 0xFF poison the scratch is left with stands in for uninitialized device
+// memory; repacking it gives a deterministic "wrong" output distinct from the
+// real source's repack.
+constexpr std::uint32_t kPoison = 0xFFFFFFFFu;
+
+void run_ordering(int K, int N, std::uint32_t seed) {
+    const auto awq = make_packed(K, N, seed);            // AWQ qweight [K, N/8]
+    const std::size_t span_words = awq.size();
+    const std::size_t span_bytes = span_words * sizeof(std::uint32_t);
+    const std::size_t out_count = static_cast<std::size_t>(K / 8) * N;
+
+    const auto want = ref_awq_qweight_to_gptq(awq, K, N);
+    const std::vector<std::uint32_t> poison(span_words, kPoison);
+    const auto want_poison = ref_awq_qweight_to_gptq(poison, K, N);
+
+    std::uint32_t* scratch = nullptr;
+    std::uint32_t* out = nullptr;
+    CUDA_CHECK(cudaMalloc(&scratch, span_bytes));
+    CUDA_CHECK(cudaMalloc(&out, out_count * sizeof(std::uint32_t)));
+
+    // ORDERED (the fix): poison, upload the source on stream 0, THEN launch the
+    // kernel on stream 0. Stream ordering guarantees the kernel reads the source.
+    CUDA_CHECK(cudaMemset(scratch, 0xFF, span_bytes));
+    CUDA_CHECK(cudaMemcpyAsync(scratch, awq.data(), span_bytes,
+                               cudaMemcpyHostToDevice, /*stream=*/0));
+    pie_cuda_driver::kernels::launch_awq_qweight_to_gptq_w4(
+        scratch, out, K, N, /*stream=*/0);
+    CUDA_CHECK(cudaStreamSynchronize(0));
+    const auto got_ordered = host_from_device(out, out_count);
+
+    // MISORDERED (the pre-fix hazard): the kernel is enqueued on stream 0 BEFORE
+    // the upload, so it reads the poison the scratch still holds.
+    CUDA_CHECK(cudaMemset(scratch, 0xFF, span_bytes));
+    pie_cuda_driver::kernels::launch_awq_qweight_to_gptq_w4(
+        scratch, out, K, N, /*stream=*/0);
+    CUDA_CHECK(cudaMemcpyAsync(scratch, awq.data(), span_bytes,
+                               cudaMemcpyHostToDevice, /*stream=*/0));
+    CUDA_CHECK(cudaStreamSynchronize(0));
+    const auto got_misordered = host_from_device(out, out_count);
+
+    // The fix: the ordered upload yields the correct repack bit-for-bit.
+    bool ordered_ok = (got_ordered == want);
+    CHECK(ordered_ok);
+    // The hazard is real and this test setup actually distinguishes the two
+    // orderings: the misordered run repacks the poison, not the source, so it is
+    // wrong and differs from the ordered run. (Guards against a test that would
+    // pass even if ordering were ignored.)
+    CHECK(got_misordered == want_poison);
+    CHECK(got_misordered != want);
+    CHECK(got_ordered != got_misordered);
+    if (!ordered_ok)
+        std::fprintf(stderr, "  ordering K=%d N=%d ordered-upload mismatch\n", K, N);
+
+    CUDA_CHECK(cudaFree(scratch));
+    CUDA_CHECK(cudaFree(out));
+}
+
+}  // namespace
+
+int main() {
+    // N multiple of 64 (Marlin), K multiple of 8 (kernel packs 8 along K).
+    run_ordering(/*K=*/64, /*N=*/128, 5u);
+    run_ordering(/*K=*/256, /*N=*/256, 6u);
+    run_ordering(/*K=*/1024, /*N=*/512, 7u);  // gs-128-relevant geometry
+
+    if (g_failures) {
+        std::fprintf(stderr, "test_awq_repack_source_ordering: %d failure(s)\n",
+                     g_failures);
+        return 1;
+    }
+    std::printf("test_awq_repack_source_ordering: OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Problem

Loading an AWQ checkpoint through the `cuda_native` driver can produce corrupt
weights (incoherent decode) or a pre-readiness SIGSEGV. The AWQ repack/cast
transient-source uploads in `TranscodeEngine` use the deferred, cross-stream
`copy_engine_.queue()`, which only executes at the next `flush()` — after the
repack/cast kernels have already launched on stream 0, and after the scratch
`DeviceTensor` has been freed. The kernels therefore read uninitialized device
memory (garbage-built GPTQ/Marlin weights), and the deferred reader-lane copy
later writes into freed device memory (a SIGSEGV inside libcuda). The timing/
layout sensitivity makes it intermittent.

## Fix

Order both `materialize_repack_source` and `cast_tile_map` uploads on stream 0 via
`copy_engine_.queue_on_stream(..., /*stream=*/0)`, mirroring the existing
encode/fp8 sibling paths. Stream-0 ordering guarantees each kernel sees its fully
uploaded source, and — because `cudaFree` synchronizes the device — keeps the
scratch alive until the kernel completes.

## Test

`test_awq_repack_source_ordering` (CTest `awq_repack_source_ordering`) drives the
real `launch_awq_qweight_to_gptq_w4` kernel: an ordered upload matches an
independent host reference bit-for-bit, while a misordered upload provably reads
the poison the scratch was left with — guarding against a test that would pass
even if ordering were ignored.

## Verification

On an A100 with a Qwen2.5-72B-Instruct-AWQ load: compute-sanitizer `initcheck`
reports zero uninitialized `__global__` reads across the full weight load (versus
reads attributed to `awq_qweight_to_gptq_w4_kernel` before the fix), and the model
serves crash-free across repeated loads.

## Note

This fixes the SIGSEGV and the uninitialized-read weight corruption. Full
72B-AWQ decode coherence additionally requires the zero-point interleave fix in
#491 (an orthogonal change to the qzero→Marlin repack); the two are independent
and both required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA stream-ordered memory transfers so transient scratch-buffer uploads occur before repack/cast kernels, preventing kernels from reading stale data.
* **Tests**
  * Added a CUDA unit test that deterministically verifies AWQ repack source ordering: the correctly ordered run matches the host reference, while a deliberate mis-order reproduces the expected “poison” outcome.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->