### PR TITLE
feat(cuda): stream GPT-OSS experts via offline native/eager packs

### DIFF
--- a/driver/cuda/CMakeLists.txt
+++ b/driver/cuda/CMakeLists.txt
@@ -172,6 +172,9 @@ add_library(pie_driver_cuda_lib STATIC
   src/spec_expansion.cpp
   src/tensor.cpp
   src/expert_stream_cache.cpp
+  src/model/expert_pack_build.cpp
+  src/model/gpt_oss_native_marlin_pack.cpp
+  src/model/gpt_oss_eager_bf16_pack.cpp
   src/model/weight_store.cpp
   src/mla_cache.cpp
   src/model/loaded_model.cpp

--- a/driver/cuda/src/expert_stream_cache.cpp
+++ b/driver/cuda/src/expert_stream_cache.cpp
@@ -128,6 +128,7 @@ StreamedExpertTable streamed_expert_table_from_program(
     table.num_layers = static_cast<int>(stream.num_layers);
     table.num_experts = static_cast<int>(stream.num_experts);
     table.sections_per_expert = sections;
+    table.pack_kind = static_cast<std::uint32_t>(stream.pack_kind);
     table.slot_bytes = stream.slot_bytes;
     table.section_bytes.assign(
         stream.section_bytes.ptr,

--- a/driver/cuda/src/expert_stream_cache.hpp
+++ b/driver/cuda/src/expert_stream_cache.hpp
@@ -49,6 +49,8 @@ struct StreamedExpertTable {
     int num_layers = 0;
     int num_experts = 0;
     int sections_per_expert = 0;
+    // Matches pie_weight_loader::PieLoaderExpertPackKind / ExpertPackKind.
+    std::uint32_t pack_kind = 0;
     std::vector<std::uint64_t> section_bytes;
     std::vector<std::uint64_t> section_offsets;
     std::uint64_t slot_bytes = 0;  // 0 = cache computes from section_bytes

--- a/driver/cuda/src/loader/rust_loader_bridge.hpp
+++ b/driver/cuda/src/loader/rust_loader_bridge.hpp
@@ -138,7 +138,7 @@ inline std::string rust_loader_compile_cache_key(
     // content-hashes the loader source), so this no longer needs bumping per
     // code change.
     constexpr const char* cache_version =
-        "pie-cuda-rust-storage-program-cache-v10";
+        "pie-cuda-rust-storage-program-cache-v11";
     h.update_bytes(cache_version, std::char_traits<char>::length(cache_version));
     // Auto-invalidate when the Rust compiler logic changes (build.rs content-
     // hashes the loader source into this weak FFI symbol). Weak-guarded so the

--- a/driver/cuda/src/loader/rust_loader_bridge.hpp
+++ b/driver/cuda/src/loader/rust_loader_bridge.hpp
@@ -630,7 +630,8 @@ inline RustLoaderCompileResult compile_rust_loader_plan_from_metadata(
         max_tile_bytes,
         preferred_alignment,
         backend_target.mxfp4_moe,
-        backend_target.mxfp4_native_gemm,
+        /*native_mxfp4_moe=*/backend_target.mxfp4_native_gemm ||
+            backend_target.gptq_marlin_int4,
         backend_target.stream_routed_experts);
     input.set_runtime_abi_name("pie-cuda", /*version=*/1);
 

--- a/driver/cuda/src/loader/rust_loader_input.hpp
+++ b/driver/cuda/src/loader/rust_loader_input.hpp
@@ -405,6 +405,7 @@ private:
         case DType::INT64:
         case DType::INT4_PACKED:
         case DType::MXFP4_PACKED:
+        case DType::MXFP4_MARLIN:
             return pie_weight_loader::PieLoaderDType::U8;
         }
         return pie_weight_loader::PieLoaderDType::U8;

--- a/driver/cuda/src/model/expert_pack_build.cpp
+++ b/driver/cuda/src/model/expert_pack_build.cpp
@@ -1,0 +1,47 @@
+#include "model/expert_pack_build.hpp"
+
+namespace pie_cuda_driver {
+
+void expert_pack_d2h_append(
+    ExpertPackWriter& writer,
+    const void* device_ptr,
+    std::uint64_t nbytes,
+    std::vector<std::uint8_t>& host)
+{
+    // Reuse the caller's bounce buffer so we don't allocate per section.
+    host.resize(static_cast<std::size_t>(nbytes));
+    CUDA_CHECK(cudaMemcpy(
+        host.data(), device_ptr, static_cast<std::size_t>(nbytes),
+        cudaMemcpyDeviceToHost));
+    writer.append_bytes(host.data(), nbytes);
+}
+
+void expert_pack_emit_slot_sections(
+    ExpertPackWriter& writer,
+    const StreamedExpertTable& table,
+    const DeviceBuf* const* sections,
+    int num_sections,
+    std::vector<std::uint8_t>& host_bounce)
+{
+    // Lay out sections at the same offsets the stream template expects, then
+    // pad to a full slot so every (layer, expert) occupies `slot_bytes`.
+    const auto& sb = table.section_bytes;
+    const std::uint64_t slot = table.slot_bytes;
+    std::uint64_t cursor = 0;
+    for (int s = 0; s < num_sections; ++s) {
+        const std::uint64_t off =
+            table.section_offsets[static_cast<std::size_t>(s)];
+        if (off > cursor) {
+            writer.append_zeros(off - cursor);
+            cursor = off;
+        }
+        const std::uint64_t nbytes = sb[static_cast<std::size_t>(s)];
+        expert_pack_d2h_append(writer, sections[s]->ptr, nbytes, host_bounce);
+        cursor += nbytes;
+    }
+    if (slot > cursor) {
+        writer.append_zeros(slot - cursor);
+    }
+}
+
+}  // namespace pie_cuda_driver

--- a/driver/cuda/src/model/expert_pack_build.cpp
+++ b/driver/cuda/src/model/expert_pack_build.cpp
@@ -25,12 +25,22 @@ void expert_pack_emit_slot_sections(
 {
     // Lay out sections at the same offsets the stream template expects, then
     // pad to a full slot so every (layer, expert) occupies `slot_bytes`.
+    if (table.slot_bytes == 0) {
+        throw std::runtime_error(
+            "expert pack: refuse to emit with slot_bytes == 0");
+    }
     const auto& sb = table.section_bytes;
     const std::uint64_t slot = table.slot_bytes;
     std::uint64_t cursor = 0;
     for (int s = 0; s < num_sections; ++s) {
         const std::uint64_t off =
             table.section_offsets[static_cast<std::size_t>(s)];
+        if (off < cursor) {
+            throw std::runtime_error(
+                "expert pack: section_offsets[" + std::to_string(s) +
+                "]=" + std::to_string(off) +
+                " is before write cursor " + std::to_string(cursor));
+        }
         if (off > cursor) {
             writer.append_zeros(off - cursor);
             cursor = off;

--- a/driver/cuda/src/model/expert_pack_build.hpp
+++ b/driver/cuda/src/model/expert_pack_build.hpp
@@ -1,0 +1,143 @@
+#pragma once
+
+// Generic offline expert-pack builder: hit/miss, writer lifecycle, and L×E loop.
+// Per-kind GPU transforms live in specialization TUs that supply a Traits type.
+// Peak VRAM stays O(one expert): staging buffers are reused across the loop.
+
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "cuda_check.hpp"
+#include "model/expert_pack_cache.hpp"
+
+namespace pie_cuda_driver {
+
+// Owning CUDA device allocation used as staging for one expert at a time.
+struct DeviceBuf {
+    void* ptr = nullptr;
+    std::uint64_t bytes = 0;
+    DeviceBuf() = default;
+    explicit DeviceBuf(std::uint64_t n) : bytes(n)
+    {
+        if (n == 0) return;
+        CUDA_CHECK(cudaMalloc(&ptr, static_cast<std::size_t>(n)));
+    }
+    ~DeviceBuf()
+    {
+        if (ptr) cudaFree(ptr);
+    }
+    DeviceBuf(const DeviceBuf&) = delete;
+    DeviceBuf& operator=(const DeviceBuf&) = delete;
+    DeviceBuf(DeviceBuf&& o) noexcept : ptr(o.ptr), bytes(o.bytes)
+    {
+        o.ptr = nullptr;
+        o.bytes = 0;
+    }
+    DeviceBuf& operator=(DeviceBuf&& o) noexcept
+    {
+        if (this == &o) return *this;
+        if (ptr) cudaFree(ptr);
+        ptr = o.ptr;
+        bytes = o.bytes;
+        o.ptr = nullptr;
+        o.bytes = 0;
+        return *this;
+    }
+};
+
+// Copy `nbytes` from device into `host`, then append that payload to the pack.
+void expert_pack_d2h_append(
+    ExpertPackWriter& writer,
+    const void* device_ptr,
+    std::uint64_t nbytes,
+    std::vector<std::uint8_t>& host);
+
+// Write one expert slot: each section at `table.section_offsets[i]`, then pad
+// the remainder of `table.slot_bytes` with zeros so slots stay fixed-size.
+void expert_pack_emit_slot_sections(
+    ExpertPackWriter& writer,
+    const StreamedExpertTable& table,
+    const DeviceBuf* const* sections,
+    int num_sections,
+    std::vector<std::uint8_t>& host_bounce);
+
+// Build or open `{cache_key}.experts` and remaps `table` extents onto it.
+//
+// Traits contract:
+//   kSections              — expected table.sections_per_expert
+//   miss_label()           — verbose string for a cold build
+//   require_build_support()— throw if this pack kind cannot be built
+//   Context                — geometry + reusable staging buffers
+//   prepare(...)           — probe shapes / allocate Context
+//   load_expert(...)       — H2D one expert from the checkpoint
+//   transform(...)         — GPU convert into pack section buffers
+//   emit(...)              — D2H those sections into the writer slot
+template <typename Traits>
+bool ensure_expert_pack(
+    StreamedExpertTable& table,
+    const std::string& cache_key,
+    SafetensorsCheckpointSource& checkpoint,
+    bool verbose)
+{
+    if (table.sections_per_expert != Traits::kSections) {
+        throw std::runtime_error(
+            std::string("expert pack: expected ") +
+            std::to_string(Traits::kSections) + " sections, got " +
+            std::to_string(table.sections_per_expert));
+    }
+    // Warm path: pack already on disk for this cache key + layout.
+    if (ExpertPackWriter::exists_and_matches(cache_key, table)) {
+        if (verbose) {
+            std::cerr << "[pie-driver-cuda] expert pack hit "
+                      << expert_pack_path(cache_key) << "\n";
+        }
+        remap_streamed_table_to_expert_pack(
+            table, expert_pack_path(cache_key), cache_key);
+        return true;
+    }
+
+    Traits::require_build_support();
+
+    if (verbose) {
+        std::cerr << "[pie-driver-cuda] expert pack miss — "
+                  << Traits::miss_label()
+                  << " (O(one expert) staging) → "
+                  << expert_pack_path(cache_key) << "\n";
+    }
+
+    // Cold path: stream every expert through staging into a temp pack file.
+    ExpertPackWriter writer(cache_key, table);
+    try {
+        auto ctx = Traits::prepare(table, checkpoint);
+        std::vector<std::uint8_t> host_bounce;
+        const int L = table.num_layers;
+        const int E = table.num_experts;
+        for (int layer = 0; layer < L; ++layer) {
+            for (int expert = 0; expert < E; ++expert) {
+                Traits::load_expert(ctx, checkpoint, layer, expert);
+                Traits::transform(ctx);
+                Traits::emit(ctx, writer, table, host_bounce);
+            }
+        }
+        writer.finalize();
+        if (verbose) {
+            std::cerr << "[pie-driver-cuda] expert pack written "
+                      << expert_pack_path(cache_key) << " ("
+                      << (expert_pack_body_bytes(table) / (1024 * 1024))
+                      << " MiB body)\n";
+        }
+    } catch (...) {
+        writer.abandon();
+        throw;
+    }
+
+    // Point the stream cache at the finished pack instead of HF shards.
+    remap_streamed_table_to_expert_pack(
+        table, expert_pack_path(cache_key), cache_key);
+    return true;
+}
+
+}  // namespace pie_cuda_driver

--- a/driver/cuda/src/model/expert_pack_build.hpp
+++ b/driver/cuda/src/model/expert_pack_build.hpp
@@ -88,6 +88,10 @@ bool ensure_expert_pack(
             std::to_string(Traits::kSections) + " sections, got " +
             std::to_string(table.sections_per_expert));
     }
+    if (table.slot_bytes == 0) {
+        throw std::runtime_error(
+            "expert pack: stream table slot_bytes must be > 0");
+    }
     // Warm path: pack already on disk for this cache key + layout.
     if (ExpertPackWriter::exists_and_matches(cache_key, table)) {
         if (verbose) {

--- a/driver/cuda/src/model/expert_pack_cache.hpp
+++ b/driver/cuda/src/model/expert_pack_cache.hpp
@@ -5,6 +5,7 @@
 // Keyed by the compile cache key. Path: `{compile_cache_dir}/{key}.experts`.
 // Pack build appends one expert at a time so peak VRAM stays O(one expert).
 
+#include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
@@ -12,6 +13,8 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+
+#include <unistd.h>
 
 #include "expert_stream_cache.hpp"
 #include "loader/safetensors.hpp"
@@ -45,9 +48,16 @@ inline std::filesystem::path expert_pack_path(const std::string& cache_key)
     return expert_pack_dir() / (cache_key + ".experts");
 }
 
+// Unique per builder so concurrent cold builds of the same cache_key do not
+// truncate each other's in-progress temps. Final publish still renames to
+// expert_pack_path(cache_key).
 inline std::filesystem::path expert_pack_tmp_path(const std::string& cache_key)
 {
-    return expert_pack_dir() / (cache_key + ".experts.tmp");
+    static std::atomic<std::uint64_t> seq{0};
+    const auto n = seq.fetch_add(1, std::memory_order_relaxed);
+    return expert_pack_dir() /
+           (cache_key + "." + std::to_string(static_cast<long long>(::getpid())) +
+            "." + std::to_string(n) + ".experts.tmp");
 }
 
 inline std::uint64_t expert_pack_header_bytes(
@@ -77,12 +87,53 @@ inline void remap_streamed_table_to_expert_pack(
 
 inline std::uint64_t expert_pack_body_bytes(const StreamedExpertTable& table)
 {
-    const std::uint64_t slot =
-        table.slot_bytes > 0
-            ? table.slot_bytes
-            : table.payload_bytes_per_expert();
-    return slot * static_cast<std::uint64_t>(table.num_layers) *
+    if (table.slot_bytes == 0) {
+        throw std::runtime_error(
+            "expert pack: slot_bytes must be > 0 (aligned slot stride from "
+            "the stream plan); refusing to infer size from raw section "
+            "payloads");
+    }
+    return table.slot_bytes * static_cast<std::uint64_t>(table.num_layers) *
            static_cast<std::uint64_t>(table.num_experts);
+}
+
+// Canonical body checksum (weight_codec::kChunkBytes folds) so warm-path
+// verify matches finalize regardless of how append_bytes was chunked.
+inline bool expert_pack_hash_body_file(
+    const std::filesystem::path& path,
+    std::uint64_t header_bytes,
+    std::uint64_t body_bytes,
+    std::uint64_t* out_hash)
+{
+    if (out_hash == nullptr) return false;
+    std::ifstream in(path, std::ios::binary);
+    if (!in) return false;
+    in.seekg(static_cast<std::streamoff>(header_bytes));
+    if (!in) return false;
+    std::uint64_t sum = weight_codec::kBlobHashSeed;
+    if (body_bytes == 0) {
+        *out_hash = sum;
+        return true;
+    }
+    std::vector<char> buf(static_cast<std::size_t>(
+        std::min(weight_codec::kChunkBytes, body_bytes)));
+    std::uint64_t left = body_bytes;
+    while (left > 0) {
+        const std::uint64_t n =
+            std::min<std::uint64_t>(left, weight_codec::kChunkBytes);
+        if (buf.size() < static_cast<std::size_t>(n)) {
+            buf.resize(static_cast<std::size_t>(n));
+        }
+        in.read(buf.data(), static_cast<std::streamsize>(n));
+        if (!in || static_cast<std::uint64_t>(in.gcount()) != n) {
+            return false;
+        }
+        sum = weight_codec::blob_hash_update(
+            sum, buf.data(), static_cast<std::size_t>(n));
+        left -= n;
+    }
+    *out_hash = sum;
+    return true;
 }
 
 class ExpertPackWriter {
@@ -117,7 +168,6 @@ public:
         std::vector<char> pad(header_bytes_, 0);
         os_.write(pad.data(), static_cast<std::streamsize>(pad.size()));
         body_cursor_ = 0;
-        hash_ = weight_codec::kBlobHashSeed;
     }
 
     void append_bytes(const void* data, std::uint64_t nbytes)
@@ -128,8 +178,6 @@ public:
         if (!os_) {
             throw std::runtime_error("expert pack: write failed");
         }
-        hash_ = weight_codec::blob_hash_update(
-            hash_, data, static_cast<std::size_t>(nbytes));
         body_cursor_ += nbytes;
     }
 
@@ -154,21 +202,40 @@ public:
                 std::to_string(body_cursor_) + ", expected " +
                 std::to_string(expected) + ")");
         }
-        os_.seekp(0);
-        os_.write(kExpertPackMagic, static_cast<std::streamsize>(kExpertPackMagicBytes));
-        write_u32(kExpertPackVersion);
-        write_u32(static_cast<std::uint32_t>(cache_key_.size()));
-        os_.write(cache_key_.data(),
-                  static_cast<std::streamsize>(cache_key_.size()));
-        write_u32(static_cast<std::uint32_t>(table_.num_layers));
-        write_u32(static_cast<std::uint32_t>(table_.num_experts));
-        write_u32(static_cast<std::uint32_t>(table_.sections_per_expert));
-        for (std::uint64_t b : table_.section_bytes) {
-            write_u64(b);
-        }
-        write_u64(hash_);
         os_.flush();
         os_.close();
+        std::uint64_t hash = 0;
+        if (!expert_pack_hash_body_file(
+                tmp_, header_bytes_, expected, &hash)) {
+            throw std::runtime_error(
+                "expert pack: failed to hash body in " + tmp_.string());
+        }
+        std::fstream out(
+            tmp_, std::ios::binary | std::ios::in | std::ios::out);
+        if (!out) {
+            throw std::runtime_error(
+                "expert pack: failed to reopen " + tmp_.string() +
+                " for header write");
+        }
+        out.seekp(0);
+        out.write(kExpertPackMagic,
+                  static_cast<std::streamsize>(kExpertPackMagicBytes));
+        write_u32(out, kExpertPackVersion);
+        write_u32(out, static_cast<std::uint32_t>(cache_key_.size()));
+        out.write(cache_key_.data(),
+                  static_cast<std::streamsize>(cache_key_.size()));
+        write_u32(out, static_cast<std::uint32_t>(table_.num_layers));
+        write_u32(out, static_cast<std::uint32_t>(table_.num_experts));
+        write_u32(out, static_cast<std::uint32_t>(table_.sections_per_expert));
+        for (std::uint64_t b : table_.section_bytes) {
+            write_u64(out, b);
+        }
+        write_u64(out, hash);
+        out.flush();
+        if (!out) {
+            throw std::runtime_error("expert pack: header write failed");
+        }
+        out.close();
         std::filesystem::rename(tmp_, path_);
     }
 
@@ -221,19 +288,36 @@ public:
                     static_cast<std::streamsize>(kExpertPackSectionBytesEntry));
             if (!in || b != expect) return false;
         }
-        return static_cast<bool>(in);
+        std::uint64_t stored_hash = 0;
+        in.read(reinterpret_cast<char*>(&stored_hash),
+                static_cast<std::streamsize>(kExpertPackHashBytes));
+        if (!in) return false;
+        in.close();
+
+        const std::uint64_t hdr = expert_pack_header_bytes(
+            cache_key, table.section_bytes.size());
+        const std::uint64_t body = expert_pack_body_bytes(table);
+        std::error_code ec;
+        const auto actual = std::filesystem::file_size(path, ec);
+        if (ec || actual != hdr + body) return false;
+
+        std::uint64_t got_hash = 0;
+        if (!expert_pack_hash_body_file(path, hdr, body, &got_hash)) {
+            return false;
+        }
+        return got_hash == stored_hash;
     }
 
 private:
-    void write_u32(std::uint32_t v)
+    static void write_u32(std::ostream& os, std::uint32_t v)
     {
-        os_.write(reinterpret_cast<const char*>(&v),
-                  static_cast<std::streamsize>(sizeof(std::uint32_t)));
+        os.write(reinterpret_cast<const char*>(&v),
+                 static_cast<std::streamsize>(sizeof(std::uint32_t)));
     }
-    void write_u64(std::uint64_t v)
+    static void write_u64(std::ostream& os, std::uint64_t v)
     {
-        os_.write(reinterpret_cast<const char*>(&v),
-                  static_cast<std::streamsize>(sizeof(std::uint64_t)));
+        os.write(reinterpret_cast<const char*>(&v),
+                 static_cast<std::streamsize>(sizeof(std::uint64_t)));
     }
 
     std::string cache_key_;
@@ -243,7 +327,6 @@ private:
     std::ofstream os_;
     std::uint64_t header_bytes_ = 0;
     std::uint64_t body_cursor_ = 0;
-    std::uint64_t hash_ = 0;
 };
 
 bool ensure_gpt_oss_native_expert_pack(

--- a/driver/cuda/src/model/expert_pack_cache.hpp
+++ b/driver/cuda/src/model/expert_pack_cache.hpp
@@ -1,0 +1,287 @@
+#pragma once
+
+// Host-side transformed expert pack for SSD streaming (GPT-OSS native Marlin).
+//
+// Keyed by the compile cache key. Path: `{compile_cache_dir}/{key}.experts`.
+// Pack build appends one expert at a time so peak VRAM stays O(one expert).
+
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "expert_stream_cache.hpp"
+#include "loader/safetensors.hpp"
+#include "loader/rust_loader_bridge.hpp"
+#include "loader/weight_store_codec.hpp"
+
+namespace pie_cuda_driver {
+
+inline constexpr char kExpertPackMagic[8] = {'P', 'I', 'E', 'E', 'X', 'P', 'K', '1'};
+inline constexpr std::uint32_t kExpertPackVersion = 1;
+
+// On-disk header layout (before the per-expert body):
+//   magic | version_u32 | key_len_u32 | key_bytes | L_u32 | E_u32 | S_u32
+//   | section_bytes[S]_u64 | body_hash_u64
+inline constexpr std::size_t kExpertPackMagicBytes = sizeof(kExpertPackMagic);
+inline constexpr std::size_t kExpertPackVersionBytes = sizeof(std::uint32_t);
+inline constexpr std::size_t kExpertPackKeyLenBytes = sizeof(std::uint32_t);
+inline constexpr std::size_t kExpertPackDimsBytes =
+    3 * sizeof(std::uint32_t);  // num_layers, num_experts, sections_per_expert
+inline constexpr std::size_t kExpertPackSectionBytesEntry =
+    sizeof(std::uint64_t);
+inline constexpr std::size_t kExpertPackHashBytes = sizeof(std::uint64_t);
+
+inline std::filesystem::path expert_pack_dir()
+{
+    return rust_loader_compile_cache_dir();
+}
+
+inline std::filesystem::path expert_pack_path(const std::string& cache_key)
+{
+    return expert_pack_dir() / (cache_key + ".experts");
+}
+
+inline std::filesystem::path expert_pack_tmp_path(const std::string& cache_key)
+{
+    return expert_pack_dir() / (cache_key + ".experts.tmp");
+}
+
+inline std::uint64_t expert_pack_header_bytes(
+    const std::string& cache_key,
+    std::size_t sections)
+{
+    return kExpertPackMagicBytes + kExpertPackVersionBytes +
+           kExpertPackKeyLenBytes + cache_key.size() + kExpertPackDimsBytes +
+           sections * kExpertPackSectionBytesEntry + kExpertPackHashBytes;
+}
+
+inline void remap_streamed_table_to_expert_pack(
+    StreamedExpertTable& table,
+    const std::filesystem::path& pack_path,
+    const std::string& cache_key)
+{
+    const std::uint64_t hdr = expert_pack_header_bytes(
+        cache_key, table.section_bytes.size());
+    table.shard_paths.assign(1, pack_path);
+    for (auto& entry : table.extents) {
+        for (auto& sec : entry.sections) {
+            sec.shard = 0;
+            sec.file_offset += hdr;
+        }
+    }
+}
+
+inline std::uint64_t expert_pack_body_bytes(const StreamedExpertTable& table)
+{
+    const std::uint64_t slot =
+        table.slot_bytes > 0
+            ? table.slot_bytes
+            : table.payload_bytes_per_expert();
+    return slot * static_cast<std::uint64_t>(table.num_layers) *
+           static_cast<std::uint64_t>(table.num_experts);
+}
+
+class ExpertPackWriter {
+public:
+    ExpertPackWriter(
+        const std::string& cache_key,
+        const StreamedExpertTable& table)
+        : cache_key_(cache_key),
+          table_(table),
+          path_(expert_pack_path(cache_key)),
+          tmp_(expert_pack_tmp_path(cache_key))
+    {
+        std::error_code ec;
+        std::filesystem::create_directories(expert_pack_dir(), ec);
+        const std::uint64_t body = expert_pack_body_bytes(table);
+        {
+            const auto space = std::filesystem::space(expert_pack_dir(), ec);
+            const std::uint64_t need = body + (256ull << 20);
+            if (!ec && space.available < need) {
+                throw std::runtime_error(
+                    "expert pack: not enough free disk for pack in " +
+                    expert_pack_dir().string());
+            }
+        }
+        os_.open(tmp_, std::ios::binary | std::ios::trunc);
+        if (!os_) {
+            throw std::runtime_error(
+                "expert pack: failed to open " + tmp_.string());
+        }
+        header_bytes_ = expert_pack_header_bytes(
+            cache_key, table.section_bytes.size());
+        std::vector<char> pad(header_bytes_, 0);
+        os_.write(pad.data(), static_cast<std::streamsize>(pad.size()));
+        body_cursor_ = 0;
+        hash_ = weight_codec::kBlobHashSeed;
+    }
+
+    void append_bytes(const void* data, std::uint64_t nbytes)
+    {
+        if (nbytes == 0) return;
+        os_.write(static_cast<const char*>(data),
+                  static_cast<std::streamsize>(nbytes));
+        if (!os_) {
+            throw std::runtime_error("expert pack: write failed");
+        }
+        hash_ = weight_codec::blob_hash_update(
+            hash_, data, static_cast<std::size_t>(nbytes));
+        body_cursor_ += nbytes;
+    }
+
+    void append_zeros(std::uint64_t nbytes)
+    {
+        if (nbytes == 0) return;
+        std::vector<char> z(static_cast<std::size_t>(std::min<std::uint64_t>(nbytes, 1 << 20)), 0);
+        std::uint64_t left = nbytes;
+        while (left > 0) {
+            const std::uint64_t n = std::min<std::uint64_t>(left, z.size());
+            append_bytes(z.data(), n);
+            left -= n;
+        }
+    }
+
+    void finalize()
+    {
+        const std::uint64_t expected = expert_pack_body_bytes(table_);
+        if (body_cursor_ != expected) {
+            throw std::runtime_error(
+                "expert pack: body size mismatch (got " +
+                std::to_string(body_cursor_) + ", expected " +
+                std::to_string(expected) + ")");
+        }
+        os_.seekp(0);
+        os_.write(kExpertPackMagic, static_cast<std::streamsize>(kExpertPackMagicBytes));
+        write_u32(kExpertPackVersion);
+        write_u32(static_cast<std::uint32_t>(cache_key_.size()));
+        os_.write(cache_key_.data(),
+                  static_cast<std::streamsize>(cache_key_.size()));
+        write_u32(static_cast<std::uint32_t>(table_.num_layers));
+        write_u32(static_cast<std::uint32_t>(table_.num_experts));
+        write_u32(static_cast<std::uint32_t>(table_.sections_per_expert));
+        for (std::uint64_t b : table_.section_bytes) {
+            write_u64(b);
+        }
+        write_u64(hash_);
+        os_.flush();
+        os_.close();
+        std::filesystem::rename(tmp_, path_);
+    }
+
+    void abandon()
+    {
+        os_.close();
+        std::error_code ec;
+        std::filesystem::remove(tmp_, ec);
+    }
+
+    const std::filesystem::path& path() const noexcept { return path_; }
+
+    static bool exists_and_matches(
+        const std::string& cache_key,
+        const StreamedExpertTable& table)
+    {
+        const auto path = expert_pack_path(cache_key);
+        std::ifstream in(path, std::ios::binary);
+        if (!in) return false;
+        char magic[kExpertPackMagicBytes];
+        in.read(magic, static_cast<std::streamsize>(kExpertPackMagicBytes));
+        if (!in ||
+            std::memcmp(magic, kExpertPackMagic, kExpertPackMagicBytes) != 0) {
+            return false;
+        }
+        std::uint32_t ver = 0, key_len = 0;
+        in.read(reinterpret_cast<char*>(&ver),
+                static_cast<std::streamsize>(kExpertPackVersionBytes));
+        in.read(reinterpret_cast<char*>(&key_len),
+                static_cast<std::streamsize>(kExpertPackKeyLenBytes));
+        if (!in || ver != kExpertPackVersion) return false;
+        std::string key(key_len, '\0');
+        in.read(key.data(), static_cast<std::streamsize>(key_len));
+        if (!in || key != cache_key) return false;
+        std::uint32_t L = 0, E = 0, S = 0;
+        in.read(reinterpret_cast<char*>(&L),
+                static_cast<std::streamsize>(sizeof(std::uint32_t)));
+        in.read(reinterpret_cast<char*>(&E),
+                static_cast<std::streamsize>(sizeof(std::uint32_t)));
+        in.read(reinterpret_cast<char*>(&S),
+                static_cast<std::streamsize>(sizeof(std::uint32_t)));
+        if (!in || static_cast<int>(L) != table.num_layers ||
+            static_cast<int>(E) != table.num_experts ||
+            static_cast<int>(S) != table.sections_per_expert) {
+            return false;
+        }
+        for (std::uint64_t expect : table.section_bytes) {
+            std::uint64_t b = 0;
+            in.read(reinterpret_cast<char*>(&b),
+                    static_cast<std::streamsize>(kExpertPackSectionBytesEntry));
+            if (!in || b != expect) return false;
+        }
+        return static_cast<bool>(in);
+    }
+
+private:
+    void write_u32(std::uint32_t v)
+    {
+        os_.write(reinterpret_cast<const char*>(&v),
+                  static_cast<std::streamsize>(sizeof(std::uint32_t)));
+    }
+    void write_u64(std::uint64_t v)
+    {
+        os_.write(reinterpret_cast<const char*>(&v),
+                  static_cast<std::streamsize>(sizeof(std::uint64_t)));
+    }
+
+    std::string cache_key_;
+    const StreamedExpertTable& table_;
+    std::filesystem::path path_;
+    std::filesystem::path tmp_;
+    std::ofstream os_;
+    std::uint64_t header_bytes_ = 0;
+    std::uint64_t body_cursor_ = 0;
+    std::uint64_t hash_ = 0;
+};
+
+bool ensure_gpt_oss_native_expert_pack(
+    StreamedExpertTable& table,
+    const std::string& cache_key,
+    SafetensorsCheckpointSource& checkpoint,
+    bool verbose);
+
+bool ensure_gpt_oss_eager_bf16_expert_pack(
+    StreamedExpertTable& table,
+    const std::string& cache_key,
+    SafetensorsCheckpointSource& checkpoint,
+    bool verbose);
+
+// Dispatch offline pack builders from `table.pack_kind` (set by the stream
+// arch recipe). No-op when pack_kind is None.
+inline void ensure_streamed_expert_pack(
+    StreamedExpertTable& table,
+    const std::string& cache_key,
+    SafetensorsCheckpointSource& checkpoint,
+    bool verbose)
+{
+    using pie_weight_loader::PieLoaderExpertPackKind;
+    switch (static_cast<PieLoaderExpertPackKind>(table.pack_kind)) {
+    case PieLoaderExpertPackKind::None:
+        return;
+    case PieLoaderExpertPackKind::GptOssNativeMarlin:
+        ensure_gpt_oss_native_expert_pack(
+            table, cache_key, checkpoint, verbose);
+        return;
+    case PieLoaderExpertPackKind::GptOssEagerBf16:
+        ensure_gpt_oss_eager_bf16_expert_pack(
+            table, cache_key, checkpoint, verbose);
+        return;
+    }
+    throw std::runtime_error(
+        "ensure_streamed_expert_pack: unknown pack_kind=" +
+        std::to_string(table.pack_kind));
+}
+
+}  // namespace pie_cuda_driver

--- a/driver/cuda/src/model/gpt_oss.cpp
+++ b/driver/cuda/src/model/gpt_oss.cpp
@@ -67,10 +67,8 @@ MixtralWeights bind_gpt_oss(const LoadedModel& engine) {
         engine.streamed_expert_table().num_layers > 0;
     const bool native_mxfp4 =
         engine.mxfp4_moe_lowering() == Mxfp4MoeLowering::NativeGemm;
-    if (streaming && native_mxfp4) {
-        throw std::runtime_error(
-            "gpt_oss: stream_routed_experts is incompatible with native MXFP4");
-    }
+    const bool eager_bf16 =
+        engine.mxfp4_moe_lowering() == Mxfp4MoeLowering::Bf16Dequant;
     const int I_native = native_mxfp4 ? align_up_int(I, 128) : I;
     const int L = cfg.num_hidden_layers;
     const int Hq = (cfg.num_attention_heads * cfg.head_dim) / T;
@@ -102,10 +100,11 @@ MixtralWeights bind_gpt_oss(const LoadedModel& engine) {
         !streaming &&
         engine.has("model.layers.0.mlp.experts.gate_up_proj.weight");
     const bool has_native_mxfp4_experts =
+        !streaming &&
         engine.has("model.layers.0.mlp.experts.gate_proj.weight") &&
         engine.has("model.layers.0.mlp.experts.up_proj.weight") &&
         engine.has("model.layers.0.mlp.experts.down_proj.weight");
-    if (native_mxfp4 && !has_native_mxfp4_experts) {
+    if (native_mxfp4 && !streaming && !has_native_mxfp4_experts) {
         throw std::runtime_error(
             "gpt_oss: native MXFP4 selected, but loader did not finalize "
             "native gate/up/down expert tensors");
@@ -116,14 +115,15 @@ MixtralWeights bind_gpt_oss(const LoadedModel& engine) {
             "did not select native MXFP4");
     }
     const bool use_mxfp4_packed_experts =
-        streaming || has_routed_mxfp4_experts || has_native_mxfp4_experts;
+        (streaming && !eager_bf16) || has_routed_mxfp4_experts ||
+        has_native_mxfp4_experts;
     if (use_mxfp4_packed_experts) {
         if (H % 32 != 0 || I % 32 != 0) {
             throw std::runtime_error(
                 "gpt_oss: packed MXFP4 expert backend requires hidden and "
                 "tp-local intermediate dimensions divisible by 32");
         }
-        if (has_native_mxfp4_experts) {
+        if (native_mxfp4) {
             if (H % 64 != 0 || I_native % 64 != 0) {
                 throw std::runtime_error(
                     "gpt_oss: native MXFP4/Marlin expert backend requires "
@@ -206,7 +206,47 @@ MixtralWeights bind_gpt_oss(const LoadedModel& engine) {
         Lw.router_bias = &must(engine, p + "mlp.router.bias");
 
         Lw.experts.resize(static_cast<std::size_t>(E));
-        if (use_mxfp4_packed_experts) {
+        if (streaming && eager_bf16) {
+            // BF16 weights live in the offline expert pack; only biases resident.
+            const std::string gate_up_bias_name =
+                p + "mlp.experts.gate_up_proj.bias";
+            const std::string down_bias_name =
+                p + "mlp.experts.down_proj.bias";
+            const auto& b_gate_up_all = must(engine, gate_up_bias_name);
+            const auto& b_down_all = must(engine, down_bias_name);
+            const std::vector<std::int64_t> gate_up_bias_shape = {E, 2 * I};
+            const std::vector<std::int64_t> down_bias_shape = {E, H};
+            if (b_gate_up_all.dtype() != DType::BF16 ||
+                b_down_all.dtype() != DType::BF16 ||
+                b_gate_up_all.shape() != gate_up_bias_shape ||
+                b_down_all.shape() != down_bias_shape) {
+                throw std::runtime_error(
+                    "gpt_oss: eager BF16 streaming bias shape mismatch at layer " +
+                    std::to_string(li));
+            }
+            for (int e = 0; e < E; ++e) {
+                auto& Ew = Lw.experts[e];
+                const auto expert_idx = static_cast<std::size_t>(e);
+                Ew.format = MixtralExpertWeightFormat::Bf16;
+
+                auto gate_bias = DeviceTensor::allocate(DType::BF16, {I});
+                auto up_bias = DeviceTensor::allocate(DType::BF16, {I});
+                kernels::launch_deinterleave_vec_bf16(
+                    static_cast<const std::uint8_t*>(b_gate_up_all.data()) +
+                        expert_idx * mxfp4_gate_up_bias_expert_bytes,
+                    gate_bias.data(), up_bias.data(), I, /*stream=*/0);
+                w.owned_expert_buffers.push_back(std::move(gate_bias));
+                Ew.b_gate = &w.owned_expert_buffers.back();
+                w.owned_expert_buffers.push_back(std::move(up_bias));
+                Ew.b_up = &w.owned_expert_buffers.back();
+
+                w.owned_expert_buffers.push_back(tensor_view(
+                    b_down_all,
+                    expert_idx * down_bias_expert_bytes,
+                    {H}));
+                Ew.b_down = &w.owned_expert_buffers.back();
+            }
+        } else if (use_mxfp4_packed_experts) {
             if (has_native_mxfp4_experts) {
                 const std::string gate_name =
                     p + "mlp.experts.gate_proj.weight";
@@ -319,8 +359,8 @@ MixtralWeights bind_gpt_oss(const LoadedModel& engine) {
                     Ew.b_down = &w.owned_expert_buffers.back();
                 }
             } else if (streaming) {
-                // Packed MXFP4 weights live in the stream cache; only biases
-                // are resident. Forward dequants from cache slot pointers.
+                // Weights live in the stream cache (HF packs or Marlin pack);
+                // only biases are resident.
                 const std::string gate_up_bias_name =
                     p + "mlp.experts.gate_up_proj.bias";
                 const std::string down_bias_name =
@@ -340,7 +380,9 @@ MixtralWeights bind_gpt_oss(const LoadedModel& engine) {
                 for (int e = 0; e < E; ++e) {
                     auto& Ew = Lw.experts[e];
                     const auto expert_idx = static_cast<std::size_t>(e);
-                    Ew.format = MixtralExpertWeightFormat::Mxfp4RoutedDequant;
+                    Ew.format = native_mxfp4
+                        ? MixtralExpertWeightFormat::Mxfp4NativeGemm
+                        : MixtralExpertWeightFormat::Mxfp4RoutedDequant;
 
                     auto gate_bias = DeviceTensor::allocate(DType::BF16, {I});
                     auto up_bias = DeviceTensor::allocate(DType::BF16, {I});

--- a/driver/cuda/src/model/gpt_oss.cpp
+++ b/driver/cuda/src/model/gpt_oss.cpp
@@ -581,7 +581,7 @@ MixtralWeights bind_gpt_oss(const LoadedModel& engine) {
         }
     }
 
-    if (use_mxfp4_packed_experts) {
+    if (use_mxfp4_packed_experts || (streaming && eager_bf16)) {
         CUDA_CHECK(cudaGetLastError());
         CUDA_CHECK(cudaDeviceSynchronize());
     }

--- a/driver/cuda/src/model/gpt_oss_eager_bf16_pack.cpp
+++ b/driver/cuda/src/model/gpt_oss_eager_bf16_pack.cpp
@@ -64,6 +64,32 @@ struct GptOssEagerBf16PackTraits {
         ctx.intermediate = fused_rows / 2;
         ctx.hidden = gu_groups * 32;
 
+        // Match Rust gpt_oss_eager_bf16_section_bytes: I*H*2 BF16 payloads.
+        const std::uint64_t gate =
+            static_cast<std::uint64_t>(ctx.intermediate) *
+            static_cast<std::uint64_t>(ctx.hidden) * 2;
+        const std::uint64_t down =
+            static_cast<std::uint64_t>(ctx.hidden) *
+            static_cast<std::uint64_t>(ctx.intermediate) * 2;
+        const std::uint64_t expect[kSections] = {gate, gate, down};
+        if (sb.size() != static_cast<std::size_t>(kSections)) {
+            throw std::runtime_error(
+                "expert pack: eager BF16 expected " +
+                std::to_string(kSections) + " section_bytes, got " +
+                std::to_string(sb.size()));
+        }
+        for (int i = 0; i < kSections; ++i) {
+            if (sb[static_cast<std::size_t>(i)] != expect[i]) {
+                throw std::runtime_error(
+                    "expert pack: eager BF16 section_bytes[" +
+                    std::to_string(i) + "]=" +
+                    std::to_string(sb[static_cast<std::size_t>(i)]) +
+                    " != expected " + std::to_string(expect[i]) +
+                    " (I=" + std::to_string(ctx.intermediate) +
+                    " H=" + std::to_string(ctx.hidden) + ")");
+            }
+        }
+
         const auto gu_w_store = checkpoint.storage_info(gu_w_name);
         const auto gu_s_store = checkpoint.storage_info(
             "model.layers.0.mlp.experts.gate_up_proj_scales");

--- a/driver/cuda/src/model/gpt_oss_eager_bf16_pack.cpp
+++ b/driver/cuda/src/model/gpt_oss_eager_bf16_pack.cpp
@@ -1,0 +1,163 @@
+#include "model/expert_pack_build.hpp"
+#include "model/expert_pack_cache.hpp"
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "cuda_check.hpp"
+#include "kernels/deinterleave.hpp"
+#include "kernels/dequant_fp4.hpp"
+#include "tensor.hpp"
+
+namespace pie_cuda_driver {
+namespace {
+
+struct GptOssEagerBf16PackTraits {
+    static constexpr int kSections = 3;
+
+    static const char* miss_label()
+    {
+        return "streaming eager BF16 dequant";
+    }
+
+    static void require_build_support() {}
+
+    struct Context {
+        int intermediate = 0;
+        int hidden = 0;
+        std::uint64_t gu_w_span = 0;
+        std::uint64_t gu_s_span = 0;
+        std::uint64_t dn_w_span = 0;
+        std::uint64_t dn_s_span = 0;
+        DeviceBuf src_gu_w;
+        DeviceBuf src_gu_s;
+        DeviceBuf src_dn_w;
+        DeviceBuf src_dn_s;
+        DeviceBuf fused_bf16;
+        DeviceBuf dst_gate;
+        DeviceBuf dst_up;
+        DeviceBuf dst_down;
+    };
+
+    static Context prepare(
+        const StreamedExpertTable& table,
+        SafetensorsCheckpointSource& checkpoint)
+    {
+        const int E = table.num_experts;
+        const auto& sb = table.section_bytes;
+
+        const std::string gu_w_name =
+            "model.layers.0.mlp.experts.gate_up_proj_blocks";
+        const std::string dn_w_name =
+            "model.layers.0.mlp.experts.down_proj_blocks";
+        const auto& gu_w_info = checkpoint.info(gu_w_name);
+        const auto& dn_w_info = checkpoint.info(dn_w_name);
+        if (gu_w_info.shape.size() != 4 || dn_w_info.shape.size() != 4) {
+            throw std::runtime_error(
+                "expert pack: unexpected GPT-OSS expert block ranks");
+        }
+        const int fused_rows = static_cast<int>(gu_w_info.shape[1]);
+        const int gu_groups = static_cast<int>(gu_w_info.shape[2]);
+
+        Context ctx;
+        ctx.intermediate = fused_rows / 2;
+        ctx.hidden = gu_groups * 32;
+
+        const auto gu_w_store = checkpoint.storage_info(gu_w_name);
+        const auto gu_s_store = checkpoint.storage_info(
+            "model.layers.0.mlp.experts.gate_up_proj_scales");
+        const auto dn_w_store = checkpoint.storage_info(dn_w_name);
+        const auto dn_s_store = checkpoint.storage_info(
+            "model.layers.0.mlp.experts.down_proj_scales");
+        ctx.gu_w_span = gu_w_store.nbytes / static_cast<std::uint64_t>(E);
+        ctx.gu_s_span = gu_s_store.nbytes / static_cast<std::uint64_t>(E);
+        ctx.dn_w_span = dn_w_store.nbytes / static_cast<std::uint64_t>(E);
+        ctx.dn_s_span = dn_s_store.nbytes / static_cast<std::uint64_t>(E);
+
+        ctx.src_gu_w = DeviceBuf(ctx.gu_w_span);
+        ctx.src_gu_s = DeviceBuf(ctx.gu_s_span);
+        ctx.src_dn_w = DeviceBuf(ctx.dn_w_span);
+        ctx.src_dn_s = DeviceBuf(ctx.dn_s_span);
+        ctx.fused_bf16 = DeviceBuf(
+            static_cast<std::uint64_t>(2 * ctx.intermediate) *
+            static_cast<std::uint64_t>(ctx.hidden) * 2);
+        ctx.dst_gate = DeviceBuf(sb[0]);
+        ctx.dst_up = DeviceBuf(sb[1]);
+        ctx.dst_down = DeviceBuf(sb[2]);
+        return ctx;
+    }
+
+    static void load_expert(
+        Context& ctx,
+        SafetensorsCheckpointSource& checkpoint,
+        int layer,
+        int expert)
+    {
+        const std::string p =
+            "model.layers." + std::to_string(layer) + ".mlp.experts.";
+        const auto gu_w = checkpoint.storage_info(p + "gate_up_proj_blocks");
+        const auto gu_s = checkpoint.storage_info(p + "gate_up_proj_scales");
+        const auto dn_w = checkpoint.storage_info(p + "down_proj_blocks");
+        const auto dn_s = checkpoint.storage_info(p + "down_proj_scales");
+        const auto e = static_cast<std::uint64_t>(expert);
+        checkpoint.copy_storage_bytes_to_device(
+            gu_w.shard_id, gu_w.file_offset + e * ctx.gu_w_span, ctx.gu_w_span,
+            ctx.src_gu_w.ptr);
+        checkpoint.copy_storage_bytes_to_device(
+            gu_s.shard_id, gu_s.file_offset + e * ctx.gu_s_span, ctx.gu_s_span,
+            ctx.src_gu_s.ptr);
+        checkpoint.copy_storage_bytes_to_device(
+            dn_w.shard_id, dn_w.file_offset + e * ctx.dn_w_span, ctx.dn_w_span,
+            ctx.src_dn_w.ptr);
+        checkpoint.copy_storage_bytes_to_device(
+            dn_s.shard_id, dn_s.file_offset + e * ctx.dn_s_span, ctx.dn_s_span,
+            ctx.src_dn_s.ptr);
+    }
+
+    static void transform(Context& ctx)
+    {
+        kernels::launch_dequant_mxfp4_to_bf16(
+            static_cast<const std::uint8_t*>(ctx.src_gu_w.ptr),
+            static_cast<const std::uint8_t*>(ctx.src_gu_s.ptr),
+            ctx.fused_bf16.ptr, 2 * ctx.intermediate, ctx.hidden,
+            /*stream=*/0);
+        kernels::launch_deinterleave_rows_bf16(
+            ctx.fused_bf16.ptr, ctx.dst_gate.ptr, ctx.dst_up.ptr,
+            ctx.intermediate, ctx.hidden, /*stream=*/0);
+        kernels::launch_dequant_mxfp4_to_bf16(
+            static_cast<const std::uint8_t*>(ctx.src_dn_w.ptr),
+            static_cast<const std::uint8_t*>(ctx.src_dn_s.ptr),
+            ctx.dst_down.ptr, ctx.hidden, ctx.intermediate, /*stream=*/0);
+        CUDA_CHECK(cudaDeviceSynchronize());
+    }
+
+    static void emit(
+        Context& ctx,
+        ExpertPackWriter& writer,
+        const StreamedExpertTable& table,
+        std::vector<std::uint8_t>& host_bounce)
+    {
+        const DeviceBuf* sections[kSections] = {
+            &ctx.dst_gate,
+            &ctx.dst_up,
+            &ctx.dst_down,
+        };
+        expert_pack_emit_slot_sections(
+            writer, table, sections, kSections, host_bounce);
+    }
+};
+
+}  // namespace
+
+bool ensure_gpt_oss_eager_bf16_expert_pack(
+    StreamedExpertTable& table,
+    const std::string& cache_key,
+    SafetensorsCheckpointSource& checkpoint,
+    bool verbose)
+{
+    return ensure_expert_pack<GptOssEagerBf16PackTraits>(
+        table, cache_key, checkpoint, verbose);
+}
+
+}  // namespace pie_cuda_driver

--- a/driver/cuda/src/model/gpt_oss_expert_sections.hpp
+++ b/driver/cuda/src/model/gpt_oss_expert_sections.hpp
@@ -1,10 +1,10 @@
 #pragma once
 
-// GPT-OSS section-index map for streamed experts (RoutedDequant path).
+// GPT-OSS section-index maps for streamed experts.
 //
-// Order must match `GPT_OSS_EXPERT_SECTIONS` in
-// `driver/weight_loader/src/stream_arch.rs`:
-//   gate_up.weight, gate_up.scale, down.weight, down.scale
+// RoutedDequant (4): HF MXFP4 packs — must match `GPT_OSS_EXPERT_SECTIONS`.
+// Native Marlin (6): offline pack — must match `GPT_OSS_NATIVE_EXPERT_SECTIONS`.
+// Eager BF16 (3): offline dequant pack — must match `GPT_OSS_EAGER_BF16_EXPERT_SECTIONS`.
 // Biases stay resident and are not streamed.
 
 #include <cstdint>
@@ -49,6 +49,81 @@ inline const std::uint8_t* gpt_oss_down(const ExpertSectionPointers& p)
 inline const std::uint8_t* gpt_oss_down_scale(const ExpertSectionPointers& p)
 {
     return p.at(kGptOssDownScale);
+}
+
+inline constexpr int kGptOssNativeExpertSectionCount = 6;
+enum GptOssNativeExpertSection : int {
+    kGptOssNativeGate = 0,
+    kGptOssNativeGateScale = 1,
+    kGptOssNativeUp = 2,
+    kGptOssNativeUpScale = 3,
+    kGptOssNativeDown = 4,
+    kGptOssNativeDownScale = 5,
+};
+
+inline void require_gpt_oss_native_sections(const ExpertSectionPointers& p)
+{
+    if (p.num_sections() != kGptOssNativeExpertSectionCount) {
+        throw std::runtime_error(
+            "gpt_oss native expert streaming: expected " +
+            std::to_string(kGptOssNativeExpertSectionCount) +
+            " sections, got " + std::to_string(p.num_sections()));
+    }
+}
+
+inline const std::uint8_t* gpt_oss_native_gate(const ExpertSectionPointers& p)
+{
+    return p.at(kGptOssNativeGate);
+}
+inline const std::uint8_t* gpt_oss_native_gate_scale(const ExpertSectionPointers& p)
+{
+    return p.at(kGptOssNativeGateScale);
+}
+inline const std::uint8_t* gpt_oss_native_up(const ExpertSectionPointers& p)
+{
+    return p.at(kGptOssNativeUp);
+}
+inline const std::uint8_t* gpt_oss_native_up_scale(const ExpertSectionPointers& p)
+{
+    return p.at(kGptOssNativeUpScale);
+}
+inline const std::uint8_t* gpt_oss_native_down(const ExpertSectionPointers& p)
+{
+    return p.at(kGptOssNativeDown);
+}
+inline const std::uint8_t* gpt_oss_native_down_scale(const ExpertSectionPointers& p)
+{
+    return p.at(kGptOssNativeDownScale);
+}
+
+inline constexpr int kGptOssEagerBf16ExpertSectionCount = 3;
+enum GptOssEagerBf16ExpertSection : int {
+    kGptOssEagerGate = 0,
+    kGptOssEagerUp = 1,
+    kGptOssEagerDown = 2,
+};
+
+inline void require_gpt_oss_eager_bf16_sections(const ExpertSectionPointers& p)
+{
+    if (p.num_sections() != kGptOssEagerBf16ExpertSectionCount) {
+        throw std::runtime_error(
+            "gpt_oss eager BF16 expert streaming: expected " +
+            std::to_string(kGptOssEagerBf16ExpertSectionCount) +
+            " sections, got " + std::to_string(p.num_sections()));
+    }
+}
+
+inline const std::uint8_t* gpt_oss_eager_gate(const ExpertSectionPointers& p)
+{
+    return p.at(kGptOssEagerGate);
+}
+inline const std::uint8_t* gpt_oss_eager_up(const ExpertSectionPointers& p)
+{
+    return p.at(kGptOssEagerUp);
+}
+inline const std::uint8_t* gpt_oss_eager_down(const ExpertSectionPointers& p)
+{
+    return p.at(kGptOssEagerDown);
 }
 
 }  // namespace model

--- a/driver/cuda/src/model/gpt_oss_native_marlin_pack.cpp
+++ b/driver/cuda/src/model/gpt_oss_native_marlin_pack.cpp
@@ -141,6 +141,40 @@ struct GptOssNativeMarlinPackTraits {
         ctx.hidden = ctx.gu_groups * 32;
         ctx.down_groups = static_cast<int>(dn_w_info.shape[2]);
 
+        // Match Rust gpt_oss_native_section_bytes / stream plan layout.
+        const std::uint64_t gate_w =
+            static_cast<std::uint64_t>(ctx.intermediate_native) *
+            static_cast<std::uint64_t>(ctx.hidden) / 2;
+        const std::uint64_t gate_s =
+            static_cast<std::uint64_t>(ctx.intermediate_native) *
+            static_cast<std::uint64_t>(ctx.gu_groups);
+        const std::uint64_t down_w =
+            static_cast<std::uint64_t>(ctx.hidden) *
+            static_cast<std::uint64_t>(ctx.intermediate_native) / 2;
+        const std::uint64_t down_s =
+            static_cast<std::uint64_t>(ctx.hidden) *
+            static_cast<std::uint64_t>(ctx.intermediate_native / 32);
+        const std::uint64_t expect[kSections] = {
+            gate_w, gate_s, gate_w, gate_s, down_w, down_s};
+        if (sb.size() != static_cast<std::size_t>(kSections)) {
+            throw std::runtime_error(
+                "expert pack: native Marlin expected " +
+                std::to_string(kSections) + " section_bytes, got " +
+                std::to_string(sb.size()));
+        }
+        for (int i = 0; i < kSections; ++i) {
+            if (sb[static_cast<std::size_t>(i)] != expect[i]) {
+                throw std::runtime_error(
+                    "expert pack: native Marlin section_bytes[" +
+                    std::to_string(i) + "]=" +
+                    std::to_string(sb[static_cast<std::size_t>(i)]) +
+                    " != expected " + std::to_string(expect[i]) +
+                    " (I_native=" + std::to_string(ctx.intermediate_native) +
+                    " H=" + std::to_string(ctx.hidden) +
+                    " groups=" + std::to_string(ctx.gu_groups) + ")");
+            }
+        }
+
         const auto gu_w_store = checkpoint.storage_info(gu_w_name);
         const auto gu_s_store = checkpoint.storage_info(gu_s_name);
         const auto dn_w_store = checkpoint.storage_info(dn_w_name);

--- a/driver/cuda/src/model/gpt_oss_native_marlin_pack.cpp
+++ b/driver/cuda/src/model/gpt_oss_native_marlin_pack.cpp
@@ -1,0 +1,275 @@
+#include "model/expert_pack_build.hpp"
+#include "model/expert_pack_cache.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "cuda_check.hpp"
+#include "kernels/mxfp4_marlin.hpp"
+#include "tensor.hpp"
+
+#if defined(PIE_CUDA_HAS_MARLIN)
+#include "marlin_wrapper.hpp"
+#endif
+
+namespace pie_cuda_driver {
+namespace {
+
+int align_up_int(int v, int a)
+{
+    return (v + a - 1) / a * a;
+}
+
+void repack_weight_one(
+    const std::uint8_t* src,
+    std::uint8_t* dst,
+    std::uint8_t* gptq_stage,
+    int source_rows,
+    int target_rows,
+    int valid_rows,
+    int source_stride_k,
+    int source_k,
+    int target_k,
+    kernels::Mxfp4RowSelect row_map)
+{
+#if defined(PIE_CUDA_HAS_MARLIN)
+    kernels::launch_mxfp4_weight_to_gptq_w4(
+        src, gptq_stage,
+        source_rows, /*source_row_offset=*/0, target_rows, valid_rows,
+        source_stride_k, /*source_col_offset=*/0, source_k, target_k,
+        row_map, /*stream=*/0);
+    marlin::launch_gptq_repack_w4_no_perm(
+        gptq_stage, dst, target_k, target_rows, /*stream=*/0);
+    CUDA_CHECK(cudaGetLastError());
+#else
+    (void)src; (void)dst; (void)gptq_stage;
+    (void)source_rows; (void)target_rows; (void)valid_rows;
+    (void)source_stride_k; (void)source_k; (void)target_k; (void)row_map;
+    throw std::runtime_error(
+        "expert pack: Marlin repack requires PIE_CUDA_HAS_MARLIN");
+#endif
+}
+
+void repack_scale_one(
+    const std::uint8_t* src,
+    std::uint8_t* dst,
+    int source_rows,
+    int target_rows,
+    int valid_rows,
+    int source_stride_groups,
+    int source_groups,
+    int target_groups,
+    kernels::Mxfp4RowSelect row_map)
+{
+    kernels::launch_mxfp4_scales_to_marlin_e8m0(
+        src, dst,
+        source_rows, /*source_row_offset=*/0, target_rows, valid_rows,
+        source_stride_groups, /*source_group_offset=*/0, source_groups,
+        target_groups, row_map, /*stream=*/0);
+    CUDA_CHECK(cudaGetLastError());
+}
+
+struct GptOssNativeMarlinPackTraits {
+    static constexpr int kSections = 6;
+
+    static const char* miss_label()
+    {
+        return "streaming Marlin build";
+    }
+
+    static void require_build_support()
+    {
+#if !defined(PIE_CUDA_HAS_MARLIN)
+        throw std::runtime_error(
+            "expert pack: native GPT-OSS pack build requires Marlin");
+#endif
+    }
+
+    struct Context {
+        int fused_rows = 0;
+        int intermediate = 0;
+        int intermediate_native = 0;
+        int hidden = 0;
+        int gu_groups = 0;
+        int down_groups = 0;
+        std::uint64_t gu_w_span = 0;
+        std::uint64_t gu_s_span = 0;
+        std::uint64_t dn_w_span = 0;
+        std::uint64_t dn_s_span = 0;
+        DeviceBuf src_gu_w;
+        DeviceBuf src_gu_s;
+        DeviceBuf src_dn_w;
+        DeviceBuf src_dn_s;
+        DeviceBuf dst_gate_w;
+        DeviceBuf dst_gate_s;
+        DeviceBuf dst_up_w;
+        DeviceBuf dst_up_s;
+        DeviceBuf dst_dn_w;
+        DeviceBuf dst_dn_s;
+        DeviceBuf gptq_stage;
+    };
+
+    static Context prepare(
+        const StreamedExpertTable& table,
+        SafetensorsCheckpointSource& checkpoint)
+    {
+        const int E = table.num_experts;
+        const auto& sb = table.section_bytes;
+
+        const std::string gu_w_name =
+            "model.layers.0.mlp.experts.gate_up_proj_blocks";
+        const std::string gu_s_name =
+            "model.layers.0.mlp.experts.gate_up_proj_scales";
+        const std::string dn_w_name =
+            "model.layers.0.mlp.experts.down_proj_blocks";
+        const std::string dn_s_name =
+            "model.layers.0.mlp.experts.down_proj_scales";
+        const auto& gu_w_info = checkpoint.info(gu_w_name);
+        const auto& dn_w_info = checkpoint.info(dn_w_name);
+        if (gu_w_info.shape.size() != 4 || dn_w_info.shape.size() != 4) {
+            throw std::runtime_error(
+                "expert pack: unexpected GPT-OSS expert block ranks");
+        }
+
+        Context ctx;
+        ctx.fused_rows = static_cast<int>(gu_w_info.shape[1]);
+        ctx.gu_groups = static_cast<int>(gu_w_info.shape[2]);
+        ctx.intermediate = ctx.fused_rows / 2;
+        ctx.intermediate_native = align_up_int(ctx.intermediate, 128);
+        ctx.hidden = ctx.gu_groups * 32;
+        ctx.down_groups = static_cast<int>(dn_w_info.shape[2]);
+
+        const auto gu_w_store = checkpoint.storage_info(gu_w_name);
+        const auto gu_s_store = checkpoint.storage_info(gu_s_name);
+        const auto dn_w_store = checkpoint.storage_info(dn_w_name);
+        const auto dn_s_store = checkpoint.storage_info(dn_s_name);
+        ctx.gu_w_span = gu_w_store.nbytes / static_cast<std::uint64_t>(E);
+        ctx.gu_s_span = gu_s_store.nbytes / static_cast<std::uint64_t>(E);
+        ctx.dn_w_span = dn_w_store.nbytes / static_cast<std::uint64_t>(E);
+        ctx.dn_s_span = dn_s_store.nbytes / static_cast<std::uint64_t>(E);
+
+        ctx.src_gu_w = DeviceBuf(ctx.gu_w_span);
+        ctx.src_gu_s = DeviceBuf(ctx.gu_s_span);
+        ctx.src_dn_w = DeviceBuf(ctx.dn_w_span);
+        ctx.src_dn_s = DeviceBuf(ctx.dn_s_span);
+        ctx.dst_gate_w = DeviceBuf(sb[0]);
+        ctx.dst_gate_s = DeviceBuf(sb[1]);
+        ctx.dst_up_w = DeviceBuf(sb[2]);
+        ctx.dst_up_s = DeviceBuf(sb[3]);
+        ctx.dst_dn_w = DeviceBuf(sb[4]);
+        ctx.dst_dn_s = DeviceBuf(sb[5]);
+        const std::uint64_t gptq_bytes = std::max(
+            std::max(sb[0], sb[4]),
+            static_cast<std::uint64_t>(ctx.intermediate_native) *
+                static_cast<std::uint64_t>(ctx.hidden) / 2);
+        ctx.gptq_stage = DeviceBuf(gptq_bytes);
+        return ctx;
+    }
+
+    static void load_expert(
+        Context& ctx,
+        SafetensorsCheckpointSource& checkpoint,
+        int layer,
+        int expert)
+    {
+        const std::string p =
+            "model.layers." + std::to_string(layer) + ".mlp.experts.";
+        const auto gu_w = checkpoint.storage_info(p + "gate_up_proj_blocks");
+        const auto gu_s = checkpoint.storage_info(p + "gate_up_proj_scales");
+        const auto dn_w = checkpoint.storage_info(p + "down_proj_blocks");
+        const auto dn_s = checkpoint.storage_info(p + "down_proj_scales");
+        const auto e = static_cast<std::uint64_t>(expert);
+        checkpoint.copy_storage_bytes_to_device(
+            gu_w.shard_id, gu_w.file_offset + e * ctx.gu_w_span, ctx.gu_w_span,
+            ctx.src_gu_w.ptr);
+        checkpoint.copy_storage_bytes_to_device(
+            gu_s.shard_id, gu_s.file_offset + e * ctx.gu_s_span, ctx.gu_s_span,
+            ctx.src_gu_s.ptr);
+        checkpoint.copy_storage_bytes_to_device(
+            dn_w.shard_id, dn_w.file_offset + e * ctx.dn_w_span, ctx.dn_w_span,
+            ctx.src_dn_w.ptr);
+        checkpoint.copy_storage_bytes_to_device(
+            dn_s.shard_id, dn_s.file_offset + e * ctx.dn_s_span, ctx.dn_s_span,
+            ctx.src_dn_s.ptr);
+    }
+
+    static void transform(Context& ctx)
+    {
+        auto* gu_w_ptr = static_cast<std::uint8_t*>(ctx.src_gu_w.ptr);
+        auto* gu_s_ptr = static_cast<std::uint8_t*>(ctx.src_gu_s.ptr);
+        auto* dn_w_ptr = static_cast<std::uint8_t*>(ctx.src_dn_w.ptr);
+        auto* dn_s_ptr = static_cast<std::uint8_t*>(ctx.src_dn_s.ptr);
+
+        // Gate (even rows) / up (odd rows).
+        repack_weight_one(
+            gu_w_ptr, static_cast<std::uint8_t*>(ctx.dst_gate_w.ptr),
+            static_cast<std::uint8_t*>(ctx.gptq_stage.ptr),
+            ctx.fused_rows, ctx.intermediate_native, ctx.intermediate,
+            ctx.hidden, ctx.hidden, ctx.hidden, kernels::Mxfp4RowSelect::Even);
+        repack_scale_one(
+            gu_s_ptr, static_cast<std::uint8_t*>(ctx.dst_gate_s.ptr),
+            ctx.fused_rows, ctx.intermediate_native, ctx.intermediate,
+            ctx.gu_groups, ctx.gu_groups, ctx.gu_groups,
+            kernels::Mxfp4RowSelect::Even);
+
+        repack_weight_one(
+            gu_w_ptr, static_cast<std::uint8_t*>(ctx.dst_up_w.ptr),
+            static_cast<std::uint8_t*>(ctx.gptq_stage.ptr),
+            ctx.fused_rows, ctx.intermediate_native, ctx.intermediate,
+            ctx.hidden, ctx.hidden, ctx.hidden, kernels::Mxfp4RowSelect::Odd);
+        repack_scale_one(
+            gu_s_ptr, static_cast<std::uint8_t*>(ctx.dst_up_s.ptr),
+            ctx.fused_rows, ctx.intermediate_native, ctx.intermediate,
+            ctx.gu_groups, ctx.gu_groups, ctx.gu_groups,
+            kernels::Mxfp4RowSelect::Odd);
+
+        // Down: Identity row map, pad K to intermediate_native.
+        repack_weight_one(
+            dn_w_ptr, static_cast<std::uint8_t*>(ctx.dst_dn_w.ptr),
+            static_cast<std::uint8_t*>(ctx.gptq_stage.ptr),
+            ctx.hidden, ctx.hidden, ctx.hidden,
+            ctx.intermediate, ctx.intermediate, ctx.intermediate_native,
+            kernels::Mxfp4RowSelect::Identity);
+        repack_scale_one(
+            dn_s_ptr, static_cast<std::uint8_t*>(ctx.dst_dn_s.ptr),
+            ctx.hidden, ctx.hidden, ctx.hidden,
+            ctx.down_groups, ctx.down_groups, ctx.intermediate_native / 32,
+            kernels::Mxfp4RowSelect::Identity);
+
+        CUDA_CHECK(cudaDeviceSynchronize());
+    }
+
+    static void emit(
+        Context& ctx,
+        ExpertPackWriter& writer,
+        const StreamedExpertTable& table,
+        std::vector<std::uint8_t>& host_bounce)
+    {
+        const DeviceBuf* sections[kSections] = {
+            &ctx.dst_gate_w,
+            &ctx.dst_gate_s,
+            &ctx.dst_up_w,
+            &ctx.dst_up_s,
+            &ctx.dst_dn_w,
+            &ctx.dst_dn_s,
+        };
+        expert_pack_emit_slot_sections(
+            writer, table, sections, kSections, host_bounce);
+    }
+};
+
+}  // namespace
+
+bool ensure_gpt_oss_native_expert_pack(
+    StreamedExpertTable& table,
+    const std::string& cache_key,
+    SafetensorsCheckpointSource& checkpoint,
+    bool verbose)
+{
+    return ensure_expert_pack<GptOssNativeMarlinPackTraits>(
+        table, cache_key, checkpoint, verbose);
+}
+
+}  // namespace pie_cuda_driver

--- a/driver/cuda/src/model/loaded_model.cpp
+++ b/driver/cuda/src/model/loaded_model.cpp
@@ -16,6 +16,7 @@
 #include "loader/rust_loader_bridge.hpp"
 #include "loader/rust_storage_executor.hpp"
 #include "model/weight_artifact_cache.hpp"
+#include "model/expert_pack_cache.hpp"
 #include "tensor.hpp"
 
 namespace pie_cuda_driver {
@@ -74,11 +75,13 @@ Mxfp4MoeLowering select_mxfp4_moe_lowering(
         return Mxfp4MoeLowering::Bf16Dequant;
     }
     if (policy == "native") {
-        if (!target.mxfp4_native_gemm) {
+        // GPT-OSS "native" is Marlin-repacked MXFP4 (W4A16), available whenever
+        // Marlin is linked. Blackwell FP4 hardware is a stricter subset.
+        if (!target.mxfp4_native_gemm && !target.gptq_marlin_int4) {
             throw std::runtime_error(
                 "engine: model.mxfp4_moe='native' requested a true MXFP4 "
                 "MoE GEMM backend, but this build has no registered native "
-                "MXFP4 expert GEMM kernels");
+                "MXFP4 / Marlin expert GEMM kernels");
         }
         return Mxfp4MoeLowering::NativeGemm;
     }
@@ -366,6 +369,13 @@ LoadedModel LoadedModel::load(const Config& boot_cfg, NcclComm* tp_comm) {
     if (boot_cfg.model.stream_routed_experts) {
         log_stage("build streamed expert table begin");
         e.streamed_experts_ = streamed_expert_table_from_program(rust_view);
+        // Offline packs (native Marlin / eager BF16): build/remap with
+        // bounded staging *before* resident materialize so peak VRAM stays
+        // O(one expert). Kind is set by the stream arch recipe.
+        log_stage("ensure streamed expert pack begin");
+        ensure_streamed_expert_pack(
+            e.streamed_experts_, rust_plan.cache_key, loader, verbose);
+        log_stage("ensure streamed expert pack done");
         log_stage("build streamed expert table done");
         if (verbose) {
             std::cerr << "[pie-driver-cuda] expert streaming: "

--- a/driver/cuda/src/model/mixtral.cpp
+++ b/driver/cuda/src/model/mixtral.cpp
@@ -391,11 +391,24 @@ void mixtral_forward_paged(
             !layer.experts.empty() &&
             layer.experts[0].format ==
                 MixtralExpertWeightFormat::Mxfp4RoutedDequant;
+        const bool stream_native =
+            expert_cache != nullptr &&
+            !layer.experts.empty() &&
+            layer.experts[0].format ==
+                MixtralExpertWeightFormat::Mxfp4NativeGemm &&
+            layer.experts[0].w_gate_mxfp4 == nullptr;
+        const bool stream_gpt_oss_bf16 =
+            expert_cache != nullptr &&
+            !layer.experts.empty() &&
+            layer.experts[0].format == MixtralExpertWeightFormat::Bf16 &&
+            layer.experts[0].w_gate == nullptr &&
+            layer.experts[0].b_gate != nullptr;
         const bool stream_bf16 =
             expert_cache != nullptr &&
             !layer.experts.empty() &&
             layer.experts[0].format == MixtralExpertWeightFormat::Bf16 &&
-            layer.experts[0].w_gate == nullptr;
+            layer.experts[0].w_gate == nullptr &&
+            !stream_gpt_oss_bf16;
 
         auto dequant_mxfp4_and_run_expert = [&](int e,
                                 const std::uint8_t* gate_up_mxfp4,
@@ -539,6 +552,189 @@ void mixtral_forward_paged(
                     dequant_mxfp4_and_run_expert(selected[off + j],
                                  gpt_oss_gate_up(p), gpt_oss_gate_up_scale(p),
                                  gpt_oss_down(p), gpt_oss_down_scale(p));
+                }
+            }
+        } else if (stream_native) {
+            const int Ip = w.mxfp4_intermediate_padded > 0
+                ? w.mxfp4_intermediate_padded : I;
+            std::vector<int> selected;
+            selected.reserve(static_cast<std::size_t>(num_experts));
+            for (int e = 0; e < num_experts; ++e) {
+                if (!routing.token_idx[static_cast<std::size_t>(e)].empty()) {
+                    selected.push_back(e);
+                }
+            }
+            std::vector<ExpertSectionPointers> ptrs;
+            const std::size_t max_batch =
+                static_cast<std::size_t>(expert_cache->num_slots());
+            for (std::size_t off = 0; off < selected.size(); off += max_batch) {
+                const std::size_t chunk =
+                    std::min(max_batch, selected.size() - off);
+                expert_cache->ensure_resident(
+                    L,
+                    std::span<const int>(selected.data() + off, chunk),
+                    stream, ptrs);
+                for (std::size_t j = 0; j < chunk; ++j) {
+                    const auto& p = ptrs[j];
+                    require_gpt_oss_native_sections(p);
+                    const int e = selected[off + j];
+                    const auto& tok_idx =
+                        routing.token_idx[static_cast<std::size_t>(e)];
+                    const auto& weights =
+                        routing.weights[static_cast<std::size_t>(e)];
+                    const int Ne = static_cast<int>(tok_idx.size());
+                    const auto& expert = layer.experts[static_cast<std::size_t>(e)];
+
+                    CUDA_CHECK(cudaMemcpyAsync(
+                        d_expert_idx.data(), tok_idx.data(),
+                        Ne * sizeof(std::int32_t), cudaMemcpyHostToDevice,
+                        stream));
+                    CUDA_CHECK(cudaMemcpyAsync(
+                        d_expert_w.data(), weights.data(),
+                        Ne * sizeof(float), cudaMemcpyHostToDevice, stream));
+                    kernels::launch_gather_bf16_rows(
+                        static_cast<const std::uint16_t*>(ws.norm_y.data()),
+                        d_expert_idx.data(),
+                        d_expert_in.data(),
+                        Ne, H, stream);
+
+                    auto gate_w = DeviceTensor::view(
+                        const_cast<std::uint8_t*>(gpt_oss_native_gate(p)),
+                        DType::UINT8, {Ip, H / 2});
+                    auto gate_s = DeviceTensor::view(
+                        const_cast<std::uint8_t*>(gpt_oss_native_gate_scale(p)),
+                        DType::UINT8, {Ip, H / 32});
+                    auto up_w = DeviceTensor::view(
+                        const_cast<std::uint8_t*>(gpt_oss_native_up(p)),
+                        DType::UINT8, {Ip, H / 2});
+                    auto up_s = DeviceTensor::view(
+                        const_cast<std::uint8_t*>(gpt_oss_native_up_scale(p)),
+                        DType::UINT8, {Ip, H / 32});
+                    auto down_w = DeviceTensor::view(
+                        const_cast<std::uint8_t*>(gpt_oss_native_down(p)),
+                        DType::UINT8, {H, Ip / 2});
+                    auto down_s = DeviceTensor::view(
+                        const_cast<std::uint8_t*>(gpt_oss_native_down_scale(p)),
+                        DType::UINT8, {H, Ip / 32});
+
+                    ops::gemm_act_x_w(cublas.handle(),
+                        d_expert_in.data(),
+                        ops::WeightView::mxfp4_marlin(gate_w, gate_s),
+                        d_expert_gate.data(), Ne, Ip, H);
+                    ops::gemm_act_x_w(cublas.handle(),
+                        d_expert_in.data(),
+                        ops::WeightView::mxfp4_marlin(up_w, up_s),
+                        d_expert_up.data(), Ne, Ip, H);
+                    if (expert.b_gate) kernels::launch_add_bias_bf16_strided(
+                        d_expert_gate.data(), expert.b_gate->data(), Ne, I, Ip,
+                        stream);
+                    if (expert.b_up) kernels::launch_add_bias_bf16_strided(
+                        d_expert_up.data(), expert.b_up->data(), Ne, I, Ip,
+                        stream);
+                    if (cfg.swiglu_limit > 0.f) {
+                        kernels::launch_gpt_oss_glu_bf16(
+                            d_expert_gate.data(), d_expert_up.data(),
+                            d_expert_gate.data(),
+                            static_cast<int>(static_cast<std::size_t>(Ne) * Ip),
+                            stream, /*limit=*/cfg.swiglu_limit);
+                    } else {
+                        kernels::launch_swiglu_bf16(
+                            d_expert_gate.data(), d_expert_up.data(),
+                            d_expert_gate.data(),
+                            static_cast<std::size_t>(Ne) * Ip, stream);
+                    }
+                    ops::gemm_act_x_w(cublas.handle(),
+                        d_expert_gate.data(),
+                        ops::WeightView::mxfp4_marlin(down_w, down_s),
+                        d_expert_out.data(), Ne, H, Ip);
+                    if (expert.b_down && tp_is_leader) {
+                        kernels::launch_add_bias_bf16(
+                            d_expert_out.data(), expert.b_down->data(), Ne, H,
+                            stream);
+                    }
+                    kernels::launch_scatter_add_weighted_bf16(
+                        moe_target, d_expert_out.data(),
+                        d_expert_idx.data(), d_expert_w.data(),
+                        Ne, H, stream);
+                }
+            }
+        } else if (stream_gpt_oss_bf16) {
+            std::vector<int> selected;
+            selected.reserve(static_cast<std::size_t>(num_experts));
+            for (int e = 0; e < num_experts; ++e) {
+                if (!routing.token_idx[static_cast<std::size_t>(e)].empty()) {
+                    selected.push_back(e);
+                }
+            }
+            std::vector<ExpertSectionPointers> ptrs;
+            const std::size_t max_batch =
+                static_cast<std::size_t>(expert_cache->num_slots());
+            for (std::size_t off = 0; off < selected.size(); off += max_batch) {
+                const std::size_t chunk =
+                    std::min(max_batch, selected.size() - off);
+                expert_cache->ensure_resident(
+                    L,
+                    std::span<const int>(selected.data() + off, chunk),
+                    stream, ptrs);
+                for (std::size_t j = 0; j < chunk; ++j) {
+                    const auto& p = ptrs[j];
+                    require_gpt_oss_eager_bf16_sections(p);
+                    const int e = selected[off + j];
+                    const auto& tok_idx =
+                        routing.token_idx[static_cast<std::size_t>(e)];
+                    const auto& weights =
+                        routing.weights[static_cast<std::size_t>(e)];
+                    const int Ne = static_cast<int>(tok_idx.size());
+                    const auto& expert = layer.experts[static_cast<std::size_t>(e)];
+
+                    CUDA_CHECK(cudaMemcpyAsync(
+                        d_expert_idx.data(), tok_idx.data(),
+                        Ne * sizeof(std::int32_t), cudaMemcpyHostToDevice,
+                        stream));
+                    CUDA_CHECK(cudaMemcpyAsync(
+                        d_expert_w.data(), weights.data(),
+                        Ne * sizeof(float), cudaMemcpyHostToDevice, stream));
+                    kernels::launch_gather_bf16_rows(
+                        static_cast<const std::uint16_t*>(ws.norm_y.data()),
+                        d_expert_idx.data(),
+                        d_expert_in.data(),
+                        Ne, H, stream);
+
+                    ops::gemm_act_x_wt_bf16(cublas.handle(),
+                        d_expert_in.data(), gpt_oss_eager_gate(p),
+                        d_expert_gate.data(), Ne, I, H);
+                    ops::gemm_act_x_wt_bf16(cublas.handle(),
+                        d_expert_in.data(), gpt_oss_eager_up(p),
+                        d_expert_up.data(), Ne, I, H);
+                    if (expert.b_gate) kernels::launch_add_bias_bf16(
+                        d_expert_gate.data(), expert.b_gate->data(), Ne, I,
+                        stream);
+                    if (expert.b_up) kernels::launch_add_bias_bf16(
+                        d_expert_up.data(), expert.b_up->data(), Ne, I, stream);
+                    if (cfg.swiglu_limit > 0.f) {
+                        kernels::launch_gpt_oss_glu_bf16(
+                            d_expert_gate.data(), d_expert_up.data(),
+                            d_expert_gate.data(),
+                            static_cast<int>(static_cast<std::size_t>(Ne) * I),
+                            stream, /*limit=*/cfg.swiglu_limit);
+                    } else {
+                        kernels::launch_swiglu_bf16(
+                            d_expert_gate.data(), d_expert_up.data(),
+                            d_expert_gate.data(),
+                            static_cast<std::size_t>(Ne) * I, stream);
+                    }
+                    ops::gemm_act_x_wt_bf16(cublas.handle(),
+                        d_expert_gate.data(), gpt_oss_eager_down(p),
+                        d_expert_out.data(), Ne, H, I);
+                    if (expert.b_down && tp_is_leader) {
+                        kernels::launch_add_bias_bf16(
+                            d_expert_out.data(), expert.b_down->data(), Ne, H,
+                            stream);
+                    }
+                    kernels::launch_scatter_add_weighted_bf16(
+                        moe_target, d_expert_out.data(),
+                        d_expert_idx.data(), d_expert_w.data(),
+                        Ne, H, stream);
                 }
             }
         } else if (stream_bf16) {

--- a/driver/cuda/src/model/mixtral_model.hpp
+++ b/driver/cuda/src/model/mixtral_model.hpp
@@ -24,12 +24,7 @@ public:
               ops::CublasHandle& cublas,
               const ForwardFn::ForwardInputs& in) override;
 
-    ModelCapabilities capabilities() const override {
-        // SSD expert page-ins need host routing; CUDA graphs cannot capture.
-        ModelCapabilities caps;
-        caps.graph_safe = fwd_cfg_.expert_cache == nullptr;
-        return caps;
-    }
+    ModelCapabilities capabilities() const override {}
 
 private:
     const MixtralWeights& weights_;

--- a/driver/cuda/src/model/mixtral_model.hpp
+++ b/driver/cuda/src/model/mixtral_model.hpp
@@ -24,7 +24,7 @@ public:
               ops::CublasHandle& cublas,
               const ForwardFn::ForwardInputs& in) override;
 
-    ModelCapabilities capabilities() const override {}
+    ModelCapabilities capabilities() const override { return {}; }
 
 private:
     const MixtralWeights& weights_;

--- a/driver/cuda/src/model/mixtral_model.hpp
+++ b/driver/cuda/src/model/mixtral_model.hpp
@@ -24,7 +24,12 @@ public:
               ops::CublasHandle& cublas,
               const ForwardFn::ForwardInputs& in) override;
 
-    ModelCapabilities capabilities() const override { return {}; }
+    ModelCapabilities capabilities() const override {
+        // SSD expert page-ins need host routing; CUDA graphs cannot capture.
+        ModelCapabilities caps;
+        caps.graph_safe = fwd_cfg_.expert_cache == nullptr;
+        return caps;
+    }
 
 private:
     const MixtralWeights& weights_;

--- a/driver/cuda/src/ops/gemm.cpp
+++ b/driver/cuda/src/ops/gemm.cpp
@@ -827,9 +827,10 @@ void validate_quant_weight_view(const char* api, const WeightView& w, int N, int
     if (w.scale_data == nullptr) {
         throw std::runtime_error(std::string(api) + ": quant scale data is null");
     }
-    const bool is_nibble_packed =
-        w.dtype == DType::INT4_PACKED || w.dtype == DType::MXFP4_PACKED;
-    const std::size_t expected_weight_bytes = is_nibble_packed
+    const bool is_4bit_packed =
+        w.dtype == DType::INT4_PACKED || w.dtype == DType::MXFP4_PACKED ||
+        w.dtype == DType::MXFP4_MARLIN;
+    const std::size_t expected_weight_bytes = is_4bit_packed
         ? (static_cast<std::size_t>(N) * static_cast<std::size_t>(K) + 1) / 2
         : static_cast<std::size_t>(N) * static_cast<std::size_t>(K) *
               dtype_bytes(w.dtype);
@@ -1449,7 +1450,8 @@ void gemm_act_x_w(
             "-DPIE_CUDA_BUILD_MARLIN=ON to enable W4A16 GEMM.");
 #endif
     }
-    if (act_dtype == DType::BF16 && w.dtype == DType::MXFP4_PACKED &&
+    if (act_dtype == DType::BF16 &&
+        (w.dtype == DType::MXFP4_PACKED || w.dtype == DType::MXFP4_MARLIN) &&
         y_dtype == DType::BF16) {
         cudaStream_t stream = nullptr;
         cublasGetStream(handle, &stream);
@@ -1467,13 +1469,17 @@ void gemm_act_x_w(
 
         // Decide path: Marlin needs pre-repacked weights. Runtime FP4 quant
         // emits raw nibble-packed weights, so default to a dequant→bf16 GEMM
-        // fallback (correct but ~2× the memory pass of native). The env var
-        // PIE_MXFP4_GEMM=marlin opts into the native path when weights are
-        // known to be Marlin-repacked (e.g., V4 / GPT-OSS prepacked ckpts).
-        static const bool use_marlin = [] {
+        // fallback (correct but ~2× the memory pass of native). Call sites
+        // with Marlin-repacked weights use DType::MXFP4_MARLIN (via
+        // WeightView::mxfp4_marlin). The env var PIE_MXFP4_GEMM=marlin opts
+        // into the native path when MXFP4_PACKED views are known to be
+        // Marlin-repacked (e.g., V4 / GPT-OSS prepacked ckpts).
+        static const bool use_marlin_env = [] {
             const char* v = std::getenv("PIE_MXFP4_GEMM");
             return (v != nullptr && std::string(v) == "marlin");
         }();
+        const bool use_marlin =
+            w.dtype == DType::MXFP4_MARLIN || use_marlin_env;
 
         if (use_marlin) {
 #ifdef PIE_CUDA_HAS_MARLIN

--- a/driver/cuda/src/ops/gemm.hpp
+++ b/driver/cuda/src/ops/gemm.hpp
@@ -103,7 +103,7 @@ struct WeightView {
     {
         WeightView v;
         v.data = weight.data();
-        v.dtype = DType::MXFP4_PACKED;
+        v.dtype = DType::MXFP4_MARLIN;
         v.nbytes = weight.nbytes();
         v.scale_data = scale.data();
         v.scale_dtype = DType::UINT8;

--- a/driver/cuda/src/tensor.hpp
+++ b/driver/cuda/src/tensor.hpp
@@ -38,10 +38,14 @@ enum class DType : std::uint8_t {
     // reads `(M, N, K)` from the QuantMeta companion (group_size /
     // channel_axis) plus the tensor shape rather than from the dtype.
     INT4_PACKED = 9,
-    // Marlin-packed MXFP4 (E2M1 values with E8M0 block scales). The tensor
-    // stores the packed FP4 bytes in Marlin's tile layout; a QuantMeta /
-    // WeightView side tensor carries the E8M0 per-32-K scales.
+    // Raw HF / OCP MXFP4 nibble packs (E2M1 values + E8M0 block scales).
+    // GEMM dequants to BF16 unless an explicit Marlin path is selected.
     MXFP4_PACKED = 10,
+    // Marlin tile-packed MXFP4 (same FE2M1/E8M0 values, Marlin W4 layout).
+    // Produced by load-time Repack / expert-pack builders; GEMM runs Marlin
+    // W4A16 directly. Distinct from MXFP4_PACKED — same storage width, different
+    // byte layout.
+    MXFP4_MARLIN = 11,
 };
 
 inline std::size_t dtype_bytes(DType d) {
@@ -57,6 +61,7 @@ inline std::size_t dtype_bytes(DType d) {
         case DType::FP8_E5M2: return 1;
         case DType::INT4_PACKED: return 1;  // 1 byte holds 2 nibbles
         case DType::MXFP4_PACKED: return 1;
+        case DType::MXFP4_MARLIN: return 1;
     }
     throw std::runtime_error("unknown dtype");
 }
@@ -74,6 +79,7 @@ inline const char* dtype_name(DType d) {
         case DType::FP8_E5M2: return "fp8e5m2";
         case DType::INT4_PACKED: return "int4-packed";
         case DType::MXFP4_PACKED: return "mxfp4-packed";
+        case DType::MXFP4_MARLIN: return "mxfp4-marlin";
     }
     return "?";
 }

--- a/driver/weight_loader/cbindgen.toml
+++ b/driver/weight_loader/cbindgen.toml
@@ -14,6 +14,7 @@ include = [
   "PieLoaderEncodingKind",
   "PieLoaderQuantScheme",
   "PieLoaderMxfp4MoePolicy",
+  "PieLoaderExpertPackKind",
   "PieLoaderSemanticRole",
   "PieLoaderStorageInstrKind",
   "PieLoaderTileMapKind",

--- a/driver/weight_loader/include/weight_loader.h
+++ b/driver/weight_loader/include/weight_loader.h
@@ -14,7 +14,7 @@
 
 namespace pie_weight_loader {
 
-constexpr static const uint32_t STORAGE_PROGRAM_VERSION = 4;
+constexpr static const uint32_t STORAGE_PROGRAM_VERSION = 5;
 
 enum class PieLoaderBackendKind {
   Cuda = 0,

--- a/driver/weight_loader/include/weight_loader.h
+++ b/driver/weight_loader/include/weight_loader.h
@@ -48,6 +48,12 @@ enum class PieLoaderEncodingKind {
   Quant = 1,
 };
 
+enum class PieLoaderExpertPackKind {
+  None = 0,
+  GptOssNativeMarlin = 1,
+  GptOssEagerBf16 = 2,
+};
+
 enum class PieLoaderMxfp4MoePolicy {
   RoutedDecode = 0,
   NativeGemm = 1,
@@ -454,6 +460,7 @@ struct PieLoaderStreamPlanView {
   uint64_t slot_bytes;
   PieLoaderU64Slice section_offsets;
   PieLoaderU64Slice section_bytes;
+  PieLoaderExpertPackKind pack_kind;
 };
 
 struct PieLoaderStorageProgramView {

--- a/driver/weight_loader/spec/storage_program.md
+++ b/driver/weight_loader/spec/storage_program.md
@@ -33,19 +33,28 @@ They are described by `StorageProgram.stream`:
   `schedule`. These are `ExtentWrite`s whose `dest.offset` is relative to a
   cache-slot base and whose `dest.buffer` is the sentinel `BufferId(u32::MAX)`.
   Section count is arch-defined (DeepSeek-V4: 6; GPT-OSS RoutedDequant: 4;
-  Mixtral: 3 BF16 `w1/w2/w3.weight`; Qwen3-MoE: 3 named `gate/up/down_proj`;
-  Qwen3.5-MoE: 2 fused `gate_up`/`down`).
+  GPT-OSS Native Marlin pack: 6; GPT-OSS Eager BF16 pack: 3 `gate/up/down`;
+  Mixtral: 3 BF16 `w1/w2/w3.weight`;
+  Qwen3-MoE: 3 named `gate/up/down_proj`; Qwen3.5-MoE: 2 fused `gate_up`/`down`).
 - `stream.bindings`: flat `[num_layers × num_experts × sections]` source
   extents that instantiate the template at decode time. An arch plugin may
   map one checkpoint tensor per cell (DSv4, Mixtral, Qwen3-MoE) or slice
-  fused `[E, …]` banks into per-expert extents (GPT-OSS, Qwen3.5-MoE).
+  fused `[E, …]` banks into per-expert extents (GPT-OSS RoutedDequant,
+  Qwen3.5-MoE). GPT-OSS native / eager-BF16 bindings describe pack-relative
+  offsets; the driver builds the pack with bounded staging and remaps
+  `stream.files` to the pack path.
 - `stream.files` / `section_offsets` / `section_bytes` / `slot_bytes`: layout
   the driver's expert stream cache needs to open shards and size the slab.
+- `stream.pack_kind`: selects the driver's offline pack builder (`None`,
+  GPT-OSS Native Marlin, GPT-OSS Eager BF16); set by the same arch selectors
+  that choose section layout.
 
 Boot execution runs `schedule` only. On a cache miss the driver executes the
 template into `slot_base` with sources taken from `bindings` for that
 `(layer, expert)` — deferred loader execution, not a parallel I/O path.
 
 Supported arches today: `deepseek_v4`, `gpt_oss`, `mixtral`, `qwen3_moe`,
-`qwen3_5_moe` (plain ExtentWrite; GPT-OSS RoutedDequant only — biases stay
-resident; Qwen shared expert / router stay resident).
+`qwen3_5_moe` (plain ExtentWrite; GPT-OSS RoutedDequant streams HF packs;
+GPT-OSS native streams a Marlin expert pack; GPT-OSS eager_bf16 streams a
+BF16 expert pack; biases stay resident; Qwen shared expert / router stay
+resident).

--- a/driver/weight_loader/src/abi.rs
+++ b/driver/weight_loader/src/abi.rs
@@ -472,10 +472,10 @@ struct ArchProfile {
     /// llama-family rules; archs with a different expert/attention layout (e.g.
     /// DeepSeek-V4's native `.ffn.experts.w*`) register their own function.
     shard_axis_fn: fn(&str) -> Option<Axis>,
-    /// SSD expert streaming: arch-specific section layout + name parser for the
-    /// deferred [`crate::storage::StreamPlan`]. `None` = arch does not support
-    /// `stream_routed_experts`.
-    stream: Option<crate::stream::StreamArchDesc>,
+    /// SSD expert streaming: resolve the arch stream recipe under `target`
+    /// (policy-dependent arches like GPT-OSS native vs routed). `None` = arch
+    /// does not support `stream_routed_experts`.
+    stream_for: Option<fn(&crate::storage::StorageTarget) -> Option<crate::stream::StreamArchDesc>>,
 }
 
 const GENERIC_ARCH: ArchProfile = ArchProfile {
@@ -491,7 +491,7 @@ const GENERIC_ARCH: ArchProfile = ArchProfile {
     skip_dense_qkv_fusion: false,
     stack_per_expert_moe: false,
     shard_axis_fn: llama_like_shard_axis,
-    stream: None,
+    stream_for: None,
 };
 
 /// (matching model_type strings, profile). Matched case-insensitively. The
@@ -517,7 +517,7 @@ const ARCH_PROFILES: &[(&[&str], ArchProfile)] = &[
         &["deepseek_v4"],
         ArchProfile {
             shard_axis_fn: dsv4_shard_axis,
-            stream: Some(crate::stream_arch::DSV4_STREAM_ARCH),
+            stream_for: Some(crate::stream_arch::select_dsv4),
             ..GENERIC_ARCH
         },
     ),
@@ -533,7 +533,7 @@ const ARCH_PROFILES: &[(&[&str], ArchProfile)] = &[
             // bind_gpt_oss reads separate q/k/v (and biases); the generic
             // dense QKV join would consume them into qkv_proj.fused.weight.
             skip_dense_qkv_fusion: true,
-            stream: Some(crate::stream_arch::GPT_OSS_STREAM_ARCH),
+            stream_for: Some(crate::stream_arch::select_gpt_oss),
             ..GENERIC_ARCH
         },
     ),
@@ -543,7 +543,7 @@ const ARCH_PROFILES: &[(&[&str], ArchProfile)] = &[
         &["mixtral"],
         ArchProfile {
             skip_dense_qkv_fusion: true,
-            stream: Some(crate::stream_arch::MIXTRAL_STREAM_ARCH),
+            stream_for: Some(crate::stream_arch::select_mixtral),
             ..GENERIC_ARCH
         },
     ),
@@ -564,7 +564,7 @@ const ARCH_PROFILES: &[(&[&str], ArchProfile)] = &[
             bf16_runtime_quant: true,
             skip_dense_qkv_fusion: true,
             stack_per_expert_moe: true,
-            stream: Some(crate::stream_arch::QWEN3_MOE_STREAM_ARCH),
+            stream_for: Some(crate::stream_arch::select_qwen3_moe),
             ..GENERIC_ARCH
         },
     ),
@@ -575,7 +575,7 @@ const ARCH_PROFILES: &[(&[&str], ArchProfile)] = &[
             bf16_runtime_quant: true,
             skip_dense_qkv_fusion: true,
             stack_per_expert_moe: true,
-            stream: Some(crate::stream_arch::QWEN35_MOE_STREAM_ARCH),
+            stream_for: Some(crate::stream_arch::select_qwen35_moe),
             ..GENERIC_ARCH
         },
     ),
@@ -594,9 +594,14 @@ fn arch_profile(model_type: &str) -> ArchProfile {
     GENERIC_ARCH
 }
 
-/// Stream-plan recipe for `model_type`, if the arch supports SSD expert streaming.
-pub(crate) fn stream_arch_for(model_type: &str) -> Option<crate::stream::StreamArchDesc> {
-    arch_profile(model_type).stream
+/// Stream-plan recipe for `model_type` + target policy.
+pub(crate) fn stream_arch_for(
+    model_type: &str,
+    target: &crate::storage::StorageTarget,
+) -> Option<crate::stream::StreamArchDesc> {
+    arch_profile(model_type)
+        .stream_for
+        .and_then(|select| select(target))
 }
 
 impl DefaultAbiBuilder<'_> {
@@ -641,7 +646,7 @@ impl DefaultAbiBuilder<'_> {
         if !self.target.stream_routed_experts {
             return Ok(());
         }
-        let Some(arch) = self.profile().stream else {
+        let Some(arch) = stream_arch_for(&self.cfg.model_type, &self.target) else {
             return Err(CompileError::InvalidInput(format!(
                 "stream_routed_experts is not supported for model_type='{}' \
                  (supported: deepseek_v4, gpt_oss, mixtral, qwen3_moe, qwen3_5_moe)",
@@ -655,20 +660,22 @@ impl DefaultAbiBuilder<'_> {
                     .to_string(),
             ));
         }
-        // GPT-OSS streaming copies packed MXFP4 extents only (RoutedDequant).
-        // Native Marlin / eager BF16 need different stream templates.
+        // GPT-OSS: RoutedDequant streams HF MXFP4 packs; NativeGemm streams a
+        // Marlin-layout pack; EagerBf16 streams an offline BF16 pack (bounded
+        // dequant staging). All keep biases resident.
         if self.profile().gpt_oss_mxfp4_groups {
             match self.target.mxfp4_moe {
-                crate::types::Mxfp4MoePolicy::NativeGemm
-                | crate::types::Mxfp4MoePolicy::EagerBf16 => {
-                    return Err(CompileError::InvalidInput(
-                        "stream_routed_experts for gpt_oss requires \
-                         mxfp4_moe=auto|routed_dequant (plain ExtentWrite of \
-                         packed MXFP4); native and eager_bf16 are unsupported"
-                            .to_string(),
-                    ));
+                crate::types::Mxfp4MoePolicy::NativeGemm => {
+                    if !self.target.native_mxfp4_moe {
+                        return Err(CompileError::InvalidInput(
+                            "stream_routed_experts with mxfp4_moe=native requires \
+                             a target that supports native MXFP4 MoE"
+                                .to_string(),
+                        ));
+                    }
                 }
-                crate::types::Mxfp4MoePolicy::RoutedDecode => {}
+                crate::types::Mxfp4MoePolicy::RoutedDecode
+                | crate::types::Mxfp4MoePolicy::EagerBf16 => {}
             }
         }
         let mut skipped = 0usize;
@@ -1655,7 +1662,13 @@ impl DefaultAbiBuilder<'_> {
                 continue;
             };
             if native {
-                self.add_gpt_oss_native_mxfp4_group(block, scale, bias, base)?;
+                if self.target.stream_routed_experts {
+                    // Marlin weights live in the offline expert pack; keep
+                    // biases resident for bind-time deinterleave.
+                    self.push_direct(bias, format!("{base}.bias"), None);
+                } else {
+                    self.add_gpt_oss_native_mxfp4_group(block, scale, bias, base)?;
+                }
             } else if self.target.stream_routed_experts
                 && crate::stream_arch::is_gpt_oss_streamed_expert_tensor(&block.name)
             {

--- a/driver/weight_loader/src/ffi_arena.rs
+++ b/driver/weight_loader/src/ffi_arena.rs
@@ -9,6 +9,7 @@ use crate::ffi_types::{
     PieLoaderStorageProgramView, PieLoaderStreamBindingSlice, PieLoaderStreamBindingView,
     PieLoaderStreamPlanView, PieLoaderStridedExtentView, PieLoaderTensorDeclSlice,
     PieLoaderTensorDeclView, PieLoaderTileMapKind, PieLoaderU32Slice, PieLoaderU64Slice,
+    PieLoaderExpertPackKind,
 };
 use crate::storage::{
     DestExtent, SourceExtent, StorageInstr, StorageProgram, StridedExtent, TileMapKind,
@@ -175,6 +176,17 @@ impl FfiArena {
                 section_bytes: PieLoaderU64Slice {
                     ptr: self.stream_section_bytes.as_ptr(),
                     len: self.stream_section_bytes.len(),
+                },
+                pack_kind: match program.stream.pack_kind {
+                    crate::storage::ExpertPackKind::None => {
+                        PieLoaderExpertPackKind::None
+                    }
+                    crate::storage::ExpertPackKind::GptOssNativeMarlin => {
+                        PieLoaderExpertPackKind::GptOssNativeMarlin
+                    }
+                    crate::storage::ExpertPackKind::GptOssEagerBf16 => {
+                        PieLoaderExpertPackKind::GptOssEagerBf16
+                    }
                 },
             },
         }

--- a/driver/weight_loader/src/ffi_types.rs
+++ b/driver/weight_loader/src/ffi_types.rs
@@ -602,6 +602,15 @@ pub struct PieLoaderU64Slice {
     pub len: usize,
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum PieLoaderExpertPackKind {
+    #[default]
+    None = 0,
+    GptOssNativeMarlin = 1,
+    GptOssEagerBf16 = 2,
+}
+
 /// Deferred expert-load plan exposed to the C++ stream cache.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -615,6 +624,7 @@ pub struct PieLoaderStreamPlanView {
     pub slot_bytes: u64,
     pub section_offsets: PieLoaderU64Slice,
     pub section_bytes: PieLoaderU64Slice,
+    pub pack_kind: PieLoaderExpertPackKind,
 }
 
 #[repr(C)]

--- a/driver/weight_loader/src/storage.rs
+++ b/driver/weight_loader/src/storage.rs
@@ -6,7 +6,7 @@ use crate::types::{
     TensorDecl, TensorId,
 };
 
-pub const STORAGE_PROGRAM_VERSION: u32 = 4;
+pub const STORAGE_PROGRAM_VERSION: u32 = 5;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MemoryPlan {

--- a/driver/weight_loader/src/storage.rs
+++ b/driver/weight_loader/src/storage.rs
@@ -177,6 +177,21 @@ pub enum StorageInstr {
     },
 }
 
+/// Offline expert-pack materialization requested by a stream recipe.
+///
+/// When non-[`Self::None`], the CUDA driver builds (or opens) a transformed
+/// host pack with bounded staging before paging sections through the expert
+/// stream cache. Plain ExtentWrite streams (HF packs / Mixtral BF16) leave
+/// this as `None`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[repr(u32)]
+pub enum ExpertPackKind {
+    #[default]
+    None = 0,
+    GptOssNativeMarlin = 1,
+    GptOssEagerBf16 = 2,
+}
+
 /// One deferred source extent for a streamed expert section.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StreamBinding {
@@ -208,6 +223,9 @@ pub struct StreamPlan {
     pub section_offsets: Vec<u64>,
     /// Per-section payload sizes (`len == sections_per_expert`).
     pub section_bytes: Vec<u64>,
+    /// Offline pack builder selected by the stream arch recipe.
+    #[serde(default)]
+    pub pack_kind: ExpertPackKind,
 }
 
 impl StreamPlan {

--- a/driver/weight_loader/src/storage_compiler.rs
+++ b/driver/weight_loader/src/storage_compiler.rs
@@ -38,7 +38,7 @@ pub fn compile_storage_program(
     let mut program = lower_layout_plan(metadata, &optimized.plan, target.clone())?;
     program.optimizer = optimized.report;
     if target.stream_routed_experts {
-        let Some(arch) = crate::abi::stream_arch_for(&cfg.model_type) else {
+        let Some(arch) = crate::abi::stream_arch_for(&cfg.model_type, &target) else {
             return Err(CompileError::InvalidInput(format!(
                 "stream_routed_experts is not supported for model_type='{}' \
                  (supported: deepseek_v4, gpt_oss, mixtral, qwen3_moe, qwen3_5_moe)",

--- a/driver/weight_loader/src/stream.rs
+++ b/driver/weight_loader/src/stream.rs
@@ -8,13 +8,14 @@
 //! with a different destination binding.
 //!
 //! Arch-specific naming (which tensors stream, section order, binding grid)
-//! lives in [`crate::stream_arch`] plugins, registered per model on `ArchProfile`.
+//! lives in [`crate::stream_arch`] plugins; each arch registers a `select_*`
+//! resolver on `ArchProfile` in [`crate::abi`].
 
 use crate::error::CompileError;
 use crate::source::{CheckpointMetadata, RawTensor};
 use crate::storage::{
-    DestExtent, DimSpec, SourceExtent, StorageInstr, StorageProgram, StreamBinding, StreamPlan,
-    StridedExtent,
+    DestExtent, DimSpec, ExpertPackKind, SourceExtent, StorageInstr, StorageProgram, StreamBinding,
+    StreamPlan, StridedExtent,
 };
 use crate::types::{BufferId, InstrId, TensorId};
 
@@ -38,6 +39,8 @@ pub struct StreamArchDesc {
         num_layers: u32,
         num_experts: u32,
     ) -> Result<Vec<StreamBinding>, CompileError>,
+    /// Offline pack builder for this recipe (`None` = plain ExtentWrite stream).
+    pub pack_kind: ExpertPackKind,
 }
 
 const SECTION_ALIGN: u64 = 256;
@@ -258,6 +261,7 @@ pub fn attach_stream_plan(
         slot_bytes,
         section_offsets,
         section_bytes,
+        pack_kind: arch.pack_kind,
     };
     Ok(())
 }
@@ -307,6 +311,7 @@ mod tests {
         sections: FAKE_SECTIONS,
         is_streamed: fake_is_streamed,
         collect_bindings: fake_collect,
+        pack_kind: ExpertPackKind::None,
     };
 
     #[test]

--- a/driver/weight_loader/src/stream_arch.rs
+++ b/driver/weight_loader/src/stream_arch.rs
@@ -1,13 +1,16 @@
 //! Arch-specific [`StreamArchDesc`] plugins for SSD expert streaming.
 //!
 //! Generic plan construction lives in [`crate::stream`]. This module owns
-//! checkpoint naming, section order, and binding-grid collectors, registered
-//! on each model's `ArchProfile` in [`crate::abi`].
+//! checkpoint naming, section order, and binding-grid collectors. Each
+//! streaming-capable arch registers a `select_*` resolver on `ArchProfile`
+//! in [`crate::abi`]; policy-dependent recipes (e.g. GPT-OSS native vs
+//! routed) live in those selectors — not as special cases in `abi`.
 
 use crate::error::CompileError;
 use crate::source::{CheckpointMetadata, RawTensor};
-use crate::storage::StreamBinding;
+use crate::storage::{ExpertPackKind, StorageTarget, StreamBinding};
 use crate::stream::{StreamArchDesc, collect_bindings_from_named_tensors};
+use crate::types::Mxfp4MoePolicy;
 
 /// Fixed DSv4 section order — must match `dsv4_expert_sections.hpp` in the
 /// CUDA driver (`w1/w2/w3` × weight/scale).
@@ -79,7 +82,12 @@ pub(crate) const DSV4_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
     sections: DSV4_EXPERT_SECTIONS,
     is_streamed: is_dsv4_routed_expert_tensor,
     collect_bindings: dsv4_collect_bindings,
+    pack_kind: ExpertPackKind::None,
 };
+
+pub(crate) fn select_dsv4(_target: &StorageTarget) -> Option<StreamArchDesc> {
+    Some(DSV4_STREAM_ARCH)
+}
 
 /// Fixed GPT-OSS section order — must match `gpt_oss_expert_sections.hpp`.
 /// Biases stay resident and are not part of the stream plan.
@@ -186,6 +194,249 @@ pub(crate) const GPT_OSS_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
     sections: GPT_OSS_EXPERT_SECTIONS,
     is_streamed: is_gpt_oss_streamed_expert_tensor,
     collect_bindings: gpt_oss_collect_bindings,
+    pack_kind: ExpertPackKind::None,
+};
+
+/// Native Marlin stream sections — must match `gpt_oss_expert_sections.hpp`.
+/// Built offline into an expert pack; biases stay resident.
+pub const GPT_OSS_NATIVE_EXPERT_SECTIONS: &[&str] = &[
+    "gate.weight",
+    "gate.scale",
+    "up.weight",
+    "up.scale",
+    "down.weight",
+    "down.scale",
+];
+
+fn align_up_u64(v: u64, a: u64) -> u64 {
+    (v + a - 1) / a * a
+}
+
+/// Marlin per-expert section byte sizes from GPT-OSS fused HF bank shapes.
+pub(crate) fn gpt_oss_native_section_bytes(
+    gate_up_blocks: &RawTensor,
+    down_blocks: &RawTensor,
+) -> Result<[u64; 6], CompileError> {
+    if gate_up_blocks.shape.len() != 4 || down_blocks.shape.len() != 4 {
+        return Err(CompileError::InvalidInput(
+            "stream_routed_experts: GPT-OSS native stream expects 4-D \
+             gate_up/down _blocks tensors"
+                .to_string(),
+        ));
+    }
+    let fused_rows = gate_up_blocks.shape[1] as u64;
+    let gu_groups = gate_up_blocks.shape[2] as u64;
+    let gu_lanes = gate_up_blocks.shape[3] as u64;
+    if fused_rows % 2 != 0 || gu_lanes != 16 {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: GPT-OSS native gate_up expected \
+             [E, 2I, H/32, 16], got {:?}",
+            gate_up_blocks.shape
+        )));
+    }
+    let intermediate = fused_rows / 2;
+    let intermediate_native = align_up_u64(intermediate, 128);
+    let hidden = gu_groups * 32;
+    let down_hidden = down_blocks.shape[1] as u64;
+    let down_groups = down_blocks.shape[2] as u64;
+    let down_lanes = down_blocks.shape[3] as u64;
+    if down_lanes != 16 || down_hidden != hidden || down_groups * 32 != intermediate {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: GPT-OSS native down shape mismatch \
+             (gate_up {:?}, down {:?})",
+            gate_up_blocks.shape, down_blocks.shape
+        )));
+    }
+    // MXFP4 nibble packing: rows * cols / 2 bytes. Scales: rows * groups.
+    let gate_w = intermediate_native * hidden / 2;
+    let gate_s = intermediate_native * gu_groups;
+    let down_w = hidden * intermediate_native / 2;
+    let down_s = hidden * (intermediate_native / 32);
+    Ok([gate_w, gate_s, gate_w, gate_s, down_w, down_s])
+}
+
+fn gpt_oss_native_collect_bindings(
+    metadata: &CheckpointMetadata,
+    num_layers: u32,
+    num_experts: u32,
+) -> Result<Vec<StreamBinding>, CompileError> {
+    let e = num_experts as u64;
+    if e == 0 {
+        return Err(CompileError::InvalidInput(
+            "stream_routed_experts: GPT-OSS num_experts must be > 0".to_string(),
+        ));
+    }
+    // Pack layout is a single virtual file; C++ remaps path after pack build.
+    // Offsets are deterministic: (layer * E + expert) * slot + section_offset.
+    const SECTION_ALIGN: u64 = 256;
+    let mut bindings = Vec::with_capacity(
+        (num_layers as usize) * (num_experts as usize) * GPT_OSS_NATIVE_EXPERT_SECTIONS.len(),
+    );
+    let mut section_bytes: Option<[u64; 6]> = None;
+    let mut section_offsets = [0u64; 6];
+    let mut slot_bytes = 0u64;
+    for layer in 0..num_layers {
+        let prefix = format!("model.layers.{layer}.mlp.experts.");
+        let gate_up_w = gpt_oss_find_tensor(metadata, &format!("{prefix}gate_up_proj_blocks"))?;
+        let down_w = gpt_oss_find_tensor(metadata, &format!("{prefix}down_proj_blocks"))?;
+        // Still require scales to exist (consumed / validated by ABI skip).
+        let _ = gpt_oss_find_tensor(metadata, &format!("{prefix}gate_up_proj_scales"))?;
+        let _ = gpt_oss_find_tensor(metadata, &format!("{prefix}down_proj_scales"))?;
+        let bytes = gpt_oss_native_section_bytes(gate_up_w, down_w)?;
+        if let Some(prev) = section_bytes {
+            if prev != bytes {
+                return Err(CompileError::InvalidInput(format!(
+                    "stream_routed_experts: GPT-OSS native section sizes differ \
+                     across layers (layer {layer})"
+                )));
+            }
+        } else {
+            let mut off = 0u64;
+            for s in 0..6 {
+                section_offsets[s] = off;
+                off = align_up_u64(off + bytes[s], SECTION_ALIGN);
+            }
+            slot_bytes = off;
+            section_bytes = Some(bytes);
+        }
+        for expert in 0..e {
+            let base = (layer as u64 * e + expert) * slot_bytes;
+            for s in 0..6 {
+                bindings.push(StreamBinding {
+                    file_id: crate::types::FileId(0),
+                    file_offset: base + section_offsets[s],
+                    span_bytes: bytes[s],
+                });
+            }
+        }
+    }
+    Ok(bindings)
+}
+
+pub(crate) const GPT_OSS_NATIVE_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
+    sections: GPT_OSS_NATIVE_EXPERT_SECTIONS,
+    // Same HF tensors are excluded from the resident schedule.
+    is_streamed: is_gpt_oss_streamed_expert_tensor,
+    collect_bindings: gpt_oss_native_collect_bindings,
+    pack_kind: ExpertPackKind::GptOssNativeMarlin,
+};
+
+/// GPT-OSS stream recipe depends on `mxfp4_moe`: HF packs (routed_dequant),
+/// Marlin pack (native), or offline BF16 pack (eager_bf16).
+pub(crate) fn select_gpt_oss(target: &StorageTarget) -> Option<StreamArchDesc> {
+    match target.mxfp4_moe {
+        Mxfp4MoePolicy::NativeGemm => Some(GPT_OSS_NATIVE_STREAM_ARCH),
+        Mxfp4MoePolicy::EagerBf16 => Some(GPT_OSS_EAGER_BF16_STREAM_ARCH),
+        Mxfp4MoePolicy::RoutedDecode => Some(GPT_OSS_STREAM_ARCH),
+    }
+}
+
+/// Eager-BF16 stream sections — offline dequant pack; biases stay resident.
+/// Must match `gpt_oss_expert_sections.hpp` BF16 helpers.
+pub const GPT_OSS_EAGER_BF16_EXPERT_SECTIONS: &[&str] =
+    &["gate.weight", "up.weight", "down.weight"];
+
+fn gpt_oss_eager_bf16_section_bytes(
+    gate_up_blocks: &RawTensor,
+    down_blocks: &RawTensor,
+) -> Result<[u64; 3], CompileError> {
+    if gate_up_blocks.shape.len() != 4 || down_blocks.shape.len() != 4 {
+        return Err(CompileError::InvalidInput(
+            "stream_routed_experts: GPT-OSS eager BF16 stream expects 4-D \
+             gate_up/down _blocks tensors"
+                .to_string(),
+        ));
+    }
+    let fused_rows = gate_up_blocks.shape[1] as u64;
+    let gu_groups = gate_up_blocks.shape[2] as u64;
+    let gu_lanes = gate_up_blocks.shape[3] as u64;
+    if fused_rows % 2 != 0 || gu_lanes != 16 {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: GPT-OSS eager BF16 gate_up expected \
+             [E, 2I, H/32, 16], got {:?}",
+            gate_up_blocks.shape
+        )));
+    }
+    let intermediate = fused_rows / 2;
+    let hidden = gu_groups * 32;
+    let down_hidden = down_blocks.shape[1] as u64;
+    let down_groups = down_blocks.shape[2] as u64;
+    let down_lanes = down_blocks.shape[3] as u64;
+    if down_lanes != 16 || down_hidden != hidden || down_groups * 32 != intermediate {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: GPT-OSS eager BF16 down shape mismatch \
+             (gate_up {:?}, down {:?})",
+            gate_up_blocks.shape, down_blocks.shape
+        )));
+    }
+    // BF16: rows * cols * 2.
+    let gate = intermediate * hidden * 2;
+    let down = hidden * intermediate * 2;
+    Ok([gate, gate, down])
+}
+
+fn gpt_oss_eager_bf16_collect_bindings(
+    metadata: &CheckpointMetadata,
+    num_layers: u32,
+    num_experts: u32,
+) -> Result<Vec<StreamBinding>, CompileError> {
+    let e = num_experts as u64;
+    if e == 0 {
+        return Err(CompileError::InvalidInput(
+            "stream_routed_experts: GPT-OSS num_experts must be > 0".to_string(),
+        ));
+    }
+    const SECTION_ALIGN: u64 = 256;
+    let mut bindings = Vec::with_capacity(
+        (num_layers as usize)
+            * (num_experts as usize)
+            * GPT_OSS_EAGER_BF16_EXPERT_SECTIONS.len(),
+    );
+    let mut section_bytes: Option<[u64; 3]> = None;
+    let mut section_offsets = [0u64; 3];
+    let mut slot_bytes = 0u64;
+    for layer in 0..num_layers {
+        let prefix = format!("model.layers.{layer}.mlp.experts.");
+        let gate_up_w = gpt_oss_find_tensor(metadata, &format!("{prefix}gate_up_proj_blocks"))?;
+        let down_w = gpt_oss_find_tensor(metadata, &format!("{prefix}down_proj_blocks"))?;
+        let _ = gpt_oss_find_tensor(metadata, &format!("{prefix}gate_up_proj_scales"))?;
+        let _ = gpt_oss_find_tensor(metadata, &format!("{prefix}down_proj_scales"))?;
+        let bytes = gpt_oss_eager_bf16_section_bytes(gate_up_w, down_w)?;
+        if let Some(prev) = section_bytes {
+            if prev != bytes {
+                return Err(CompileError::InvalidInput(format!(
+                    "stream_routed_experts: GPT-OSS eager BF16 section sizes \
+                     differ across layers (layer {layer})"
+                )));
+            }
+        } else {
+            let mut off = 0u64;
+            for s in 0..3 {
+                section_offsets[s] = off;
+                off = align_up_u64(off + bytes[s], SECTION_ALIGN);
+            }
+            slot_bytes = off;
+            section_bytes = Some(bytes);
+        }
+        for expert in 0..e {
+            let base = (layer as u64 * e + expert) * slot_bytes;
+            for s in 0..3 {
+                bindings.push(StreamBinding {
+                    file_id: crate::types::FileId(0),
+                    file_offset: base + section_offsets[s],
+                    span_bytes: bytes[s],
+                });
+            }
+        }
+    }
+    Ok(bindings)
+}
+
+pub(crate) const GPT_OSS_EAGER_BF16_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
+    sections: GPT_OSS_EAGER_BF16_EXPERT_SECTIONS,
+    is_streamed: is_gpt_oss_streamed_expert_tensor,
+    collect_bindings: gpt_oss_eager_bf16_collect_bindings,
+    pack_kind: ExpertPackKind::GptOssEagerBf16,
 };
 
 /// Fixed Mixtral section order — must match `mixtral_expert_sections.hpp`.
@@ -238,7 +489,12 @@ pub(crate) const MIXTRAL_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
     sections: MIXTRAL_EXPERT_SECTIONS,
     is_streamed: is_mixtral_routed_expert_tensor,
     collect_bindings: mixtral_collect_bindings,
+    pack_kind: ExpertPackKind::None,
 };
+
+pub(crate) fn select_mixtral(_target: &StorageTarget) -> Option<StreamArchDesc> {
+    Some(MIXTRAL_STREAM_ARCH)
+}
 
 /// Plain Qwen3-MoE per-expert BF16 weights — must match `qwen_moe_expert_sections.hpp`.
 pub const QWEN3_MOE_EXPERT_SECTIONS: &[&str] = &[
@@ -305,7 +561,12 @@ pub(crate) const QWEN3_MOE_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
     sections: QWEN3_MOE_EXPERT_SECTIONS,
     is_streamed: is_qwen3_moe_routed_expert_tensor,
     collect_bindings: qwen3_moe_collect_bindings,
+    pack_kind: ExpertPackKind::None,
 };
+
+pub(crate) fn select_qwen3_moe(_target: &StorageTarget) -> Option<StreamArchDesc> {
+    Some(QWEN3_MOE_STREAM_ARCH)
+}
 
 /// Qwen3.5/3.6-MoE fused BF16 banks — must match `qwen_moe_expert_sections.hpp`.
 pub const QWEN35_MOE_EXPERT_SECTIONS: &[&str] = &["gate_up.weight", "down.weight"];
@@ -400,7 +661,12 @@ pub(crate) const QWEN35_MOE_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
     sections: QWEN35_MOE_EXPERT_SECTIONS,
     is_streamed: is_qwen35_moe_streamed_expert_tensor,
     collect_bindings: qwen35_moe_collect_bindings,
+    pack_kind: ExpertPackKind::None,
 };
+
+pub(crate) fn select_qwen35_moe(_target: &StorageTarget) -> Option<StreamArchDesc> {
+    Some(QWEN35_MOE_STREAM_ARCH)
+}
 
 fn ends_with_any(value: &str, suffixes: &[&str]) -> bool {
     suffixes.iter().any(|suffix| value.ends_with(suffix))

--- a/driver/weight_loader/tests/storage_compiler.rs
+++ b/driver/weight_loader/tests/storage_compiler.rs
@@ -1571,6 +1571,10 @@ fn gpt_oss_stream_routed_experts_fused_plan() {
     assert_eq!(streamed.stream.sections_per_expert, 4);
     assert_eq!(streamed.stream.template.len(), 4);
     assert_eq!(streamed.stream.bindings.len(), 1 * 2 * 4);
+    assert_eq!(
+        streamed.stream.pack_kind,
+        pie_weight_loader::storage::ExpertPackKind::None
+    );
     // Per-expert slices: gate_up weight 100, scale 20, down weight 50, scale 10.
     assert_eq!(streamed.stream.section_bytes, vec![100, 20, 50, 10]);
     assert_eq!(streamed.stream.bindings[0].span_bytes, 100);
@@ -1581,25 +1585,183 @@ fn gpt_oss_stream_routed_experts_fused_plan() {
 }
 
 #[test]
-fn gpt_oss_stream_rejects_native_mxfp4() {
-    // Enough of a streamed tensor for skip_streamed to fire before the policy check.
+fn gpt_oss_eager_bf16_stream_plan_section_bytes() {
+    // E=2, I=128, H=64 → gate/up: 128*64*2=16384; down: 64*128*2=16384.
+    let mut offset = 0u64;
+    let mut tensors = Vec::new();
+    let mut push = |id: u32, name: &str, shape: Vec<i64>, span: u64| {
+        tensors.push(RawTensor {
+            id: TensorId(id),
+            name: name.to_string(),
+            file_id: FileId(0),
+            file_offset: offset,
+            span_bytes: span,
+            shape,
+            encoding: Encoding::Raw(DType::U8),
+            layout: Layout::dense(1),
+        });
+        offset += span;
+    };
+    let mut id = 0u32;
+    let mut next = || {
+        let v = id;
+        id += 1;
+        v
+    };
+    push(next(), "model.embed_tokens.weight", vec![64], 64);
+    push(
+        next(),
+        "model.layers.0.mlp.experts.gate_up_proj_blocks",
+        vec![2, 256, 2, 16],
+        16384,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.gate_up_proj_scales",
+        vec![2, 256, 2],
+        1024,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.gate_up_proj_bias",
+        vec![2, 256],
+        1024,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.down_proj_blocks",
+        vec![2, 64, 4, 16],
+        8192,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.down_proj_scales",
+        vec![2, 64, 4],
+        512,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.down_proj_bias",
+        vec![2, 64],
+        256,
+    );
     let meta = CheckpointMetadata {
         files: vec![CheckpointFile {
             id: FileId(0),
             path: "gpt-oss.safetensors".into(),
-            size_bytes: 8,
+            size_bytes: offset,
             format: CheckpointFormat::Safetensors,
         }],
-        tensors: vec![RawTensor {
-            id: TensorId(0),
-            name: "model.layers.0.mlp.experts.gate_up_proj_blocks".into(),
+        tensors,
+    };
+    let cfg = pie_weight_loader::config::ModelConfig {
+        model_type: "gpt_oss".to_string(),
+        num_hidden_layers: 1,
+        num_experts: 2,
+        num_experts_per_tok: 2,
+        ..pie_weight_loader::config::ModelConfig::default()
+    };
+    let target = StorageTarget {
+        backend: BackendKind::Cuda,
+        stream_routed_experts: true,
+        mxfp4_moe: pie_weight_loader::types::Mxfp4MoePolicy::EagerBf16,
+        ..StorageTarget::default()
+    };
+    let abi =
+        pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target).unwrap();
+    let streamed = compile_storage_program(&meta, &cfg, &abi, target).unwrap();
+    assert_eq!(streamed.stream.sections_per_expert, 3);
+    assert_eq!(
+        streamed.stream.section_bytes,
+        vec![16384, 16384, 16384]
+    );
+    assert_eq!(streamed.stream.bindings.len(), 1 * 2 * 3);
+    assert_eq!(
+        streamed.stream.pack_kind,
+        pie_weight_loader::storage::ExpertPackKind::GptOssEagerBf16
+    );
+    assert!(
+        streamed
+            .tensors
+            .iter()
+            .any(|t| t.name.contains("gate_up_proj.bias")),
+        "biases must remain resident"
+    );
+}
+
+#[test]
+fn gpt_oss_native_stream_plan_section_bytes() {
+    // E=2, I=128, H=64 → I_native=128, groups=2.
+    // gate/up weight: 128*64/2=4096; scale: 128*2=256;
+    // down weight: 64*128/2=4096; scale: 64*(128/32)=256.
+    let mut offset = 0u64;
+    let mut tensors = Vec::new();
+    let mut push = |id: u32, name: &str, shape: Vec<i64>, span: u64| {
+        tensors.push(RawTensor {
+            id: TensorId(id),
+            name: name.to_string(),
             file_id: FileId(0),
-            file_offset: 0,
-            span_bytes: 8,
-            shape: vec![8],
+            file_offset: offset,
+            span_bytes: span,
+            shape,
             encoding: Encoding::Raw(DType::U8),
             layout: Layout::dense(1),
+        });
+        offset += span;
+    };
+    let mut id = 0u32;
+    let mut next = || {
+        let v = id;
+        id += 1;
+        v
+    };
+    push(next(), "model.embed_tokens.weight", vec![64], 64);
+    // gate_up [E=2, 2I=256, H/32=2, 16]; bytes per bank = 2*256*2*16 = 16384
+    push(
+        next(),
+        "model.layers.0.mlp.experts.gate_up_proj_blocks",
+        vec![2, 256, 2, 16],
+        16384,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.gate_up_proj_scales",
+        vec![2, 256, 2],
+        1024,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.gate_up_proj_bias",
+        vec![2, 256],
+        1024,
+    );
+    // down [E=2, H=64, I/32=4, 16]; bytes = 2*64*4*16 = 8192
+    push(
+        next(),
+        "model.layers.0.mlp.experts.down_proj_blocks",
+        vec![2, 64, 4, 16],
+        8192,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.down_proj_scales",
+        vec![2, 64, 4],
+        512,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.down_proj_bias",
+        vec![2, 64],
+        256,
+    );
+    let meta = CheckpointMetadata {
+        files: vec![CheckpointFile {
+            id: FileId(0),
+            path: "gpt-oss.safetensors".into(),
+            size_bytes: offset,
+            format: CheckpointFormat::Safetensors,
         }],
+        tensors,
     };
     let cfg = pie_weight_loader::config::ModelConfig {
         model_type: "gpt_oss".to_string(),
@@ -1615,12 +1777,33 @@ fn gpt_oss_stream_rejects_native_mxfp4() {
         native_mxfp4_moe: true,
         ..StorageTarget::default()
     };
-    let err = pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target)
-        .unwrap_err()
-        .to_string();
+    let abi =
+        pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target).unwrap();
+    let streamed = compile_storage_program(&meta, &cfg, &abi, target).unwrap();
+    assert_eq!(streamed.stream.sections_per_expert, 6);
+    assert_eq!(
+        streamed.stream.section_bytes,
+        vec![4096, 256, 4096, 256, 4096, 256]
+    );
+    assert_eq!(
+        streamed.stream.pack_kind,
+        pie_weight_loader::storage::ExpertPackKind::GptOssNativeMarlin
+    );
     assert!(
-        err.contains("routed_dequant") || err.contains("ExtentWrite"),
-        "unexpected error: {err}"
+        streamed
+            .tensors
+            .iter()
+            .any(|t| t.name.contains("gate_up_proj.bias")),
+        "biases must remain resident"
+    );
+    assert!(
+        !streamed
+            .tensors
+            .iter()
+            .any(|t| t.name.contains("gate_proj.weight")
+                || t.name.contains("gate_up_proj.weight")),
+        "native Marlin weights must not be resident; got: {:?}",
+        streamed.tensors.iter().map(|t| &t.name).collect::<Vec<_>>()
     );
 }
 


### PR DESCRIPTION
On a streamed MoE cache miss we would otherwise dequantize or Marlin-repack expert weights from the HF checkpoint every time. That repeats expensive GPU work and can spike VRAM if many experts are transformed at once.

Carry `pack_kind` on the stream plan so the driver builds Marlin or BF16 expert packs once, transforming and writing one expert at a time so peak GPU memory stays about a single expert, then pages those packs through the existing stream cache instead of keeping transformed MoE weights resident or re-transforming on every miss.

## Forecast
This pack-to-disk path is a building block for upcoming routed-expert streaming under TP: each rank will need its own TP-sharded expert pack on disk, which this mechanism is intended to support.

