### PR TITLE
fix(cuda): use thread_local CUDA scratch under in-process TP

### DIFF
--- a/driver/cuda/src/executor/executor.cpp
+++ b/driver/cuda/src/executor/executor.cpp
@@ -29,6 +29,7 @@
 #include "cuda_check.hpp"
 #include "device_buffer.hpp"
 #include "distributed.hpp"
+#include "tls_cuda_resource.hpp"
 #include "model/loaded_model.hpp"
 #include "kv_cache.hpp"
 #include "recurrent_state_cache.hpp"
@@ -1097,14 +1098,12 @@ int tensor_rows(const DeviceTensor& t) {
 
 std::int32_t* sampled_pinned_buf(std::size_t want_elems) {
     // Per-thread pinned scratch: TP ranks are separate threads in one process.
-    thread_local std::int32_t* buf = nullptr;
-    thread_local std::size_t buf_capacity = 0;
-    if (want_elems > buf_capacity) {
-        if (buf) cudaFreeHost(buf);
-        CUDA_CHECK(cudaMallocHost(&buf, want_elems * sizeof(std::int32_t)));
-        buf_capacity = want_elems;
+    // RAII frees on thread exit (raw thread_local pointers would leak).
+    thread_local TlsHostPinnedBuf<std::int32_t> scratch;
+    if (!scratch.ensure(want_elems)) {
+        throw std::runtime_error("sampled_pinned_buf: cudaMallocHost failed");
     }
-    return buf;
+    return scratch.ptr;
 }
 
 std::int32_t masked_argmax_bf16(

--- a/driver/cuda/src/executor/executor.cpp
+++ b/driver/cuda/src/executor/executor.cpp
@@ -1096,8 +1096,9 @@ int tensor_rows(const DeviceTensor& t) {
 }
 
 std::int32_t* sampled_pinned_buf(std::size_t want_elems) {
-    static std::int32_t* buf = nullptr;
-    static std::size_t buf_capacity = 0;
+    // Per-thread pinned scratch: TP ranks are separate threads in one process.
+    thread_local std::int32_t* buf = nullptr;
+    thread_local std::size_t buf_capacity = 0;
     if (want_elems > buf_capacity) {
         if (buf) cudaFreeHost(buf);
         CUDA_CHECK(cudaMallocHost(&buf, want_elems * sizeof(std::int32_t)));

--- a/driver/cuda/src/kernels/argmax.cu
+++ b/driver/cuda/src/kernels/argmax.cu
@@ -2,8 +2,12 @@
 
 #include <cstddef>
 #include <cstdlib>
+#include <stdexcept>
 
 #include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+#include "tls_cuda_resource.hpp"
 
 namespace pie_cuda_driver::kernels {
 
@@ -906,13 +910,10 @@ void launch_lm_head_gemv_argmax_int8(
     const std::size_t pairs_elems =
         static_cast<std::size_t>(num_blocks_x) * num_rows;
     // TP ranks are separate threads on different devices; process-wide
-    // static device pointers IMA across ranks.
-    thread_local std::uint64_t* s_partial_pairs = nullptr;
-    thread_local std::size_t s_pairs_cap = 0;
-    if (pairs_elems > s_pairs_cap) {
-        if (s_partial_pairs) cudaFree(s_partial_pairs);
-        cudaMalloc(&s_partial_pairs, pairs_elems * sizeof(std::uint64_t));
-        s_pairs_cap = pairs_elems;
+    // static device pointers IMA across ranks. RAII frees on thread exit.
+    thread_local pie_cuda_driver::TlsDeviceBuf<std::uint64_t> s_partial_pairs;
+    if (!s_partial_pairs.ensure(pairs_elems)) {
+        throw std::runtime_error("lm_head gemv-argmax: cudaMalloc partials failed");
     }
 
     dim3 grid(num_blocks_x, num_rows);
@@ -921,7 +922,7 @@ void launch_lm_head_gemv_argmax_int8(
         static_cast<const __nv_bfloat16*>(hidden_states),
         lm_head_weight,
         scale_inv,
-        s_partial_pairs,
+        s_partial_pairs.ptr,
         num_rows,
         hidden,
         vocab,
@@ -930,7 +931,7 @@ void launch_lm_head_gemv_argmax_int8(
     dim3 sel_block(128);
     dim3 sel_grid((num_rows + sel_block.x - 1) / sel_block.x);
     select_lm_head_argmax_pairs_kernel<<<sel_grid, sel_block, 0, stream>>>(
-        s_partial_pairs, token_ids, num_rows, num_blocks_x);
+        s_partial_pairs.ptr, token_ids, num_rows, num_blocks_x);
 }
 
 // ── BF16 variant of fused GEMV + argmax ──────────────────────────
@@ -1026,12 +1027,10 @@ void launch_lm_head_gemv_argmax_bf16(
 
     const std::size_t pairs_elems =
         static_cast<std::size_t>(num_blocks_x) * num_rows;
-    thread_local std::uint64_t* s_partial_pairs_bf16 = nullptr;
-    thread_local std::size_t s_pairs_cap_bf16 = 0;
-    if (pairs_elems > s_pairs_cap_bf16) {
-        if (s_partial_pairs_bf16) cudaFree(s_partial_pairs_bf16);
-        cudaMalloc(&s_partial_pairs_bf16, pairs_elems * sizeof(std::uint64_t));
-        s_pairs_cap_bf16 = pairs_elems;
+    thread_local pie_cuda_driver::TlsDeviceBuf<std::uint64_t> s_partial_pairs_bf16;
+    if (!s_partial_pairs_bf16.ensure(pairs_elems)) {
+        throw std::runtime_error(
+            "lm_head gemv-argmax bf16: cudaMalloc partials failed");
     }
 
     dim3 grid(num_blocks_x, num_rows);
@@ -1039,7 +1038,7 @@ void launch_lm_head_gemv_argmax_bf16(
     lm_head_gemv_argmax_bf16_kernel<<<grid, block, shmem_bytes, stream>>>(
         static_cast<const __nv_bfloat16*>(hidden_states),
         static_cast<const __nv_bfloat16*>(lm_head_weight),
-        s_partial_pairs_bf16,
+        s_partial_pairs_bf16.ptr,
         num_rows,
         hidden,
         vocab,
@@ -1048,7 +1047,7 @@ void launch_lm_head_gemv_argmax_bf16(
     dim3 sel_block(128);
     dim3 sel_grid((num_rows + sel_block.x - 1) / sel_block.x);
     select_lm_head_argmax_pairs_kernel<<<sel_grid, sel_block, 0, stream>>>(
-        s_partial_pairs_bf16, token_ids, num_rows, num_blocks_x);
+        s_partial_pairs_bf16.ptr, token_ids, num_rows, num_blocks_x);
 }
 
 void launch_argmax_fp32(

--- a/driver/cuda/src/kernels/argmax.cu
+++ b/driver/cuda/src/kernels/argmax.cu
@@ -905,8 +905,10 @@ void launch_lm_head_gemv_argmax_int8(
 
     const std::size_t pairs_elems =
         static_cast<std::size_t>(num_blocks_x) * num_rows;
-    static std::uint64_t* s_partial_pairs = nullptr;
-    static std::size_t s_pairs_cap = 0;
+    // TP ranks are separate threads on different devices; process-wide
+    // static device pointers IMA across ranks.
+    thread_local std::uint64_t* s_partial_pairs = nullptr;
+    thread_local std::size_t s_pairs_cap = 0;
     if (pairs_elems > s_pairs_cap) {
         if (s_partial_pairs) cudaFree(s_partial_pairs);
         cudaMalloc(&s_partial_pairs, pairs_elems * sizeof(std::uint64_t));
@@ -1024,8 +1026,8 @@ void launch_lm_head_gemv_argmax_bf16(
 
     const std::size_t pairs_elems =
         static_cast<std::size_t>(num_blocks_x) * num_rows;
-    static std::uint64_t* s_partial_pairs_bf16 = nullptr;
-    static std::size_t s_pairs_cap_bf16 = 0;
+    thread_local std::uint64_t* s_partial_pairs_bf16 = nullptr;
+    thread_local std::size_t s_pairs_cap_bf16 = 0;
     if (pairs_elems > s_pairs_cap_bf16) {
         if (s_partial_pairs_bf16) cudaFree(s_partial_pairs_bf16);
         cudaMalloc(&s_partial_pairs_bf16, pairs_elems * sizeof(std::uint64_t));

--- a/driver/cuda/src/model/qwen3_vl_vision_adapter.cpp
+++ b/driver/cuda/src/model/qwen3_vl_vision_adapter.cpp
@@ -14,6 +14,7 @@
 #include "attention_workspace.hpp"
 #include "ops/attention_flashinfer.hpp"
 #include "ops/gemm.hpp"
+#include "tls_cuda_resource.hpp"
 
 namespace pie_cuda_driver::model {
 
@@ -48,10 +49,21 @@ struct VisAttnRes {
     // Vision images in one batch are equal-sized, so this captures the shape.
     int sig_seqs = -1, sig_total = -1, sig_len0 = -1, sig_NH = -1, sig_HD = -1;
     std::uint32_t *qo_d = nullptr, *kvpi_d = nullptr, *kvidx_d = nullptr, *klpl_d = nullptr;
+    int device = -1;
     std::mutex mu;
+
+    ~VisAttnRes() { free_indices(); }
+
+    void free_indices() noexcept {
+        for (void* p : {(void*)qo_d, (void*)kvpi_d, (void*)kvidx_d, (void*)klpl_d}) {
+            tls_cuda_free_device(p, device);
+        }
+        qo_d = kvpi_d = kvidx_d = klpl_d = nullptr;
+    }
 };
 // Per-thread: TP ranks are separate threads on different GPUs; a process-wide
 // singleton would cudaMalloc the workspace/indices on the first rank's device.
+// Destructor frees index buffers; AttentionWorkspace is already RAII.
 VisAttnRes& vis_attn() { thread_local VisAttnRes v; return v; }
 constexpr int kVisPageSize = 16;  // image patch counts are multiples; flashinfer-friendly
 }  // namespace
@@ -69,6 +81,7 @@ void qwen3vl_vis_attn(const void* q, void* k, void* v, void* o,
     if (!st.ready) {
         st.ws = AttentionWorkspace::allocate();
         st.plan = ops::make_prefill_plan();
+        st.device = tls_cuda_current_device();
         st.ready = true;
     }
     // Build host indptr/index arrays for the multi-sequence paged layout.
@@ -86,8 +99,7 @@ void qwen3vl_vis_attn(const void* q, void* k, void* v, void* o,
     const bool changed = st.sig_seqs != num_seqs || st.sig_total != total ||
                          st.sig_len0 != len0 || st.sig_NH != NH || st.sig_HD != HEAD;
     if (changed) {
-        for (void* p : {(void*)st.qo_d, (void*)st.kvpi_d, (void*)st.kvidx_d, (void*)st.klpl_d})
-            if (p) cudaFree(p);
+        st.free_indices();
         std::vector<std::uint32_t> kvidx(total_pages);
         for (int i = 0; i < total_pages; ++i) kvidx[i] = (std::uint32_t)i;
         auto up = [&](std::uint32_t** d, const std::vector<std::uint32_t>& h) {
@@ -95,6 +107,7 @@ void qwen3vl_vis_attn(const void* q, void* k, void* v, void* o,
             cudaMemcpy(*d, h.data(), h.size() * sizeof(std::uint32_t), cudaMemcpyHostToDevice);
         };
         up(&st.qo_d, qo); up(&st.kvpi_d, kvpi); up(&st.kvidx_d, kvidx); up(&st.klpl_d, klpl);
+        if (st.device < 0) st.device = tls_cuda_current_device();
         ops::plan_attention_flashinfer_prefill_bf16(
             *st.plan, qo.data(), kvpi.data(), klpl.data(), /*total_tokens=*/total, num_seqs,
             NH, NH, HEAD, ps, st.ws, S, /*enable_cuda_graph=*/false, /*window_left=*/-1,

--- a/driver/cuda/src/model/qwen3_vl_vision_adapter.cpp
+++ b/driver/cuda/src/model/qwen3_vl_vision_adapter.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "attention_workspace.hpp"
+#include "cuda_check.hpp"
 #include "ops/attention_flashinfer.hpp"
 #include "ops/gemm.hpp"
 #include "tls_cuda_resource.hpp"
@@ -103,10 +104,17 @@ void qwen3vl_vis_attn(const void* q, void* k, void* v, void* o,
         std::vector<std::uint32_t> kvidx(total_pages);
         for (int i = 0; i < total_pages; ++i) kvidx[i] = (std::uint32_t)i;
         auto up = [&](std::uint32_t** d, const std::vector<std::uint32_t>& h) {
-            cudaMalloc(d, h.size() * sizeof(std::uint32_t));
-            cudaMemcpy(*d, h.data(), h.size() * sizeof(std::uint32_t), cudaMemcpyHostToDevice);
+            CUDA_CHECK(cudaMalloc(d, h.size() * sizeof(std::uint32_t)));
+            CUDA_CHECK(cudaMemcpy(*d, h.data(), h.size() * sizeof(std::uint32_t),
+                                 cudaMemcpyHostToDevice));
         };
-        up(&st.qo_d, qo); up(&st.kvpi_d, kvpi); up(&st.kvidx_d, kvidx); up(&st.klpl_d, klpl);
+        try {
+            up(&st.qo_d, qo); up(&st.kvpi_d, kvpi); up(&st.kvidx_d, kvidx); up(&st.klpl_d, klpl);
+        } catch (...) {
+            // Drop any partial uploads so destructor / next rebuild stay consistent.
+            st.free_indices();
+            throw;
+        }
         if (st.device < 0) st.device = tls_cuda_current_device();
         ops::plan_attention_flashinfer_prefill_bf16(
             *st.plan, qo.data(), kvpi.data(), klpl.data(), /*total_tokens=*/total, num_seqs,

--- a/driver/cuda/src/model/qwen3_vl_vision_adapter.cpp
+++ b/driver/cuda/src/model/qwen3_vl_vision_adapter.cpp
@@ -50,7 +50,9 @@ struct VisAttnRes {
     std::uint32_t *qo_d = nullptr, *kvpi_d = nullptr, *kvidx_d = nullptr, *klpl_d = nullptr;
     std::mutex mu;
 };
-VisAttnRes& vis_attn() { static VisAttnRes v; return v; }
+// Per-thread: TP ranks are separate threads on different GPUs; a process-wide
+// singleton would cudaMalloc the workspace/indices on the first rank's device.
+VisAttnRes& vis_attn() { thread_local VisAttnRes v; return v; }
 constexpr int kVisPageSize = 16;  // image patch counts are multiples; flashinfer-friendly
 }  // namespace
 

--- a/driver/cuda/src/model/qwen3_vl_vision_forward.cu
+++ b/driver/cuda/src/model/qwen3_vl_vision_forward.cu
@@ -33,7 +33,10 @@
 #include <stdexcept>
 #include <tuple>
 #include <string>
+#include <utility>
 #include <vector>
+
+#include "tls_cuda_resource.hpp"
 
 namespace pie_cuda_driver::model {
 
@@ -515,20 +518,62 @@ void scatter_qwen3vl_vision(const Qwen3VLVisionInputs& vin, bf* hidden,
     // grid — identical for every same-size image. Cache the device buffers by grid
     // so the CPU interp + bf16 convert + H2D run ONCE, not per image.
     // thread_local: buffers are device memory; a process-wide map would IMA under
-    // multi-GPU TP threads.
-    thread_local std::map<std::tuple<int,int,int>, std::pair<float*,bf*>> pe_cache;
+    // multi-GPU TP threads. PeEntry frees on map erase / thread exit.
+    struct PeEntry {
+        float* rope = nullptr;
+        bf* pe = nullptr;
+        int device = -1;
+        PeEntry() = default;
+        PeEntry(const PeEntry&) = delete;
+        PeEntry& operator=(const PeEntry&) = delete;
+        PeEntry(PeEntry&& o) noexcept
+            : rope(o.rope), pe(o.pe), device(o.device)
+        {
+            o.rope = nullptr;
+            o.pe = nullptr;
+            o.device = -1;
+        }
+        PeEntry& operator=(PeEntry&& o) noexcept
+        {
+            if (this == &o) return *this;
+            reset();
+            rope = o.rope;
+            pe = o.pe;
+            device = o.device;
+            o.rope = nullptr;
+            o.pe = nullptr;
+            o.device = -1;
+            return *this;
+        }
+        ~PeEntry() { reset(); }
+        void reset() noexcept
+        {
+            tls_cuda_free_device(rope, device);
+            tls_cuda_free_device(pe, device);
+            rope = nullptr;
+            pe = nullptr;
+            device = -1;
+        }
+    };
+    thread_local std::map<std::tuple<int,int,int>, PeEntry> pe_cache;
     auto grid_rope_pe = [&](int gt,int gh,int gw)->std::pair<float*,bf*>{
         auto key=std::make_tuple(gt,gh,gw); auto it=pe_cache.find(key);
-        if(it!=pe_cache.end()) return it->second;
+        if(it!=pe_cache.end()) return {it->second.rope, it->second.pe};
         auto c0=clk::now();
         std::vector<float> rope=vision_rope_positions(gt,gh,gw,MERGE);
         std::vector<float> pe=interp_pos_embed(table,w.num_grid_per_side,Hd,gt,gh,gw,MERGE);
         std::vector<bf> pe_bf(pe.size()); for(size_t i=0;i<pe.size();++i) pe_bf[i]=__float2bfloat16(pe[i]);
         cpu_host_ms+=MS(c0,clk::now());
-        float* rd; bf* pd;
-        QCK(cudaMalloc(&rd,(long)rope.size()*4)); QCK(cudaMemcpy(rd,rope.data(),(long)rope.size()*4,cudaMemcpyHostToDevice));
-        QCK(cudaMalloc(&pd,(long)pe_bf.size()*sizeof(bf))); QCK(cudaMemcpy(pd,pe_bf.data(),(long)pe_bf.size()*sizeof(bf),cudaMemcpyHostToDevice));
-        pe_cache[key]={rd,pd}; return {rd,pd};
+        PeEntry entry;
+        QCK(cudaMalloc(&entry.rope,(long)rope.size()*4));
+        QCK(cudaMemcpy(entry.rope,rope.data(),(long)rope.size()*4,cudaMemcpyHostToDevice));
+        QCK(cudaMalloc(&entry.pe,(long)pe_bf.size()*sizeof(bf)));
+        QCK(cudaMemcpy(entry.pe,pe_bf.data(),(long)pe_bf.size()*sizeof(bf),cudaMemcpyHostToDevice));
+        entry.device = tls_cuda_current_device();
+        auto* rp = entry.rope;
+        auto* pp = entry.pe;
+        pe_cache.emplace(key, std::move(entry));
+        return {rp, pp};
     };
 
     // Uniform batch test: all images share a grid and are page-aligned → encode

--- a/driver/cuda/src/model/qwen3_vl_vision_forward.cu
+++ b/driver/cuda/src/model/qwen3_vl_vision_forward.cu
@@ -30,7 +30,6 @@
 #include <cublas_v2.h>
 #include <map>
 #include <math_constants.h>
-#include <mutex>
 #include <stdexcept>
 #include <tuple>
 #include <string>
@@ -494,19 +493,17 @@ void scatter_qwen3vl_vision(const Qwen3VLVisionInputs& vin, bf* hidden,
 
     // The abs pos-embed table is a constant model weight. Cache the host-side
     // fp32 copy (keyed by the device pointer) so we don't re-do the ~5 MB D2H +
-    // convert on every forward pass. Forward passes for one model are serialized
-    // by the engine; the mutex guards the (rare) first-touch.
+    // convert on every forward pass. Per-thread: TP ranks own different devices /
+    // weight pointers; a process-wide static would D2H from the wrong GPU.
     auto t_tbl0=clk::now();
-    static std::mutex tbl_mu; static const void* tbl_key=nullptr; static std::vector<float> tbl_cache;
-    {
-        std::lock_guard<std::mutex> lk(tbl_mu);
-        if(tbl_key != w.pos_embed){
-            std::vector<bf> tbf((long)w.num_pos_embed*Hd);
-            QCK(cudaMemcpy(tbf.data(),w.pos_embed,(long)w.num_pos_embed*Hd*sizeof(bf),cudaMemcpyDeviceToHost));
-            tbl_cache.resize(tbf.size());
-            for(size_t i=0;i<tbf.size();++i) tbl_cache[i]=__bfloat162float(tbf[i]);
-            tbl_key = w.pos_embed;
-        }
+    thread_local const void* tbl_key=nullptr;
+    thread_local std::vector<float> tbl_cache;
+    if(tbl_key != w.pos_embed){
+        std::vector<bf> tbf((long)w.num_pos_embed*Hd);
+        QCK(cudaMemcpy(tbf.data(),w.pos_embed,(long)w.num_pos_embed*Hd*sizeof(bf),cudaMemcpyDeviceToHost));
+        tbl_cache.resize(tbf.size());
+        for(size_t i=0;i<tbf.size();++i) tbl_cache[i]=__bfloat162float(tbf[i]);
+        tbl_key = w.pos_embed;
     }
     const std::vector<float>& table = tbl_cache;
     if(VTIM) fprintf(stderr,"[vtim] num_images=%d  pos_embed table = %.1fms\n", vin.num_images, MS(t_tbl0,clk::now()));
@@ -517,10 +514,10 @@ void scatter_qwen3vl_vision(const Qwen3VLVisionInputs& vin, bf* hidden,
     // rope positions + interpolated pos-embed are a deterministic function of the
     // grid — identical for every same-size image. Cache the device buffers by grid
     // so the CPU interp + bf16 convert + H2D run ONCE, not per image.
-    static std::mutex pe_mu;
-    static std::map<std::tuple<int,int,int>, std::pair<float*,bf*>> pe_cache;
+    // thread_local: buffers are device memory; a process-wide map would IMA under
+    // multi-GPU TP threads.
+    thread_local std::map<std::tuple<int,int,int>, std::pair<float*,bf*>> pe_cache;
     auto grid_rope_pe = [&](int gt,int gh,int gw)->std::pair<float*,bf*>{
-        std::lock_guard<std::mutex> lk(pe_mu);
         auto key=std::make_tuple(gt,gh,gw); auto it=pe_cache.find(key);
         if(it!=pe_cache.end()) return it->second;
         auto c0=clk::now();

--- a/driver/cuda/src/ops/gemm.cpp
+++ b/driver/cuda/src/ops/gemm.cpp
@@ -96,13 +96,18 @@ std::size_t cublaslt_bf16_workspace_bytes() {
     return bytes;
 }
 
+// Per-thread cuBLASLt handle + workspace. TP ranks are separate threads
+// that each `cudaSetDevice` to a different GPU; a process-wide static
+// would allocate the workspace on the first rank's device and IMA on the
+// others (commonly at the wide lm_head GEMM that is the first shape to
+// enter the Lt path under GPT-OSS TP).
 struct Bf16LtCtx {
     cublasLtHandle_t handle = nullptr;
     void* workspace = nullptr;
     std::size_t workspace_bytes = cublaslt_bf16_workspace_bytes();
 
     static Bf16LtCtx& instance() {
-        static Bf16LtCtx ctx;
+        thread_local Bf16LtCtx ctx;
         return ctx;
     }
 
@@ -919,12 +924,11 @@ struct LtMatmulPref {
 };
 
 #ifdef PIE_CUDA_HAS_MARLIN
-// Per-process marlin workspace. Marlin's split-K reduce uses one int32
-// per SM as a barrier counter; we allocate generously (16 KiB) to cover
-// every realistic SM count without per-call allocation. Lazy-init on
-// first INT4_PACKED dispatch.
+// Per-thread marlin workspace. TP ranks are separate threads that each
+// `cudaSetDevice` to a different GPU; a process-wide static would allocate
+// on the first rank's device and IMA on the others.
 void* marlin_workspace_() {
-    static void* ws = nullptr;
+    thread_local void* ws = nullptr;
     static const std::size_t ws_bytes = 16 * 1024;
     if (!ws) {
         if (cudaMalloc(&ws, ws_bytes) != cudaSuccess) {
@@ -936,7 +940,7 @@ void* marlin_workspace_() {
 }
 
 void* marlin_fp32_reduce_scratch_() {
-    static void* ws = nullptr;
+    thread_local void* ws = nullptr;
     static const std::size_t ws_bytes = 32 * 1024 * 1024;
     if (!ws) {
         if (cudaMalloc(&ws, ws_bytes) != cudaSuccess) {
@@ -947,13 +951,13 @@ void* marlin_fp32_reduce_scratch_() {
     return ws;
 }
 
-// Per-process bf16 residual scratch — used when the INT4 dispatcher is
+// Per-thread bf16 residual scratch — used when the INT4 dispatcher is
 // called with beta=1 (the residual-add fusion the bf16/fp8 paths handle
 // natively via cuBLAS's beta param). Marlin overwrites C, so we run it
 // into a scratch and add into y in a second pass. Grows monotonically.
 void* marlin_residual_scratch_(std::size_t bytes) {
-    static void* buf = nullptr;
-    static std::size_t buf_bytes = 0;
+    thread_local void* buf = nullptr;
+    thread_local std::size_t buf_bytes = 0;
     if (bytes <= buf_bytes) return buf;
     if (buf) cudaFree(buf);
     if (cudaMalloc(&buf, bytes) != cudaSuccess) {
@@ -1013,7 +1017,7 @@ struct LtCtx {
 
     // Grow-on-demand device scratch. Caller passes byte size; returns
     // a pointer valid until the next `ensure(bigger_size)` on the same
-    // buffer. Cleared at process exit (LtCtx is a static singleton).
+    // buffer. Cleared at process exit (LtCtx is thread_local per TP rank).
     struct GrowScratch {
         void*       p = nullptr;
         std::size_t bytes = 0;

--- a/driver/cuda/src/ops/gemm.cpp
+++ b/driver/cuda/src/ops/gemm.cpp
@@ -20,6 +20,7 @@
 #include "kernels/dequant_fp8.hpp"
 #include "kernels/quant_bf16_to_fp8.hpp"
 #include "kernels/residual_add.hpp"
+#include "tls_cuda_resource.hpp"
 
 #ifdef PIE_CUDA_HAS_MARLIN
 #include "marlin_wrapper.hpp"
@@ -105,16 +106,37 @@ struct Bf16LtCtx {
     cublasLtHandle_t handle = nullptr;
     void* workspace = nullptr;
     std::size_t workspace_bytes = cublaslt_bf16_workspace_bytes();
+    int device = -1;
 
     static Bf16LtCtx& instance() {
         thread_local Bf16LtCtx ctx;
         return ctx;
     }
 
+    ~Bf16LtCtx() {
+        if (workspace != nullptr) {
+            tls_cuda_free_device(workspace, device);
+            workspace = nullptr;
+        }
+        if (handle != nullptr) {
+            int prev = -1;
+            if (device >= 0 && cudaGetDevice(&prev) == cudaSuccess) {
+                (void)cudaSetDevice(device);
+            }
+            (void)cublasLtDestroy(handle);
+            if (device >= 0 && prev >= 0) (void)cudaSetDevice(prev);
+            handle = nullptr;
+        }
+    }
+
     void ensure() {
-        if (!handle) check(cublasLtCreate(&handle), "cublasLtCreate");
+        if (!handle) {
+            check(cublasLtCreate(&handle), "cublasLtCreate");
+            device = tls_cuda_current_device();
+        }
         if (!workspace) {
             CUDA_CHECK(cudaMalloc(&workspace, workspace_bytes));
+            if (device < 0) device = tls_cuda_current_device();
         }
     }
 };
@@ -926,29 +948,29 @@ struct LtMatmulPref {
 #ifdef PIE_CUDA_HAS_MARLIN
 // Per-thread marlin workspace. TP ranks are separate threads that each
 // `cudaSetDevice` to a different GPU; a process-wide static would allocate
-// on the first rank's device and IMA on the others.
+// on the first rank's device and IMA on the others. RAII frees on thread exit.
 void* marlin_workspace_() {
-    thread_local void* ws = nullptr;
-    static const std::size_t ws_bytes = 16 * 1024;
-    if (!ws) {
-        if (cudaMalloc(&ws, ws_bytes) != cudaSuccess) {
+    thread_local TlsDeviceBuf<std::uint8_t> ws;
+    constexpr std::size_t ws_bytes = 16 * 1024;
+    if (ws.capacity < ws_bytes) {
+        if (!ws.ensure(ws_bytes)) {
             throw std::runtime_error("marlin: cudaMalloc workspace failed");
         }
-        cudaMemset(ws, 0, ws_bytes);
+        cudaMemset(ws.ptr, 0, ws_bytes);
     }
-    return ws;
+    return ws.ptr;
 }
 
 void* marlin_fp32_reduce_scratch_() {
-    thread_local void* ws = nullptr;
-    static const std::size_t ws_bytes = 32 * 1024 * 1024;
-    if (!ws) {
-        if (cudaMalloc(&ws, ws_bytes) != cudaSuccess) {
+    thread_local TlsDeviceBuf<std::uint8_t> ws;
+    constexpr std::size_t ws_bytes = 32 * 1024 * 1024;
+    if (ws.capacity < ws_bytes) {
+        if (!ws.ensure(ws_bytes)) {
             throw std::runtime_error(
                 "marlin: cudaMalloc fp32 reduce scratch failed");
         }
     }
-    return ws;
+    return ws.ptr;
 }
 
 // Per-thread bf16 residual scratch — used when the INT4 dispatcher is
@@ -956,17 +978,14 @@ void* marlin_fp32_reduce_scratch_() {
 // natively via cuBLAS's beta param). Marlin overwrites C, so we run it
 // into a scratch and add into y in a second pass. Grows monotonically.
 void* marlin_residual_scratch_(std::size_t bytes) {
-    thread_local void* buf = nullptr;
-    thread_local std::size_t buf_bytes = 0;
-    if (bytes <= buf_bytes) return buf;
-    if (buf) cudaFree(buf);
-    if (cudaMalloc(&buf, bytes) != cudaSuccess) {
+    thread_local TlsDeviceBuf<std::uint8_t> buf;
+    if (bytes <= buf.capacity) return buf.ptr;
+    if (!buf.ensure(bytes)) {
         throw std::runtime_error(
             "marlin: cudaMalloc residual scratch failed (" +
             std::to_string(bytes) + " bytes)");
     }
-    buf_bytes = bytes;
-    return buf;
+    return buf.ptr;
 }
 #endif
 
@@ -983,6 +1002,7 @@ struct LtCtx {
     cublasLtHandle_t handle = nullptr;
     void*            workspace = nullptr;
     std::size_t      workspace_bytes = 0;
+    int              device = -1;
     int              compute_capability_major = 0;  // 0 = unqueried
     bool             fp8_native_supported = false;
 
@@ -991,11 +1011,32 @@ struct LtCtx {
         return ctx;
     }
 
+    ~LtCtx() {
+        // GrowScratch members free themselves first (declaration order).
+        if (workspace != nullptr) {
+            tls_cuda_free_device(workspace, device);
+            workspace = nullptr;
+        }
+        if (handle != nullptr) {
+            int prev = -1;
+            if (device >= 0 && cudaGetDevice(&prev) == cudaSuccess) {
+                (void)cudaSetDevice(device);
+            }
+            (void)cublasLtDestroy(handle);
+            if (device >= 0 && prev >= 0) (void)cudaSetDevice(prev);
+            handle = nullptr;
+        }
+    }
+
     void ensure_init(std::size_t ws_bytes = kDefaultLtWorkspaceBytes) {
-        if (!handle) LT_CHECK(cublasLtCreate(&handle));
+        if (!handle) {
+            LT_CHECK(cublasLtCreate(&handle));
+            device = tls_cuda_current_device();
+        }
         if (!workspace) {
             CUDA_CHECK(cudaMalloc(&workspace, ws_bytes));
             workspace_bytes = ws_bytes;
+            if (device < 0) device = tls_cuda_current_device();
         }
         if (compute_capability_major == 0) {
             int dev = 0;
@@ -1017,12 +1058,20 @@ struct LtCtx {
 
     // Grow-on-demand device scratch. Caller passes byte size; returns
     // a pointer valid until the next `ensure(bigger_size)` on the same
-    // buffer. Cleared at process exit (LtCtx is thread_local per TP rank).
+    // buffer. Freed when the owning LtCtx (thread_local) is destroyed.
     struct GrowScratch {
         void*       p = nullptr;
         std::size_t bytes = 0;
+        int         device = -1;
         bool        sealed = false;
         const char* name = "runtime quant scratch";
+
+        ~GrowScratch() {
+            tls_cuda_free_device(p, device);
+            p = nullptr;
+            bytes = 0;
+            device = -1;
+        }
 
         void reserve(std::size_t want) {
             if (want <= bytes) return;
@@ -1034,9 +1083,15 @@ struct LtCtx {
                     std::to_string(bytes) +
                     " bytes. Increase the planner reserve or disable CUDA graphs.");
             }
-            if (p) CUDA_CHECK(cudaFree(p));
+            if (p) {
+                tls_cuda_free_device(p, device);
+                p = nullptr;
+                bytes = 0;
+                device = -1;
+            }
             CUDA_CHECK(cudaMalloc(&p, want));
             bytes = want;
+            device = tls_cuda_current_device();
         }
 
         void* ensure(std::size_t want) {

--- a/driver/cuda/src/sampling_dispatch.cpp
+++ b/driver/cuda/src/sampling_dispatch.cpp
@@ -11,6 +11,9 @@
 #include "kernels/scatter_int32.hpp"
 #include "model/qwen3_forward.hpp"
 #include "executor/persistent_inputs.hpp"
+#include "tls_cuda_resource.hpp"
+
+#include <stdexcept>
 
 namespace pie_cuda_driver {
 
@@ -31,19 +34,14 @@ void upload_async(DeviceBuffer<T>& dst, std::span<const T> src,
                                cudaMemcpyHostToDevice, stream));
 }
 
-// Pinned host scratch for the topk+top-p seed widening. Allocated once
-// per process so we can keep upload_sampling_inputs allocation-free.
+// Pinned host scratch for the topk+top-p seed widening. Per-thread RAII so
+// TP rank threads free on exit without racing a process-wide static.
 std::uint64_t* seed64_pinned_buf(std::size_t want_elems) {
-    // Per-thread pinned scratch: TP ranks are separate threads; a process-wide
-    // static races if both ranks ever widen seeds concurrently.
-    thread_local std::uint64_t* buf = nullptr;
-    thread_local std::size_t buf_capacity = 0;
-    if (want_elems > buf_capacity) {
-        if (buf) cudaFreeHost(buf);
-        CUDA_CHECK(cudaMallocHost(&buf, want_elems * sizeof(std::uint64_t)));
-        buf_capacity = want_elems;
+    thread_local TlsHostPinnedBuf<std::uint64_t> scratch;
+    if (!scratch.ensure(want_elems)) {
+        throw std::runtime_error("seed64_pinned_buf: cudaMallocHost failed");
     }
-    return buf;
+    return scratch.ptr;
 }
 
 }  // namespace

--- a/driver/cuda/src/sampling_dispatch.cpp
+++ b/driver/cuda/src/sampling_dispatch.cpp
@@ -34,8 +34,10 @@ void upload_async(DeviceBuffer<T>& dst, std::span<const T> src,
 // Pinned host scratch for the topk+top-p seed widening. Allocated once
 // per process so we can keep upload_sampling_inputs allocation-free.
 std::uint64_t* seed64_pinned_buf(std::size_t want_elems) {
-    static std::uint64_t* buf = nullptr;
-    static std::size_t buf_capacity = 0;
+    // Per-thread pinned scratch: TP ranks are separate threads; a process-wide
+    // static races if both ranks ever widen seeds concurrently.
+    thread_local std::uint64_t* buf = nullptr;
+    thread_local std::size_t buf_capacity = 0;
     if (want_elems > buf_capacity) {
         if (buf) cudaFreeHost(buf);
         CUDA_CHECK(cudaMallocHost(&buf, want_elems * sizeof(std::uint64_t)));

--- a/driver/cuda/src/tls_cuda_resource.hpp
+++ b/driver/cuda/src/tls_cuda_resource.hpp
@@ -1,0 +1,129 @@
+#pragma once
+
+// RAII helpers for thread_local CUDA scratch. TP ranks are threads that each
+// own a device; when the thread exits, these destructors free memory / handles
+// while that thread's CUDA context is still the intended one. Best-effort:
+// if the context is already gone (process teardown), free is skipped.
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <utility>
+
+namespace pie_cuda_driver {
+
+inline int tls_cuda_current_device() noexcept
+{
+    int d = -1;
+    return (cudaGetDevice(&d) == cudaSuccess) ? d : -1;
+}
+
+inline void tls_cuda_free_device(void* p, int device) noexcept
+{
+    if (p == nullptr) return;
+    int prev = -1;
+    if (device >= 0) {
+        if (cudaGetDevice(&prev) != cudaSuccess) return;
+        if (cudaSetDevice(device) != cudaSuccess) return;
+    }
+    (void)cudaFree(p);
+    if (device >= 0 && prev >= 0) (void)cudaSetDevice(prev);
+}
+
+inline void tls_cuda_free_host(void* p) noexcept
+{
+    if (p != nullptr) (void)cudaFreeHost(p);
+}
+
+// Growable device buffer owned by a thread_local.
+template <typename T>
+struct TlsDeviceBuf {
+    T* ptr = nullptr;
+    std::size_t capacity = 0;  // element count
+    int device = -1;
+
+    TlsDeviceBuf() = default;
+    TlsDeviceBuf(const TlsDeviceBuf&) = delete;
+    TlsDeviceBuf& operator=(const TlsDeviceBuf&) = delete;
+    TlsDeviceBuf(TlsDeviceBuf&& o) noexcept
+        : ptr(o.ptr), capacity(o.capacity), device(o.device)
+    {
+        o.ptr = nullptr;
+        o.capacity = 0;
+        o.device = -1;
+    }
+    TlsDeviceBuf& operator=(TlsDeviceBuf&& o) noexcept
+    {
+        if (this == &o) return *this;
+        reset();
+        ptr = o.ptr;
+        capacity = o.capacity;
+        device = o.device;
+        o.ptr = nullptr;
+        o.capacity = 0;
+        o.device = -1;
+        return *this;
+    }
+
+    ~TlsDeviceBuf() { reset(); }
+
+    void reset() noexcept
+    {
+        tls_cuda_free_device(ptr, device);
+        ptr = nullptr;
+        capacity = 0;
+        device = -1;
+    }
+
+    // Ensure capacity >= want_elems. Throws cudaError via CUDA_CHECK only when
+    // the caller wraps malloc; here returns false on alloc failure so .cu
+    // files without CUDA_CHECK can decide.
+    bool ensure(std::size_t want_elems)
+    {
+        if (want_elems <= capacity) return ptr != nullptr || want_elems == 0;
+        reset();
+        if (want_elems == 0) return true;
+        if (cudaMalloc(&ptr, want_elems * sizeof(T)) != cudaSuccess) {
+            ptr = nullptr;
+            return false;
+        }
+        capacity = want_elems;
+        device = tls_cuda_current_device();
+        return true;
+    }
+};
+
+// Growable pinned host buffer owned by a thread_local.
+template <typename T>
+struct TlsHostPinnedBuf {
+    T* ptr = nullptr;
+    std::size_t capacity = 0;
+
+    TlsHostPinnedBuf() = default;
+    TlsHostPinnedBuf(const TlsHostPinnedBuf&) = delete;
+    TlsHostPinnedBuf& operator=(const TlsHostPinnedBuf&) = delete;
+
+    ~TlsHostPinnedBuf() { reset(); }
+
+    void reset() noexcept
+    {
+        tls_cuda_free_host(ptr);
+        ptr = nullptr;
+        capacity = 0;
+    }
+
+    bool ensure(std::size_t want_elems)
+    {
+        if (want_elems <= capacity) return ptr != nullptr || want_elems == 0;
+        reset();
+        if (want_elems == 0) return true;
+        if (cudaMallocHost(&ptr, want_elems * sizeof(T)) != cudaSuccess) {
+            ptr = nullptr;
+            return false;
+        }
+        capacity = want_elems;
+        return true;
+    }
+};
+
+}  // namespace pie_cuda_driver


### PR DESCRIPTION
Pie's tensor-parallel ranks are threads in one process, each with cudaSetDevice on a different GPU. Several lazy-init helpers used process-wide static device (or pinned) buffers, so the first rank to touch them allocated on its device and later ranks reused those pointers on theirs — CUDA illegal memory access.

Make per-rank CUDA scratch thread_local: Bf16LtCtx workspace, Marlin workspaces, fused-argmax partial pairs, Qwen3-VL vision PE/attn caches, and sampling pinned host scratch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA stability during concurrent execution by isolating temporary buffers, caches, and workspace resources between threads.
  * Prevented cross-thread sharing of sampling, vision, attention, matrix-processing, and positional-embedding resources.
  * Improved handling of GPU resources across device changes and thread shutdown.
  * Preserved cache reuse and on-demand allocation while reducing contention, data interference, and resource leaks.
  * Added clearer error reporting and cleanup when required GPU or pinned host memory cannot be allocated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->