### PR TITLE
Support TP with MoE Expert Streaming

### DIFF
--- a/driver/cuda/CMakeLists.txt
+++ b/driver/cuda/CMakeLists.txt
@@ -176,6 +176,7 @@ add_library(pie_driver_cuda_lib STATIC
   src/model/gpt_oss_native_marlin_pack.cpp
   src/model/gpt_oss_eager_bf16_pack.cpp
   src/model/gpt_oss_routed_mxfp4_pack.cpp
+  src/model/mixtral_tp_bf16_pack.cpp
   src/model/weight_store.cpp
   src/mla_cache.cpp
   src/model/loaded_model.cpp

--- a/driver/cuda/CMakeLists.txt
+++ b/driver/cuda/CMakeLists.txt
@@ -179,6 +179,7 @@ add_library(pie_driver_cuda_lib STATIC
   src/model/mixtral_tp_bf16_pack.cpp
   src/model/qwen35_moe_tp_bf16_pack.cpp
   src/model/qwen3_moe_tp_bf16_pack.cpp
+  src/model/dsv4_tp_mxfp4_pack.cpp
   src/model/weight_store.cpp
   src/mla_cache.cpp
   src/model/loaded_model.cpp

--- a/driver/cuda/CMakeLists.txt
+++ b/driver/cuda/CMakeLists.txt
@@ -51,12 +51,12 @@ endif()
 # call sites are gated on tp_size > 1), but we always link so a TP-enabled
 # wrapper can talk to the same binary. System NCCL only — vendoring via CPM
 # is impractical (kernel-heavy build).
-find_path(NCCL_INCLUDE_DIR nccl.h
-  HINTS ${CUDAToolkit_INCLUDE_DIRS} /usr/include /usr/local/include
-  REQUIRED)
-find_library(NCCL_LIBRARY nccl
-  HINTS ${CUDAToolkit_LIBRARY_DIR} /usr/lib/x86_64-linux-gnu /usr/local/lib
-  REQUIRED)
+  find_path(NCCL_INCLUDE_DIR nccl.h
+    HINTS ${CUDAToolkit_INCLUDE_DIRS} /usr/include /usr/local/include
+    REQUIRED)
+  find_library(NCCL_LIBRARY nccl
+    HINTS ${CUDAToolkit_LIBRARY_DIR} /usr/lib/x86_64-linux-gnu /usr/local/lib
+    REQUIRED)
 message(STATUS "Using NCCL: ${NCCL_LIBRARY} (header: ${NCCL_INCLUDE_DIR})")
 
 include(cmake/CPM.cmake)
@@ -175,6 +175,7 @@ add_library(pie_driver_cuda_lib STATIC
   src/model/expert_pack_build.cpp
   src/model/gpt_oss_native_marlin_pack.cpp
   src/model/gpt_oss_eager_bf16_pack.cpp
+  src/model/gpt_oss_routed_mxfp4_pack.cpp
   src/model/weight_store.cpp
   src/mla_cache.cpp
   src/model/loaded_model.cpp

--- a/driver/cuda/CMakeLists.txt
+++ b/driver/cuda/CMakeLists.txt
@@ -177,6 +177,8 @@ add_library(pie_driver_cuda_lib STATIC
   src/model/gpt_oss_eager_bf16_pack.cpp
   src/model/gpt_oss_routed_mxfp4_pack.cpp
   src/model/mixtral_tp_bf16_pack.cpp
+  src/model/qwen35_moe_tp_bf16_pack.cpp
+  src/model/qwen3_moe_tp_bf16_pack.cpp
   src/model/weight_store.cpp
   src/mla_cache.cpp
   src/model/loaded_model.cpp

--- a/driver/cuda/src/config.hpp
+++ b/driver/cuda/src/config.hpp
@@ -40,7 +40,8 @@ struct ModelConfig {
     // When true, routed MoE expert weights are not materialized on the GPU
     // at load time; instead they are paged on demand from safetensors (or a
     // per-rank offline pack) into a bounded LRU expert cache at forward time.
-    // TP+streaming is GPT-OSS / Mixtral (per-rank packs); other arches need tp=1.
+    // TP+streaming is GPT-OSS / Mixtral / Qwen MoE (per-rank packs); other
+    // arches need tp=1.
     bool stream_routed_experts = false;
     // Expert stream cache budget in GiB. 0 (default) = auto: half of the
     // free device memory after resident weights, capped at the full routed
@@ -205,9 +206,9 @@ inline Config load_config(const std::filesystem::path& path) {
         throw std::runtime_error(
             "config: [model].expert_cache_gb must be >= 0");
     }
-    // stream_routed_experts + tp_size>1 is allowed in config (GPT-OSS / Mixtral
-    // use per-rank packs). Other arches are rejected after model type is known
-    // (entry) and again in the weight-loader compiler.
+    // stream_routed_experts + tp_size>1 is allowed in config (GPT-OSS / Mixtral /
+    // Qwen MoE use per-rank packs). Other arches are rejected after model type
+    // is known (entry) and again in the weight-loader compiler.
     if (!(c.batching.gpu_mem_utilization > 0.0 &&
           c.batching.gpu_mem_utilization <= 1.0)) {
         throw std::runtime_error(

--- a/driver/cuda/src/config.hpp
+++ b/driver/cuda/src/config.hpp
@@ -40,7 +40,7 @@ struct ModelConfig {
     // When true, routed MoE expert weights are not materialized on the GPU
     // at load time; instead they are paged on demand from safetensors (or a
     // per-rank offline pack) into a bounded LRU expert cache at forward time.
-    // TP+streaming is GPT-OSS only (per-rank packs); other arches need tp=1.
+    // TP+streaming is GPT-OSS / Mixtral (per-rank packs); other arches need tp=1.
     bool stream_routed_experts = false;
     // Expert stream cache budget in GiB. 0 (default) = auto: half of the
     // free device memory after resident weights, capped at the full routed
@@ -205,9 +205,9 @@ inline Config load_config(const std::filesystem::path& path) {
         throw std::runtime_error(
             "config: [model].expert_cache_gb must be >= 0");
     }
-    // stream_routed_experts + tp_size>1 is allowed in config (GPT-OSS uses
-    // per-rank packs). Non–GPT-OSS combinations are rejected after model
-    // type is known (entry) and again in the weight-loader compiler.
+    // stream_routed_experts + tp_size>1 is allowed in config (GPT-OSS / Mixtral
+    // use per-rank packs). Other arches are rejected after model type is known
+    // (entry) and again in the weight-loader compiler.
     if (!(c.batching.gpu_mem_utilization > 0.0 &&
           c.batching.gpu_mem_utilization <= 1.0)) {
         throw std::runtime_error(

--- a/driver/cuda/src/config.hpp
+++ b/driver/cuda/src/config.hpp
@@ -40,8 +40,8 @@ struct ModelConfig {
     // When true, routed MoE expert weights are not materialized on the GPU
     // at load time; instead they are paged on demand from safetensors (or a
     // per-rank offline pack) into a bounded LRU expert cache at forward time.
-    // TP+streaming is GPT-OSS / Mixtral / Qwen MoE (per-rank packs); other
-    // arches need tp=1.
+    // TP+streaming is DeepSeek-V4 / GPT-OSS / Mixtral / Qwen MoE (per-rank
+    // packs); other arches need tp=1.
     bool stream_routed_experts = false;
     // Expert stream cache budget in GiB. 0 (default) = auto: half of the
     // free device memory after resident weights, capped at the full routed
@@ -206,9 +206,10 @@ inline Config load_config(const std::filesystem::path& path) {
         throw std::runtime_error(
             "config: [model].expert_cache_gb must be >= 0");
     }
-    // stream_routed_experts + tp_size>1 is allowed in config (GPT-OSS / Mixtral /
-    // Qwen MoE use per-rank packs). Other arches are rejected after model type
-    // is known (entry) and again in the weight-loader compiler.
+    // stream_routed_experts + tp_size>1 is allowed in config (DeepSeek-V4 /
+    // GPT-OSS / Mixtral / Qwen MoE use per-rank packs). Other arches are
+    // rejected after model type is known (entry) and again in the
+    // weight-loader compiler.
     if (!(c.batching.gpu_mem_utilization > 0.0 &&
           c.batching.gpu_mem_utilization <= 1.0)) {
         throw std::runtime_error(

--- a/driver/cuda/src/config.hpp
+++ b/driver/cuda/src/config.hpp
@@ -36,10 +36,11 @@ struct ModelConfig {
     //   * "bf16" / "dequant" — eagerly dequantize experts to BF16 at load.
     //   * "native" — require a true MXFP4 MoE GEMM backend.
     std::string mxfp4_moe = "auto";
-    // SSD expert streaming (DeepSeek-V4 / GPT-OSS / Mixtral / Qwen MoE,
-    // tp_size=1). When true, routed MoE expert weights are not materialized
-    // on the GPU at load time; instead they are paged on demand from the
-    // safetensors shards into a bounded LRU expert cache at forward time.
+    // SSD expert streaming (DeepSeek-V4 / GPT-OSS / Mixtral / Qwen MoE).
+    // When true, routed MoE expert weights are not materialized on the GPU
+    // at load time; instead they are paged on demand from safetensors (or a
+    // per-rank offline pack) into a bounded LRU expert cache at forward time.
+    // TP+streaming is GPT-OSS only (per-rank packs); other arches need tp=1.
     bool stream_routed_experts = false;
     // Expert stream cache budget in GiB. 0 (default) = auto: half of the
     // free device memory after resident weights, capped at the full routed
@@ -204,10 +205,9 @@ inline Config load_config(const std::filesystem::path& path) {
         throw std::runtime_error(
             "config: [model].expert_cache_gb must be >= 0");
     }
-    if (c.model.stream_routed_experts && c.distributed.tp_size > 1) {
-        throw std::runtime_error(
-            "config: [model].stream_routed_experts requires tp_size=1");
-    }
+    // stream_routed_experts + tp_size>1 is allowed in config (GPT-OSS uses
+    // per-rank packs). Non–GPT-OSS combinations are rejected after model
+    // type is known (entry) and again in the weight-loader compiler.
     if (!(c.batching.gpu_mem_utilization > 0.0 &&
           c.batching.gpu_mem_utilization <= 1.0)) {
         throw std::runtime_error(

--- a/driver/cuda/src/cuda_memory_planner.cpp
+++ b/driver/cuda/src/cuda_memory_planner.cpp
@@ -390,8 +390,13 @@ CudaMemoryPlan plan_cuda_memory(
     if (per_kv_token_bytes == 0) {
         throw std::runtime_error("cuda memory planner: computed zero KV page bytes");
     }
+    // Sharded GQA/MHA: each rank holds 1/tp of the heads, so scale by tp to
+    // recover the model-wide KV footprint for heuristics. Replicated MQA
+    // (DeepSeek-V4) already stores the full KV on every rank.
     const std::size_t global_per_kv_token_bytes =
-        per_kv_token_bytes * static_cast<std::size_t>(tp_size);
+        (hf.model_type == "deepseek_v4")
+            ? per_kv_token_bytes
+            : per_kv_token_bytes * static_cast<std::size_t>(tp_size);
     const int throughput_decode_target =
         profile_decode_target("throughput", cfg, prop);
     const bool kv_heavy_auto_model =

--- a/driver/cuda/src/entry.cpp
+++ b/driver/cuda/src/entry.cpp
@@ -474,12 +474,12 @@ int run_impl(int argc,
                       << engine.hf_config().model_type << "')\n";
             return 2;
         }
-        // TP+streaming: GPT-OSS builds per-rank contiguous expert packs.
+        // TP+streaming: GPT-OSS / Mixtral build per-rank contiguous expert packs.
         // Other arches still rely on strided HF extents the streamer cannot
         // page — reject here so --tp-size overrides fail before compile.
-        if (cfg.distributed.tp_size > 1 && !is_gpt_oss_arch) {
+        if (cfg.distributed.tp_size > 1 && !is_gpt_oss_arch && !is_mixtral_arch) {
             std::cerr << "[pie-driver-cuda] model.stream_routed_experts with "
-                         "tp_size>1 is only supported for gpt_oss (got '"
+                         "tp_size>1 is only supported for gpt_oss and mixtral (got '"
                       << engine.hf_config().model_type << "', tp_size="
                       << cfg.distributed.tp_size << ")\n";
             return 1;

--- a/driver/cuda/src/entry.cpp
+++ b/driver/cuda/src/entry.cpp
@@ -474,12 +474,14 @@ int run_impl(int argc,
                       << engine.hf_config().model_type << "')\n";
             return 2;
         }
-        // TP+streaming: GPT-OSS / Mixtral build per-rank contiguous expert packs.
+        // TP+streaming: GPT-OSS / Mixtral / Qwen MoE build per-rank packs.
         // Other arches still rely on strided HF extents the streamer cannot
         // page — reject here so --tp-size overrides fail before compile.
-        if (cfg.distributed.tp_size > 1 && !is_gpt_oss_arch && !is_mixtral_arch) {
+        if (cfg.distributed.tp_size > 1 && !is_gpt_oss_arch && !is_mixtral_arch &&
+            !is_qwen3_5_moe_arch) {
             std::cerr << "[pie-driver-cuda] model.stream_routed_experts with "
-                         "tp_size>1 is only supported for gpt_oss and mixtral (got '"
+                         "tp_size>1 is only supported for gpt_oss, mixtral, and "
+                         "qwen3_moe/qwen3_5_moe (got '"
                       << engine.hf_config().model_type << "', tp_size="
                       << cfg.distributed.tp_size << ")\n";
             return 1;

--- a/driver/cuda/src/entry.cpp
+++ b/driver/cuda/src/entry.cpp
@@ -474,14 +474,14 @@ int run_impl(int argc,
                       << engine.hf_config().model_type << "')\n";
             return 2;
         }
-        // TP+streaming: GPT-OSS / Mixtral / Qwen MoE build per-rank packs.
+        // TP+streaming: DSv4 / GPT-OSS / Mixtral / Qwen MoE build per-rank packs.
         // Other arches still rely on strided HF extents the streamer cannot
         // page — reject here so --tp-size overrides fail before compile.
-        if (cfg.distributed.tp_size > 1 && !is_gpt_oss_arch && !is_mixtral_arch &&
-            !is_qwen3_5_moe_arch) {
+        if (cfg.distributed.tp_size > 1 && !is_dsv4_arch && !is_gpt_oss_arch &&
+            !is_mixtral_arch && !is_qwen3_5_moe_arch) {
             std::cerr << "[pie-driver-cuda] model.stream_routed_experts with "
-                         "tp_size>1 is only supported for gpt_oss, mixtral, and "
-                         "qwen3_moe/qwen3_5_moe (got '"
+                         "tp_size>1 is only supported for deepseek_v4, gpt_oss, "
+                         "mixtral, and qwen3_moe/qwen3_5_moe (got '"
                       << engine.hf_config().model_type << "', tp_size="
                       << cfg.distributed.tp_size << ")\n";
             return 1;

--- a/driver/cuda/src/entry.cpp
+++ b/driver/cuda/src/entry.cpp
@@ -169,16 +169,6 @@ int run_impl(int argc,
     if (!cli_nccl_unique_id_hex.empty())
         cfg.distributed.nccl_unique_id_hex = cli_nccl_unique_id_hex;
     const bool verbose = cfg.runtime.verbose;
-    // SSD expert streaming is single-GPU only for now (per-expert TP shards
-    // are strided file extents the streamer does not support). The config
-    // loader rejects the TOML combination; re-check here because --tp-size
-    // can override [distributed] after load_config.
-    if (cfg.model.stream_routed_experts && cfg.distributed.tp_size > 1) {
-        std::cerr << "[pie-driver-cuda] model.stream_routed_experts requires "
-                     "tp_size=1 (got tp_size="
-                  << cfg.distributed.tp_size << ")\n";
-        return 1;
-    }
     if (cfg.distributed.tp_size > 1 &&
         cfg.distributed.tp_rank > 0 &&
         cfg.distributed.nccl_unique_id_hex.empty()) {
@@ -483,6 +473,16 @@ int run_impl(int argc,
                          "qwen3_moe/qwen3_5_moe (got '"
                       << engine.hf_config().model_type << "')\n";
             return 2;
+        }
+        // TP+streaming: GPT-OSS builds per-rank contiguous expert packs.
+        // Other arches still rely on strided HF extents the streamer cannot
+        // page — reject here so --tp-size overrides fail before compile.
+        if (cfg.distributed.tp_size > 1 && !is_gpt_oss_arch) {
+            std::cerr << "[pie-driver-cuda] model.stream_routed_experts with "
+                         "tp_size>1 is only supported for gpt_oss (got '"
+                      << engine.hf_config().model_type << "', tp_size="
+                      << cfg.distributed.tp_size << ")\n";
+            return 1;
         }
         std::size_t free_bytes = 0;
         std::size_t total_bytes = 0;

--- a/driver/cuda/src/expert_stream_cache.hpp
+++ b/driver/cuda/src/expert_stream_cache.hpp
@@ -18,9 +18,9 @@
 // lives in the weight loader / model forward, not here).
 //
 // Scope (v1): on-demand only — no prefetch, no popularity preload.
-// TP+streaming uses per-rank offline packs (GPT-OSS MXFP4/BF16/Marlin,
-// Mixtral BF16, Qwen3/3.5-MoE BF16) with dense local-I sections; other
-// arches remain tp_size=1.
+// TP+streaming uses per-rank offline packs (DeepSeek-V4 MXFP4, GPT-OSS
+// MXFP4/BF16/Marlin, Mixtral BF16, Qwen3/3.5-MoE BF16) with dense local-I
+// sections; other arches remain tp_size=1.
 // The table/slot bookkeeping (`ExpertSlotIndex`) is host-only so it can be
 // unit-tested without a GPU.
 

--- a/driver/cuda/src/expert_stream_cache.hpp
+++ b/driver/cuda/src/expert_stream_cache.hpp
@@ -18,9 +18,10 @@
 // lives in the weight loader / model forward, not here).
 //
 // Scope (v1): on-demand only — no prefetch, no popularity preload.
-// TP+streaming is GPT-OSS-only via per-rank offline packs (dense local-I
-// sections); other arches remain tp_size=1. The table/slot bookkeeping
-// (`ExpertSlotIndex`) is host-only so it can be unit-tested without a GPU.
+// TP+streaming uses per-rank offline packs (GPT-OSS MXFP4/BF16/Marlin,
+// Mixtral BF16) with dense local-I sections; other arches remain tp_size=1.
+// The table/slot bookkeeping (`ExpertSlotIndex`) is host-only so it can be
+// unit-tested without a GPU.
 
 #include <cstdint>
 #include <filesystem>

--- a/driver/cuda/src/expert_stream_cache.hpp
+++ b/driver/cuda/src/expert_stream_cache.hpp
@@ -17,9 +17,10 @@
 // Section count and layout come from the stream plan (arch-specific naming
 // lives in the weight loader / model forward, not here).
 //
-// Scope (v1): on-demand only — no prefetch, no popularity preload, tp=1.
-// The table/slot bookkeeping (`ExpertSlotIndex`) is host-only so it can be
-// unit-tested without a GPU.
+// Scope (v1): on-demand only — no prefetch, no popularity preload.
+// TP+streaming is GPT-OSS-only via per-rank offline packs (dense local-I
+// sections); other arches remain tp_size=1. The table/slot bookkeeping
+// (`ExpertSlotIndex`) is host-only so it can be unit-tested without a GPU.
 
 #include <cstdint>
 #include <filesystem>
@@ -51,6 +52,9 @@ struct StreamedExpertTable {
     int sections_per_expert = 0;
     // Matches pie_weight_loader::PieLoaderExpertPackKind / ExpertPackKind.
     std::uint32_t pack_kind = 0;
+    // TP geometry for offline pack builders (local I = I_full / tp_size).
+    int tp_rank = 0;
+    int tp_size = 1;
     std::vector<std::uint64_t> section_bytes;
     std::vector<std::uint64_t> section_offsets;
     std::uint64_t slot_bytes = 0;  // 0 = cache computes from section_bytes

--- a/driver/cuda/src/expert_stream_cache.hpp
+++ b/driver/cuda/src/expert_stream_cache.hpp
@@ -19,7 +19,8 @@
 //
 // Scope (v1): on-demand only — no prefetch, no popularity preload.
 // TP+streaming uses per-rank offline packs (GPT-OSS MXFP4/BF16/Marlin,
-// Mixtral BF16) with dense local-I sections; other arches remain tp_size=1.
+// Mixtral BF16, Qwen3/3.5-MoE BF16) with dense local-I sections; other
+// arches remain tp_size=1.
 // The table/slot bookkeeping (`ExpertSlotIndex`) is host-only so it can be
 // unit-tested without a GPU.
 

--- a/driver/cuda/src/kv_cache.cpp
+++ b/driver/cuda/src/kv_cache.cpp
@@ -336,7 +336,13 @@ std::size_t kv_cache_device_bytes_per_page(const KvCacheFormat& format,
 std::size_t kv_page_bytes_homogeneous(const HfConfig& cfg,
                                       int tp_size,
                                       const KvCacheFormat& format) {
-    const int kv_heads = cfg.num_key_value_heads / std::max(1, tp_size);
+    const int world = std::max(1, tp_size);
+    // DeepSeek-V4 is MQA (num_key_value_heads=1): the single KV head is
+    // replicated on every TP rank, matching KvCache::allocate(..., 1, ...)
+    // in entry.cpp. Dividing by tp_size would yield 0 heads and zero bytes.
+    const int kv_heads = (cfg.model_type == "deepseek_v4")
+        ? std::max(1, cfg.num_key_value_heads)
+        : cfg.num_key_value_heads / world;
     return static_cast<std::size_t>(cfg.num_hidden_layers) *
            kv_cache_device_bytes_per_page(
                format, 1, kv_heads, cfg.head_dim_kernel);

--- a/driver/cuda/src/loader/rust_loader_bridge.hpp
+++ b/driver/cuda/src/loader/rust_loader_bridge.hpp
@@ -138,7 +138,7 @@ inline std::string rust_loader_compile_cache_key(
     // content-hashes the loader source), so this no longer needs bumping per
     // code change.
     constexpr const char* cache_version =
-        "pie-cuda-rust-storage-program-cache-v11";
+        "pie-cuda-rust-storage-program-cache-v12";
     h.update_bytes(cache_version, std::char_traits<char>::length(cache_version));
     // Auto-invalidate when the Rust compiler logic changes (build.rs content-
     // hashes the loader source into this weak FFI symbol). Weak-guarded so the

--- a/driver/cuda/src/model/dsv4_tp_mxfp4_pack.cpp
+++ b/driver/cuda/src/model/dsv4_tp_mxfp4_pack.cpp
@@ -1,0 +1,268 @@
+#include "model/expert_pack_build.hpp"
+#include "model/expert_pack_cache.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "cuda_check.hpp"
+#include "tensor.hpp"
+
+namespace pie_cuda_driver {
+namespace {
+
+// Contiguous TP-local MXFP4 sections for DeepSeek-V4 under tp_size>1.
+// HF: w1/w3 [I, H/2] + scale [I, H/32]; w2 [H, I/2] + scale [H, I/32].
+// Pack densifies w2 columns (strided in HF) so the streamer can page
+// contiguous extents matching resident Partition layout.
+struct Dsv4TpMxfp4PackTraits {
+    static constexpr int kSections = 6;
+
+    static const char* miss_label()
+    {
+        return "streaming DeepSeek-V4 TP MXFP4 pack";
+    }
+
+    static void require_build_support() {}
+
+    struct Context {
+        int full_intermediate = 0;
+        int local_start = 0;
+        int local_intermediate = 0;
+        int hidden = 0;
+        std::uint64_t w1_span = 0;
+        std::uint64_t w1s_span = 0;
+        std::uint64_t w2_span = 0;
+        std::uint64_t w2s_span = 0;
+        std::uint64_t w3_span = 0;
+        std::uint64_t w3s_span = 0;
+        DeviceBuf src_w1;
+        DeviceBuf src_w1s;
+        DeviceBuf src_w2;
+        DeviceBuf src_w2s;
+        DeviceBuf src_w3;
+        DeviceBuf src_w3s;
+        DeviceBuf dst_w1;
+        DeviceBuf dst_w1s;
+        DeviceBuf dst_w2;
+        DeviceBuf dst_w2s;
+        DeviceBuf dst_w3;
+        DeviceBuf dst_w3s;
+    };
+
+    static Context prepare(
+        const StreamedExpertTable& table,
+        SafetensorsCheckpointSource& checkpoint)
+    {
+        const int tp = std::max(1, table.tp_size);
+        const int rank = table.tp_rank;
+        if (tp <= 1) {
+            throw std::runtime_error(
+                "expert pack: Dsv4TpMxfp4 requires tp_size>1");
+        }
+        const auto& sb = table.section_bytes;
+
+        const std::string w1_name = "layers.0.ffn.experts.0.w1.weight";
+        const std::string w1s_name = "layers.0.ffn.experts.0.w1.scale";
+        const std::string w2_name = "layers.0.ffn.experts.0.w2.weight";
+        const std::string w2s_name = "layers.0.ffn.experts.0.w2.scale";
+        const std::string w3_name = "layers.0.ffn.experts.0.w3.weight";
+        const std::string w3s_name = "layers.0.ffn.experts.0.w3.scale";
+        const auto& w1_info = checkpoint.info(w1_name);
+        const auto& w2_info = checkpoint.info(w2_name);
+        if (w1_info.shape.size() != 2 || w2_info.shape.size() != 2) {
+            throw std::runtime_error(
+                "expert pack: unexpected DeepSeek-V4 expert weight ranks");
+        }
+
+        Context ctx;
+        ctx.full_intermediate = static_cast<int>(w1_info.shape[0]);
+        ctx.hidden = static_cast<int>(w1_info.shape[1]) * 2;
+        if (ctx.hidden % 32 != 0) {
+            throw std::runtime_error(
+                "expert pack: DeepSeek-V4 hidden must be divisible by 32");
+        }
+        if (static_cast<int>(w2_info.shape[0]) != ctx.hidden ||
+            static_cast<int>(w2_info.shape[1]) != ctx.full_intermediate / 2) {
+            throw std::runtime_error(
+                "expert pack: DeepSeek-V4 w2 expected [H, I/2]");
+        }
+        if (ctx.full_intermediate % tp != 0) {
+            throw std::runtime_error(
+                "expert pack: intermediate not divisible by tp_size");
+        }
+        ctx.local_intermediate = ctx.full_intermediate / tp;
+        ctx.local_start = rank * ctx.local_intermediate;
+        if (ctx.local_intermediate % 32 != 0) {
+            throw std::runtime_error(
+                "expert pack: DeepSeek-V4 I_local must be divisible by 32");
+        }
+
+        const std::uint64_t i_local =
+            static_cast<std::uint64_t>(ctx.local_intermediate);
+        const std::uint64_t h = static_cast<std::uint64_t>(ctx.hidden);
+        const std::uint64_t w13 = i_local * h / 2;
+        const std::uint64_t s13 = i_local * h / 32;
+        const std::uint64_t w2b = h * i_local / 2;
+        const std::uint64_t s2 = h * i_local / 32;
+        const std::uint64_t expect[kSections] = {w13, s13, w2b, s2, w13, s13};
+        if (sb.size() != static_cast<std::size_t>(kSections)) {
+            throw std::runtime_error(
+                "expert pack: DeepSeek-V4 TP expected " +
+                std::to_string(kSections) + " section_bytes, got " +
+                std::to_string(sb.size()));
+        }
+        for (int i = 0; i < kSections; ++i) {
+            if (sb[static_cast<std::size_t>(i)] != expect[i]) {
+                throw std::runtime_error(
+                    "expert pack: DeepSeek-V4 TP section_bytes[" +
+                    std::to_string(i) + "]=" +
+                    std::to_string(sb[static_cast<std::size_t>(i)]) +
+                    " != expected " + std::to_string(expect[i]) +
+                    " (I_local=" + std::to_string(ctx.local_intermediate) +
+                    " H=" + std::to_string(ctx.hidden) + ")");
+            }
+        }
+
+        ctx.w1_span = checkpoint.storage_info(w1_name).nbytes;
+        ctx.w1s_span = checkpoint.storage_info(w1s_name).nbytes;
+        ctx.w2_span = checkpoint.storage_info(w2_name).nbytes;
+        ctx.w2s_span = checkpoint.storage_info(w2s_name).nbytes;
+        ctx.w3_span = checkpoint.storage_info(w3_name).nbytes;
+        ctx.w3s_span = checkpoint.storage_info(w3s_name).nbytes;
+        ctx.src_w1 = DeviceBuf(ctx.w1_span);
+        ctx.src_w1s = DeviceBuf(ctx.w1s_span);
+        ctx.src_w2 = DeviceBuf(ctx.w2_span);
+        ctx.src_w2s = DeviceBuf(ctx.w2s_span);
+        ctx.src_w3 = DeviceBuf(ctx.w3_span);
+        ctx.src_w3s = DeviceBuf(ctx.w3s_span);
+        ctx.dst_w1 = DeviceBuf(sb[0]);
+        ctx.dst_w1s = DeviceBuf(sb[1]);
+        ctx.dst_w2 = DeviceBuf(sb[2]);
+        ctx.dst_w2s = DeviceBuf(sb[3]);
+        ctx.dst_w3 = DeviceBuf(sb[4]);
+        ctx.dst_w3s = DeviceBuf(sb[5]);
+        return ctx;
+    }
+
+    static void load_expert(
+        Context& ctx,
+        SafetensorsCheckpointSource& checkpoint,
+        int layer,
+        int expert)
+    {
+        const std::string p =
+            "layers." + std::to_string(layer) + ".ffn.experts." +
+            std::to_string(expert) + ".";
+        const auto w1 = checkpoint.storage_info(p + "w1.weight");
+        const auto w1s = checkpoint.storage_info(p + "w1.scale");
+        const auto w2 = checkpoint.storage_info(p + "w2.weight");
+        const auto w2s = checkpoint.storage_info(p + "w2.scale");
+        const auto w3 = checkpoint.storage_info(p + "w3.weight");
+        const auto w3s = checkpoint.storage_info(p + "w3.scale");
+        checkpoint.copy_storage_bytes_to_device(
+            w1.shard_id, w1.file_offset, ctx.w1_span, ctx.src_w1.ptr);
+        checkpoint.copy_storage_bytes_to_device(
+            w1s.shard_id, w1s.file_offset, ctx.w1s_span, ctx.src_w1s.ptr);
+        checkpoint.copy_storage_bytes_to_device(
+            w2.shard_id, w2.file_offset, ctx.w2_span, ctx.src_w2.ptr);
+        checkpoint.copy_storage_bytes_to_device(
+            w2s.shard_id, w2s.file_offset, ctx.w2s_span, ctx.src_w2s.ptr);
+        checkpoint.copy_storage_bytes_to_device(
+            w3.shard_id, w3.file_offset, ctx.w3_span, ctx.src_w3.ptr);
+        checkpoint.copy_storage_bytes_to_device(
+            w3s.shard_id, w3s.file_offset, ctx.w3s_span, ctx.src_w3s.ptr);
+    }
+
+    static void transform(Context& ctx)
+    {
+        // w1/w3 weight: [I, H/2] — contiguous row slice.
+        const std::size_t w_row = static_cast<std::size_t>(ctx.hidden) / 2;
+        const std::size_t w_off =
+            static_cast<std::size_t>(ctx.local_start) * w_row;
+        const std::size_t w_copy =
+            static_cast<std::size_t>(ctx.local_intermediate) * w_row;
+        CUDA_CHECK(cudaMemcpy(
+            ctx.dst_w1.ptr,
+            static_cast<const std::uint8_t*>(ctx.src_w1.ptr) + w_off, w_copy,
+            cudaMemcpyDeviceToDevice));
+        CUDA_CHECK(cudaMemcpy(
+            ctx.dst_w3.ptr,
+            static_cast<const std::uint8_t*>(ctx.src_w3.ptr) + w_off, w_copy,
+            cudaMemcpyDeviceToDevice));
+
+        // w1/w3 scale: [I, H/32] — contiguous row slice.
+        const std::size_t s_row = static_cast<std::size_t>(ctx.hidden) / 32;
+        const std::size_t s_off =
+            static_cast<std::size_t>(ctx.local_start) * s_row;
+        const std::size_t s_copy =
+            static_cast<std::size_t>(ctx.local_intermediate) * s_row;
+        CUDA_CHECK(cudaMemcpy(
+            ctx.dst_w1s.ptr,
+            static_cast<const std::uint8_t*>(ctx.src_w1s.ptr) + s_off, s_copy,
+            cudaMemcpyDeviceToDevice));
+        CUDA_CHECK(cudaMemcpy(
+            ctx.dst_w3s.ptr,
+            static_cast<const std::uint8_t*>(ctx.src_w3s.ptr) + s_off, s_copy,
+            cudaMemcpyDeviceToDevice));
+
+        // w2 weight: [H, I/2] — gather local packed columns.
+        const std::size_t w2_full = static_cast<std::size_t>(ctx.full_intermediate) / 2;
+        const std::size_t w2_local =
+            static_cast<std::size_t>(ctx.local_intermediate) / 2;
+        const std::size_t w2_col =
+            static_cast<std::size_t>(ctx.local_start) / 2;
+        CUDA_CHECK(cudaMemcpy2D(
+            ctx.dst_w2.ptr, w2_local,
+            static_cast<const std::uint8_t*>(ctx.src_w2.ptr) + w2_col, w2_full,
+            w2_local, static_cast<std::size_t>(ctx.hidden),
+            cudaMemcpyDeviceToDevice));
+
+        // w2 scale: [H, I/32] — gather local scale columns.
+        const std::size_t s2_full = static_cast<std::size_t>(ctx.full_intermediate) / 32;
+        const std::size_t s2_local =
+            static_cast<std::size_t>(ctx.local_intermediate) / 32;
+        const std::size_t s2_col =
+            static_cast<std::size_t>(ctx.local_start) / 32;
+        CUDA_CHECK(cudaMemcpy2D(
+            ctx.dst_w2s.ptr, s2_local,
+            static_cast<const std::uint8_t*>(ctx.src_w2s.ptr) + s2_col, s2_full,
+            s2_local, static_cast<std::size_t>(ctx.hidden),
+            cudaMemcpyDeviceToDevice));
+
+        CUDA_CHECK(cudaDeviceSynchronize());
+    }
+
+    static void emit(
+        Context& ctx,
+        ExpertPackWriter& writer,
+        const StreamedExpertTable& table,
+        std::vector<std::uint8_t>& host_bounce)
+    {
+        const DeviceBuf* sections[kSections] = {
+            &ctx.dst_w1,
+            &ctx.dst_w1s,
+            &ctx.dst_w2,
+            &ctx.dst_w2s,
+            &ctx.dst_w3,
+            &ctx.dst_w3s,
+        };
+        expert_pack_emit_slot_sections(
+            writer, table, sections, kSections, host_bounce);
+    }
+};
+
+}  // namespace
+
+bool ensure_dsv4_tp_mxfp4_expert_pack(
+    StreamedExpertTable& table,
+    const std::string& cache_key,
+    SafetensorsCheckpointSource& checkpoint,
+    bool verbose)
+{
+    return ensure_expert_pack<Dsv4TpMxfp4PackTraits>(
+        table, cache_key, checkpoint, verbose);
+}
+
+}  // namespace pie_cuda_driver

--- a/driver/cuda/src/model/expert_pack_cache.hpp
+++ b/driver/cuda/src/model/expert_pack_cache.hpp
@@ -341,6 +341,12 @@ bool ensure_gpt_oss_eager_bf16_expert_pack(
     SafetensorsCheckpointSource& checkpoint,
     bool verbose);
 
+bool ensure_gpt_oss_routed_mxfp4_expert_pack(
+    StreamedExpertTable& table,
+    const std::string& cache_key,
+    SafetensorsCheckpointSource& checkpoint,
+    bool verbose);
+
 // Dispatch offline pack builders from `table.pack_kind` (set by the stream
 // arch recipe). No-op when pack_kind is None.
 inline void ensure_streamed_expert_pack(
@@ -359,6 +365,10 @@ inline void ensure_streamed_expert_pack(
         return;
     case PieLoaderExpertPackKind::GptOssEagerBf16:
         ensure_gpt_oss_eager_bf16_expert_pack(
+            table, cache_key, checkpoint, verbose);
+        return;
+    case PieLoaderExpertPackKind::GptOssRoutedMxfp4:
+        ensure_gpt_oss_routed_mxfp4_expert_pack(
             table, cache_key, checkpoint, verbose);
         return;
     }

--- a/driver/cuda/src/model/expert_pack_cache.hpp
+++ b/driver/cuda/src/model/expert_pack_cache.hpp
@@ -365,6 +365,12 @@ bool ensure_qwen3_moe_tp_bf16_expert_pack(
     SafetensorsCheckpointSource& checkpoint,
     bool verbose);
 
+bool ensure_dsv4_tp_mxfp4_expert_pack(
+    StreamedExpertTable& table,
+    const std::string& cache_key,
+    SafetensorsCheckpointSource& checkpoint,
+    bool verbose);
+
 // Dispatch offline pack builders from `table.pack_kind` (set by the stream
 // arch recipe). No-op when pack_kind is None.
 inline void ensure_streamed_expert_pack(
@@ -399,6 +405,10 @@ inline void ensure_streamed_expert_pack(
         return;
     case PieLoaderExpertPackKind::Qwen3MoeTpBf16:
         ensure_qwen3_moe_tp_bf16_expert_pack(
+            table, cache_key, checkpoint, verbose);
+        return;
+    case PieLoaderExpertPackKind::Dsv4TpMxfp4:
+        ensure_dsv4_tp_mxfp4_expert_pack(
             table, cache_key, checkpoint, verbose);
         return;
     }

--- a/driver/cuda/src/model/expert_pack_cache.hpp
+++ b/driver/cuda/src/model/expert_pack_cache.hpp
@@ -347,6 +347,12 @@ bool ensure_gpt_oss_routed_mxfp4_expert_pack(
     SafetensorsCheckpointSource& checkpoint,
     bool verbose);
 
+bool ensure_mixtral_tp_bf16_expert_pack(
+    StreamedExpertTable& table,
+    const std::string& cache_key,
+    SafetensorsCheckpointSource& checkpoint,
+    bool verbose);
+
 // Dispatch offline pack builders from `table.pack_kind` (set by the stream
 // arch recipe). No-op when pack_kind is None.
 inline void ensure_streamed_expert_pack(
@@ -369,6 +375,10 @@ inline void ensure_streamed_expert_pack(
         return;
     case PieLoaderExpertPackKind::GptOssRoutedMxfp4:
         ensure_gpt_oss_routed_mxfp4_expert_pack(
+            table, cache_key, checkpoint, verbose);
+        return;
+    case PieLoaderExpertPackKind::MixtralTpBf16:
+        ensure_mixtral_tp_bf16_expert_pack(
             table, cache_key, checkpoint, verbose);
         return;
     }

--- a/driver/cuda/src/model/expert_pack_cache.hpp
+++ b/driver/cuda/src/model/expert_pack_cache.hpp
@@ -353,6 +353,18 @@ bool ensure_mixtral_tp_bf16_expert_pack(
     SafetensorsCheckpointSource& checkpoint,
     bool verbose);
 
+bool ensure_qwen35_moe_tp_bf16_expert_pack(
+    StreamedExpertTable& table,
+    const std::string& cache_key,
+    SafetensorsCheckpointSource& checkpoint,
+    bool verbose);
+
+bool ensure_qwen3_moe_tp_bf16_expert_pack(
+    StreamedExpertTable& table,
+    const std::string& cache_key,
+    SafetensorsCheckpointSource& checkpoint,
+    bool verbose);
+
 // Dispatch offline pack builders from `table.pack_kind` (set by the stream
 // arch recipe). No-op when pack_kind is None.
 inline void ensure_streamed_expert_pack(
@@ -379,6 +391,14 @@ inline void ensure_streamed_expert_pack(
         return;
     case PieLoaderExpertPackKind::MixtralTpBf16:
         ensure_mixtral_tp_bf16_expert_pack(
+            table, cache_key, checkpoint, verbose);
+        return;
+    case PieLoaderExpertPackKind::Qwen35MoeTpBf16:
+        ensure_qwen35_moe_tp_bf16_expert_pack(
+            table, cache_key, checkpoint, verbose);
+        return;
+    case PieLoaderExpertPackKind::Qwen3MoeTpBf16:
+        ensure_qwen3_moe_tp_bf16_expert_pack(
             table, cache_key, checkpoint, verbose);
         return;
     }

--- a/driver/cuda/src/model/gpt_oss_native_marlin_pack.cpp
+++ b/driver/cuda/src/model/gpt_oss_native_marlin_pack.cpp
@@ -27,9 +27,11 @@ void repack_weight_one(
     std::uint8_t* dst,
     std::uint8_t* gptq_stage,
     int source_rows,
+    int source_row_offset,
     int target_rows,
     int valid_rows,
     int source_stride_k,
+    int source_col_offset,
     int source_k,
     int target_k,
     kernels::Mxfp4RowSelect row_map)
@@ -37,16 +39,18 @@ void repack_weight_one(
 #if defined(PIE_CUDA_HAS_MARLIN)
     kernels::launch_mxfp4_weight_to_gptq_w4(
         src, gptq_stage,
-        source_rows, /*source_row_offset=*/0, target_rows, valid_rows,
-        source_stride_k, /*source_col_offset=*/0, source_k, target_k,
+        source_rows, source_row_offset, target_rows, valid_rows,
+        source_stride_k, source_col_offset, source_k, target_k,
         row_map, /*stream=*/0);
     marlin::launch_gptq_repack_w4_no_perm(
         gptq_stage, dst, target_k, target_rows, /*stream=*/0);
     CUDA_CHECK(cudaGetLastError());
 #else
     (void)src; (void)dst; (void)gptq_stage;
-    (void)source_rows; (void)target_rows; (void)valid_rows;
-    (void)source_stride_k; (void)source_k; (void)target_k; (void)row_map;
+    (void)source_rows; (void)source_row_offset;
+    (void)target_rows; (void)valid_rows;
+    (void)source_stride_k; (void)source_col_offset;
+    (void)source_k; (void)target_k; (void)row_map;
     throw std::runtime_error(
         "expert pack: Marlin repack requires PIE_CUDA_HAS_MARLIN");
 #endif
@@ -56,17 +60,19 @@ void repack_scale_one(
     const std::uint8_t* src,
     std::uint8_t* dst,
     int source_rows,
+    int source_row_offset,
     int target_rows,
     int valid_rows,
     int source_stride_groups,
+    int source_group_offset,
     int source_groups,
     int target_groups,
     kernels::Mxfp4RowSelect row_map)
 {
     kernels::launch_mxfp4_scales_to_marlin_e8m0(
         src, dst,
-        source_rows, /*source_row_offset=*/0, target_rows, valid_rows,
-        source_stride_groups, /*source_group_offset=*/0, source_groups,
+        source_rows, source_row_offset, target_rows, valid_rows,
+        source_stride_groups, source_group_offset, source_groups,
         target_groups, row_map, /*stream=*/0);
     CUDA_CHECK(cudaGetLastError());
 }
@@ -89,7 +95,9 @@ struct GptOssNativeMarlinPackTraits {
 
     struct Context {
         int fused_rows = 0;
-        int intermediate = 0;
+        int full_intermediate = 0;
+        int local_start = 0;
+        int local_intermediate = 0;
         int intermediate_native = 0;
         int hidden = 0;
         int gu_groups = 0;
@@ -116,6 +124,8 @@ struct GptOssNativeMarlinPackTraits {
         SafetensorsCheckpointSource& checkpoint)
     {
         const int E = table.num_experts;
+        const int tp = std::max(1, table.tp_size);
+        const int rank = table.tp_rank;
         const auto& sb = table.section_bytes;
 
         const std::string gu_w_name =
@@ -136,8 +146,18 @@ struct GptOssNativeMarlinPackTraits {
         Context ctx;
         ctx.fused_rows = static_cast<int>(gu_w_info.shape[1]);
         ctx.gu_groups = static_cast<int>(gu_w_info.shape[2]);
-        ctx.intermediate = ctx.fused_rows / 2;
-        ctx.intermediate_native = align_up_int(ctx.intermediate, 128);
+        ctx.full_intermediate = ctx.fused_rows / 2;
+        if (ctx.full_intermediate % tp != 0) {
+            throw std::runtime_error(
+                "expert pack: intermediate not divisible by tp_size");
+        }
+        ctx.local_intermediate = ctx.full_intermediate / tp;
+        ctx.local_start = rank * ctx.local_intermediate;
+        if (ctx.local_start % 32 != 0 || ctx.local_intermediate % 32 != 0) {
+            throw std::runtime_error(
+                "expert pack: native Marlin TP shard must align to 32");
+        }
+        ctx.intermediate_native = align_up_int(ctx.local_intermediate, 128);
         ctx.hidden = ctx.gu_groups * 32;
         ctx.down_groups = static_cast<int>(dn_w_info.shape[2]);
 
@@ -171,7 +191,8 @@ struct GptOssNativeMarlinPackTraits {
                     " != expected " + std::to_string(expect[i]) +
                     " (I_native=" + std::to_string(ctx.intermediate_native) +
                     " H=" + std::to_string(ctx.hidden) +
-                    " groups=" + std::to_string(ctx.gu_groups) + ")");
+                    " groups=" + std::to_string(ctx.gu_groups) +
+                    " tp=" + std::to_string(tp) + ")");
             }
         }
 
@@ -236,41 +257,43 @@ struct GptOssNativeMarlinPackTraits {
         auto* dn_w_ptr = static_cast<std::uint8_t*>(ctx.src_dn_w.ptr);
         auto* dn_s_ptr = static_cast<std::uint8_t*>(ctx.src_dn_s.ptr);
 
-        // Gate (even rows) / up (odd rows).
+        // Gate (even rows) / up (odd rows); source_row_offset = TP local_start.
         repack_weight_one(
             gu_w_ptr, static_cast<std::uint8_t*>(ctx.dst_gate_w.ptr),
             static_cast<std::uint8_t*>(ctx.gptq_stage.ptr),
-            ctx.fused_rows, ctx.intermediate_native, ctx.intermediate,
-            ctx.hidden, ctx.hidden, ctx.hidden, kernels::Mxfp4RowSelect::Even);
+            ctx.fused_rows, ctx.local_start, ctx.intermediate_native,
+            ctx.local_intermediate, ctx.hidden, /*source_col_offset=*/0,
+            ctx.hidden, ctx.hidden, kernels::Mxfp4RowSelect::Even);
         repack_scale_one(
             gu_s_ptr, static_cast<std::uint8_t*>(ctx.dst_gate_s.ptr),
-            ctx.fused_rows, ctx.intermediate_native, ctx.intermediate,
-            ctx.gu_groups, ctx.gu_groups, ctx.gu_groups,
-            kernels::Mxfp4RowSelect::Even);
+            ctx.fused_rows, ctx.local_start, ctx.intermediate_native,
+            ctx.local_intermediate, ctx.gu_groups, /*source_group_offset=*/0,
+            ctx.gu_groups, ctx.gu_groups, kernels::Mxfp4RowSelect::Even);
 
         repack_weight_one(
             gu_w_ptr, static_cast<std::uint8_t*>(ctx.dst_up_w.ptr),
             static_cast<std::uint8_t*>(ctx.gptq_stage.ptr),
-            ctx.fused_rows, ctx.intermediate_native, ctx.intermediate,
-            ctx.hidden, ctx.hidden, ctx.hidden, kernels::Mxfp4RowSelect::Odd);
+            ctx.fused_rows, ctx.local_start, ctx.intermediate_native,
+            ctx.local_intermediate, ctx.hidden, /*source_col_offset=*/0,
+            ctx.hidden, ctx.hidden, kernels::Mxfp4RowSelect::Odd);
         repack_scale_one(
             gu_s_ptr, static_cast<std::uint8_t*>(ctx.dst_up_s.ptr),
-            ctx.fused_rows, ctx.intermediate_native, ctx.intermediate,
-            ctx.gu_groups, ctx.gu_groups, ctx.gu_groups,
-            kernels::Mxfp4RowSelect::Odd);
+            ctx.fused_rows, ctx.local_start, ctx.intermediate_native,
+            ctx.local_intermediate, ctx.gu_groups, /*source_group_offset=*/0,
+            ctx.gu_groups, ctx.gu_groups, kernels::Mxfp4RowSelect::Odd);
 
-        // Down: Identity row map, pad K to intermediate_native.
+        // Down: Identity rows; source_col_offset = TP local_start.
         repack_weight_one(
             dn_w_ptr, static_cast<std::uint8_t*>(ctx.dst_dn_w.ptr),
             static_cast<std::uint8_t*>(ctx.gptq_stage.ptr),
-            ctx.hidden, ctx.hidden, ctx.hidden,
-            ctx.intermediate, ctx.intermediate, ctx.intermediate_native,
-            kernels::Mxfp4RowSelect::Identity);
+            ctx.hidden, /*source_row_offset=*/0, ctx.hidden, ctx.hidden,
+            ctx.full_intermediate, ctx.local_start, ctx.local_intermediate,
+            ctx.intermediate_native, kernels::Mxfp4RowSelect::Identity);
         repack_scale_one(
             dn_s_ptr, static_cast<std::uint8_t*>(ctx.dst_dn_s.ptr),
-            ctx.hidden, ctx.hidden, ctx.hidden,
-            ctx.down_groups, ctx.down_groups, ctx.intermediate_native / 32,
-            kernels::Mxfp4RowSelect::Identity);
+            ctx.hidden, /*source_row_offset=*/0, ctx.hidden, ctx.hidden,
+            ctx.down_groups, ctx.local_start / 32, ctx.local_intermediate / 32,
+            ctx.intermediate_native / 32, kernels::Mxfp4RowSelect::Identity);
 
         CUDA_CHECK(cudaDeviceSynchronize());
     }

--- a/driver/cuda/src/model/gpt_oss_routed_mxfp4_pack.cpp
+++ b/driver/cuda/src/model/gpt_oss_routed_mxfp4_pack.cpp
@@ -7,19 +7,20 @@
 #include <vector>
 
 #include "cuda_check.hpp"
-#include "kernels/deinterleave.hpp"
-#include "kernels/dequant_fp4.hpp"
 #include "tensor.hpp"
 
 namespace pie_cuda_driver {
 namespace {
 
-struct GptOssEagerBf16PackTraits {
-    static constexpr int kSections = 3;
+// Contiguous TP-local HF MXFP4 sections for RoutedDecode under tp_size>1.
+// Gate/up fused rows are contiguous; down groups are strided in the HF bank
+// and must be gathered into a dense local buffer.
+struct GptOssRoutedMxfp4PackTraits {
+    static constexpr int kSections = 4;
 
     static const char* miss_label()
     {
-        return "streaming eager BF16 dequant";
+        return "streaming RoutedDecode TP MXFP4 pack";
     }
 
     static void require_build_support() {}
@@ -29,6 +30,9 @@ struct GptOssEagerBf16PackTraits {
         int local_start = 0;
         int local_intermediate = 0;
         int hidden = 0;
+        int gu_groups = 0;
+        int down_groups_full = 0;
+        int down_groups_local = 0;
         std::uint64_t gu_w_span = 0;
         std::uint64_t gu_s_span = 0;
         std::uint64_t dn_w_span = 0;
@@ -37,13 +41,10 @@ struct GptOssEagerBf16PackTraits {
         DeviceBuf src_gu_s;
         DeviceBuf src_dn_w;
         DeviceBuf src_dn_s;
-        DeviceBuf fused_bf16;
-        DeviceBuf full_gate;
-        DeviceBuf full_up;
-        DeviceBuf full_down;
-        DeviceBuf dst_gate;
-        DeviceBuf dst_up;
-        DeviceBuf dst_down;
+        DeviceBuf dst_gu_w;
+        DeviceBuf dst_gu_s;
+        DeviceBuf dst_dn_w;
+        DeviceBuf dst_dn_s;
     };
 
     static Context prepare(
@@ -53,6 +54,10 @@ struct GptOssEagerBf16PackTraits {
         const int E = table.num_experts;
         const int tp = std::max(1, table.tp_size);
         const int rank = table.tp_rank;
+        if (tp <= 1) {
+            throw std::runtime_error(
+                "expert pack: GptOssRoutedMxfp4 requires tp_size>1");
+        }
         const auto& sb = table.section_bytes;
 
         const std::string gu_w_name =
@@ -65,10 +70,10 @@ struct GptOssEagerBf16PackTraits {
             throw std::runtime_error(
                 "expert pack: unexpected GPT-OSS expert block ranks");
         }
-        const int fused_rows = static_cast<int>(gu_w_info.shape[1]);
-        const int gu_groups = static_cast<int>(gu_w_info.shape[2]);
 
         Context ctx;
+        const int fused_rows = static_cast<int>(gu_w_info.shape[1]);
+        ctx.gu_groups = static_cast<int>(gu_w_info.shape[2]);
         ctx.full_intermediate = fused_rows / 2;
         if (ctx.full_intermediate % tp != 0) {
             throw std::runtime_error(
@@ -76,32 +81,37 @@ struct GptOssEagerBf16PackTraits {
         }
         ctx.local_intermediate = ctx.full_intermediate / tp;
         ctx.local_start = rank * ctx.local_intermediate;
-        ctx.hidden = gu_groups * 32;
+        if (ctx.local_start % 32 != 0 || ctx.local_intermediate % 32 != 0) {
+            throw std::runtime_error(
+                "expert pack: RoutedDecode TP shard must align to 32");
+        }
+        ctx.hidden = ctx.gu_groups * 32;
+        ctx.down_groups_full = static_cast<int>(dn_w_info.shape[2]);
+        ctx.down_groups_local = ctx.local_intermediate / 32;
 
-        // Match Rust gpt_oss_eager_bf16_section_bytes: I_local*H*2 BF16.
-        const std::uint64_t gate =
-            static_cast<std::uint64_t>(ctx.local_intermediate) *
-            static_cast<std::uint64_t>(ctx.hidden) * 2;
-        const std::uint64_t down =
-            static_cast<std::uint64_t>(ctx.hidden) *
-            static_cast<std::uint64_t>(ctx.local_intermediate) * 2;
-        const std::uint64_t expect[kSections] = {gate, gate, down};
+        const std::uint64_t i_local =
+            static_cast<std::uint64_t>(ctx.local_intermediate);
+        const std::uint64_t h = static_cast<std::uint64_t>(ctx.hidden);
+        const std::uint64_t gu_w = i_local * h;
+        const std::uint64_t gu_s = 2 * i_local * (h / 32);
+        const std::uint64_t dn_w = h * i_local / 2;
+        const std::uint64_t dn_s = h * (i_local / 32);
+        const std::uint64_t expect[kSections] = {gu_w, gu_s, dn_w, dn_s};
         if (sb.size() != static_cast<std::size_t>(kSections)) {
             throw std::runtime_error(
-                "expert pack: eager BF16 expected " +
+                "expert pack: RoutedDecode TP expected " +
                 std::to_string(kSections) + " section_bytes, got " +
                 std::to_string(sb.size()));
         }
         for (int i = 0; i < kSections; ++i) {
             if (sb[static_cast<std::size_t>(i)] != expect[i]) {
                 throw std::runtime_error(
-                    "expert pack: eager BF16 section_bytes[" +
+                    "expert pack: RoutedDecode TP section_bytes[" +
                     std::to_string(i) + "]=" +
                     std::to_string(sb[static_cast<std::size_t>(i)]) +
                     " != expected " + std::to_string(expect[i]) +
                     " (I_local=" + std::to_string(ctx.local_intermediate) +
-                    " H=" + std::to_string(ctx.hidden) +
-                    " tp=" + std::to_string(tp) + ")");
+                    " H=" + std::to_string(ctx.hidden) + ")");
             }
         }
 
@@ -120,21 +130,10 @@ struct GptOssEagerBf16PackTraits {
         ctx.src_gu_s = DeviceBuf(ctx.gu_s_span);
         ctx.src_dn_w = DeviceBuf(ctx.dn_w_span);
         ctx.src_dn_s = DeviceBuf(ctx.dn_s_span);
-        ctx.fused_bf16 = DeviceBuf(
-            static_cast<std::uint64_t>(2 * ctx.full_intermediate) *
-            static_cast<std::uint64_t>(ctx.hidden) * 2);
-        const std::uint64_t full_gate_bytes =
-            static_cast<std::uint64_t>(ctx.full_intermediate) *
-            static_cast<std::uint64_t>(ctx.hidden) * 2;
-        const std::uint64_t full_down_bytes =
-            static_cast<std::uint64_t>(ctx.hidden) *
-            static_cast<std::uint64_t>(ctx.full_intermediate) * 2;
-        ctx.full_gate = DeviceBuf(full_gate_bytes);
-        ctx.full_up = DeviceBuf(full_gate_bytes);
-        ctx.full_down = DeviceBuf(full_down_bytes);
-        ctx.dst_gate = DeviceBuf(sb[0]);
-        ctx.dst_up = DeviceBuf(sb[1]);
-        ctx.dst_down = DeviceBuf(sb[2]);
+        ctx.dst_gu_w = DeviceBuf(sb[0]);
+        ctx.dst_gu_s = DeviceBuf(sb[1]);
+        ctx.dst_dn_w = DeviceBuf(sb[2]);
+        ctx.dst_dn_s = DeviceBuf(sb[3]);
         return ctx;
     }
 
@@ -167,45 +166,59 @@ struct GptOssEagerBf16PackTraits {
 
     static void transform(Context& ctx)
     {
-        kernels::launch_dequant_mxfp4_to_bf16(
-            static_cast<const std::uint8_t*>(ctx.src_gu_w.ptr),
-            static_cast<const std::uint8_t*>(ctx.src_gu_s.ptr),
-            ctx.fused_bf16.ptr, 2 * ctx.full_intermediate, ctx.hidden,
-            /*stream=*/0);
-        kernels::launch_deinterleave_rows_bf16(
-            ctx.fused_bf16.ptr, ctx.full_gate.ptr, ctx.full_up.ptr,
-            ctx.full_intermediate, ctx.hidden, /*stream=*/0);
-        kernels::launch_dequant_mxfp4_to_bf16(
-            static_cast<const std::uint8_t*>(ctx.src_dn_w.ptr),
-            static_cast<const std::uint8_t*>(ctx.src_dn_s.ptr),
-            ctx.full_down.ptr, ctx.hidden, ctx.full_intermediate, /*stream=*/0);
-
-        // Copy TP-local gate/up rows and down columns into pack sections.
-        const std::size_t row_bytes =
-            static_cast<std::size_t>(ctx.hidden) * 2;
-        const std::size_t gate_offset =
-            static_cast<std::size_t>(ctx.local_start) * row_bytes;
-        const std::size_t gate_bytes =
-            static_cast<std::size_t>(ctx.local_intermediate) * row_bytes;
+        // Gate/up fused weight: [2I, H/32, 16] → contiguous row slice.
+        // Each fused row is (H/32)*16 = H/2 bytes.
+        const std::size_t gu_row_bytes =
+            static_cast<std::size_t>(ctx.hidden) / 2;
+        const std::size_t gu_row_offset =
+            static_cast<std::size_t>(2 * ctx.local_start) * gu_row_bytes;
+        const std::size_t gu_copy_bytes =
+            static_cast<std::size_t>(2 * ctx.local_intermediate) * gu_row_bytes;
         CUDA_CHECK(cudaMemcpy(
-            ctx.dst_gate.ptr,
-            static_cast<const std::uint8_t*>(ctx.full_gate.ptr) + gate_offset,
-            gate_bytes, cudaMemcpyDeviceToDevice));
-        CUDA_CHECK(cudaMemcpy(
-            ctx.dst_up.ptr,
-            static_cast<const std::uint8_t*>(ctx.full_up.ptr) + gate_offset,
-            gate_bytes, cudaMemcpyDeviceToDevice));
+            ctx.dst_gu_w.ptr,
+            static_cast<const std::uint8_t*>(ctx.src_gu_w.ptr) + gu_row_offset,
+            gu_copy_bytes, cudaMemcpyDeviceToDevice));
 
-        const std::size_t full_row_bytes =
-            static_cast<std::size_t>(ctx.full_intermediate) * 2;
-        const std::size_t local_row_bytes =
-            static_cast<std::size_t>(ctx.local_intermediate) * 2;
-        const std::size_t col_offset =
-            static_cast<std::size_t>(ctx.local_start) * 2;
+        // Gate/up scales: [2I, H/32] u8 → contiguous row slice.
+        const std::size_t gu_s_row_bytes =
+            static_cast<std::size_t>(ctx.gu_groups);
+        const std::size_t gu_s_offset =
+            static_cast<std::size_t>(2 * ctx.local_start) * gu_s_row_bytes;
+        const std::size_t gu_s_copy =
+            static_cast<std::size_t>(2 * ctx.local_intermediate) *
+            gu_s_row_bytes;
+        CUDA_CHECK(cudaMemcpy(
+            ctx.dst_gu_s.ptr,
+            static_cast<const std::uint8_t*>(ctx.src_gu_s.ptr) + gu_s_offset,
+            gu_s_copy, cudaMemcpyDeviceToDevice));
+
+        // Down weight: [H, I/32, 16] — gather local groups per hidden row.
+        // Each group is 16 bytes; full row pitch = down_groups_full * 16.
+        const std::size_t dn_group_bytes = 16;
+        const std::size_t dn_full_pitch =
+            static_cast<std::size_t>(ctx.down_groups_full) * dn_group_bytes;
+        const std::size_t dn_local_pitch =
+            static_cast<std::size_t>(ctx.down_groups_local) * dn_group_bytes;
+        const std::size_t dn_col_offset =
+            static_cast<std::size_t>(ctx.local_start / 32) * dn_group_bytes;
         CUDA_CHECK(cudaMemcpy2D(
-            ctx.dst_down.ptr, local_row_bytes,
-            static_cast<const std::uint8_t*>(ctx.full_down.ptr) + col_offset,
-            full_row_bytes, local_row_bytes,
+            ctx.dst_dn_w.ptr, dn_local_pitch,
+            static_cast<const std::uint8_t*>(ctx.src_dn_w.ptr) + dn_col_offset,
+            dn_full_pitch, dn_local_pitch,
+            static_cast<std::size_t>(ctx.hidden), cudaMemcpyDeviceToDevice));
+
+        // Down scales: [H, I/32] u8 — same gather pattern.
+        const std::size_t dn_s_full_pitch =
+            static_cast<std::size_t>(ctx.down_groups_full);
+        const std::size_t dn_s_local_pitch =
+            static_cast<std::size_t>(ctx.down_groups_local);
+        const std::size_t dn_s_col_offset =
+            static_cast<std::size_t>(ctx.local_start / 32);
+        CUDA_CHECK(cudaMemcpy2D(
+            ctx.dst_dn_s.ptr, dn_s_local_pitch,
+            static_cast<const std::uint8_t*>(ctx.src_dn_s.ptr) +
+                dn_s_col_offset,
+            dn_s_full_pitch, dn_s_local_pitch,
             static_cast<std::size_t>(ctx.hidden), cudaMemcpyDeviceToDevice));
 
         CUDA_CHECK(cudaDeviceSynchronize());
@@ -218,9 +231,10 @@ struct GptOssEagerBf16PackTraits {
         std::vector<std::uint8_t>& host_bounce)
     {
         const DeviceBuf* sections[kSections] = {
-            &ctx.dst_gate,
-            &ctx.dst_up,
-            &ctx.dst_down,
+            &ctx.dst_gu_w,
+            &ctx.dst_gu_s,
+            &ctx.dst_dn_w,
+            &ctx.dst_dn_s,
         };
         expert_pack_emit_slot_sections(
             writer, table, sections, kSections, host_bounce);
@@ -229,13 +243,13 @@ struct GptOssEagerBf16PackTraits {
 
 }  // namespace
 
-bool ensure_gpt_oss_eager_bf16_expert_pack(
+bool ensure_gpt_oss_routed_mxfp4_expert_pack(
     StreamedExpertTable& table,
     const std::string& cache_key,
     SafetensorsCheckpointSource& checkpoint,
     bool verbose)
 {
-    return ensure_expert_pack<GptOssEagerBf16PackTraits>(
+    return ensure_expert_pack<GptOssRoutedMxfp4PackTraits>(
         table, cache_key, checkpoint, verbose);
 }
 

--- a/driver/cuda/src/model/gpt_oss_routed_mxfp4_pack.cpp
+++ b/driver/cuda/src/model/gpt_oss_routed_mxfp4_pack.cpp
@@ -87,6 +87,13 @@ struct GptOssRoutedMxfp4PackTraits {
         }
         ctx.hidden = ctx.gu_groups * 32;
         ctx.down_groups_full = static_cast<int>(dn_w_info.shape[2]);
+        if (ctx.down_groups_full != ctx.full_intermediate / 32) {
+            throw std::runtime_error(
+                "expert pack: RoutedDecode down groups " +
+                std::to_string(ctx.down_groups_full) +
+                " != full_intermediate/32 (" +
+                std::to_string(ctx.full_intermediate / 32) + ")");
+        }
         ctx.down_groups_local = ctx.local_intermediate / 32;
 
         const std::uint64_t i_local =

--- a/driver/cuda/src/model/loaded_model.cpp
+++ b/driver/cuda/src/model/loaded_model.cpp
@@ -369,9 +369,12 @@ LoadedModel LoadedModel::load(const Config& boot_cfg, NcclComm* tp_comm) {
     if (boot_cfg.model.stream_routed_experts) {
         log_stage("build streamed expert table begin");
         e.streamed_experts_ = streamed_expert_table_from_program(rust_view);
-        // Offline packs (native Marlin / eager BF16): build/remap with
-        // bounded staging *before* resident materialize so peak VRAM stays
-        // O(one expert). Kind is set by the stream arch recipe.
+        e.streamed_experts_.tp_rank = boot_cfg.distributed.tp_rank;
+        e.streamed_experts_.tp_size =
+            std::max(1, boot_cfg.distributed.tp_size);
+        // Offline packs (native Marlin / eager BF16 / RoutedDecode TP):
+        // build/remap with bounded staging *before* resident materialize so
+        // peak VRAM stays O(one expert). Kind is set by the stream arch recipe.
         log_stage("ensure streamed expert pack begin");
         ensure_streamed_expert_pack(
             e.streamed_experts_, rust_plan.cache_key, loader, verbose);

--- a/driver/cuda/src/model/mixtral.cpp
+++ b/driver/cuda/src/model/mixtral.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstdlib>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -169,7 +170,10 @@ void mixtral_forward_paged(
     const int V  = cfg.vocab_size;
     const int d  = cfg.head_dim;
     const float eps = cfg.rms_norm_eps;
-    cudaStream_t stream = nullptr;
+    // Match llama_like: kernels and NCCL must share cuBLAS's stream so
+    // GEMMs, custom kernels, and TP all-reduces stay ordered. nullptr here
+    // races whenever cuBLAS is bound to a non-default stream.
+    cudaStream_t stream = cublas.stream();
     NcclComm* tp = (T > 1) ? fwd_cfg.tp_comm : nullptr;
     const bool tp_is_leader = (T == 1) || (tp != nullptr && tp->rank() == 0);
 
@@ -255,10 +259,36 @@ void mixtral_forward_paged(
         if (layer.v_bias) kernels::launch_add_bias_bf16(
             ws.v.data(), layer.v_bias->data(), N, Hk, stream);
 
-        kernels::launch_rope_bf16(
-            ws.q.data(), ws.k.data(), positions,
-            N, num_q_heads_local, num_kv_heads_local, d,
-            cfg.rope_theta, stream);
+        // GPT-OSS uses YaRN-original; Mixtral uses standard RoPE. Dispatch
+        // from fwd_cfg so TP+streaming GPT-OSS does not silently fall back
+        // to the wrong kernel.
+        if (fwd_cfg.rope_kind == RopeKind::YaRN) {
+            kernels::launch_rope_yarn_bf16(
+                ws.q.data(), ws.k.data(), positions,
+                N, num_q_heads_local, num_kv_heads_local, d,
+                cfg.rope_theta,
+                fwd_cfg.yarn_factor,
+                fwd_cfg.yarn_low_freq_factor,
+                fwd_cfg.yarn_high_freq_factor,
+                fwd_cfg.yarn_original_max_position,
+                stream);
+        } else if (fwd_cfg.rope_kind == RopeKind::YaRNOriginal) {
+            kernels::launch_rope_yarn_original_bf16(
+                ws.q.data(), ws.k.data(), positions,
+                N, num_q_heads_local, num_kv_heads_local, d,
+                cfg.rope_theta,
+                fwd_cfg.yarn_factor,
+                fwd_cfg.yarn_beta_fast,
+                fwd_cfg.yarn_beta_slow,
+                fwd_cfg.yarn_attention_factor,
+                fwd_cfg.yarn_original_max_position,
+                stream);
+        } else {
+            kernels::launch_rope_bf16(
+                ws.q.data(), ws.k.data(), positions,
+                N, num_q_heads_local, num_kv_heads_local, d,
+                cfg.rope_theta, stream);
+        }
 
         auto kv_view = cache.layer_view(L);
         kernels::launch_write_kv_to_pages(
@@ -918,14 +948,42 @@ void mixtral_forward_paged(
             kernels::launch_residual_add_bf16(
                 ws.y.data(), ws.norm_x.data(), N * H, stream);
         }
+
+        // Localize sticky CUDA illegal-memory-access errors (common under
+        // TP+streaming) to the layer that first faulted.
+        if (const char* sync = std::getenv("PIE_CUDA_SYNC_LAYERS");
+            sync != nullptr && sync[0] != '\0' && sync[0] != '0') {
+            const cudaError_t pe = cudaPeekAtLastError();
+            if (pe != cudaSuccess) {
+                throw std::runtime_error(
+                    std::string("mixtral/gpt_oss: CUDA error after MoE layer ") +
+                    std::to_string(L) + ": " + cudaGetErrorString(pe));
+            }
+            CUDA_CHECK(cudaStreamSynchronize(stream));
+            CUDA_CHECK(cudaDeviceSynchronize());
+        }
     }
 
     kernels::launch_rmsnorm_bf16(
         ws.y.data(), w.final_norm->data(), ws.norm_x.data(),
         N, H, eps, stream);
+    if (static_cast<std::size_t>(N) >
+        (ws.logits.shape().empty()
+             ? 0
+             : static_cast<std::size_t>(ws.logits.shape()[0]))) {
+        throw std::runtime_error(
+            "mixtral/gpt_oss: lm_head rows N=" + std::to_string(N) +
+            " exceed logits capacity");
+    }
     ops::gemm_act_x_wt_bf16(cublas.handle(),
         ws.norm_x.data(), w.lm_head->data(), ws.logits.data(),
         N, V, H);
+    if (const char* sync = std::getenv("PIE_CUDA_SYNC_LAYERS");
+        sync != nullptr && sync[0] != '\0' && sync[0] != '0') {
+        CUDA_CHECK(cudaGetLastError());
+        CUDA_CHECK(cudaStreamSynchronize(stream));
+        CUDA_CHECK(cudaDeviceSynchronize());
+    }
 }
 
 }  // namespace pie_cuda_driver::model

--- a/driver/cuda/src/model/mixtral_tp_bf16_pack.cpp
+++ b/driver/cuda/src/model/mixtral_tp_bf16_pack.cpp
@@ -1,0 +1,209 @@
+#include "model/expert_pack_build.hpp"
+#include "model/expert_pack_cache.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "cuda_check.hpp"
+#include "tensor.hpp"
+
+namespace pie_cuda_driver {
+namespace {
+
+// Contiguous TP-local BF16 sections for Mixtral under tp_size>1.
+// HF: w1/w3 [I,H] row-major, w2 [H,I]. Pack densifies the w2 column shard
+// (strided in HF) so the streamer can page contiguous extents.
+struct MixtralTpBf16PackTraits {
+    static constexpr int kSections = 3;
+
+    static const char* miss_label()
+    {
+        return "streaming Mixtral TP BF16 pack";
+    }
+
+    static void require_build_support() {}
+
+    struct Context {
+        int full_intermediate = 0;
+        int local_start = 0;
+        int local_intermediate = 0;
+        int hidden = 0;
+        std::uint64_t w1_span = 0;
+        std::uint64_t w2_span = 0;
+        std::uint64_t w3_span = 0;
+        DeviceBuf src_w1;
+        DeviceBuf src_w2;
+        DeviceBuf src_w3;
+        DeviceBuf dst_w1;
+        DeviceBuf dst_w2;
+        DeviceBuf dst_w3;
+    };
+
+    static Context prepare(
+        const StreamedExpertTable& table,
+        SafetensorsCheckpointSource& checkpoint)
+    {
+        const int tp = std::max(1, table.tp_size);
+        const int rank = table.tp_rank;
+        if (tp <= 1) {
+            throw std::runtime_error(
+                "expert pack: MixtralTpBf16 requires tp_size>1");
+        }
+        const auto& sb = table.section_bytes;
+
+        const std::string w1_name =
+            "model.layers.0.block_sparse_moe.experts.0.w1.weight";
+        const std::string w2_name =
+            "model.layers.0.block_sparse_moe.experts.0.w2.weight";
+        const std::string w3_name =
+            "model.layers.0.block_sparse_moe.experts.0.w3.weight";
+        const auto& w1_info = checkpoint.info(w1_name);
+        const auto& w2_info = checkpoint.info(w2_name);
+        const auto& w3_info = checkpoint.info(w3_name);
+        if (w1_info.shape.size() != 2 || w2_info.shape.size() != 2 ||
+            w3_info.shape.size() != 2) {
+            throw std::runtime_error(
+                "expert pack: unexpected Mixtral expert weight ranks");
+        }
+
+        Context ctx;
+        ctx.full_intermediate = static_cast<int>(w1_info.shape[0]);
+        ctx.hidden = static_cast<int>(w1_info.shape[1]);
+        if (static_cast<int>(w3_info.shape[0]) != ctx.full_intermediate ||
+            static_cast<int>(w3_info.shape[1]) != ctx.hidden) {
+            throw std::runtime_error(
+                "expert pack: Mixtral w3 shape must match w1");
+        }
+        if (static_cast<int>(w2_info.shape[0]) != ctx.hidden ||
+            static_cast<int>(w2_info.shape[1]) != ctx.full_intermediate) {
+            throw std::runtime_error(
+                "expert pack: Mixtral w2 expected [H, I]");
+        }
+        if (ctx.full_intermediate % tp != 0) {
+            throw std::runtime_error(
+                "expert pack: intermediate not divisible by tp_size");
+        }
+        ctx.local_intermediate = ctx.full_intermediate / tp;
+        ctx.local_start = rank * ctx.local_intermediate;
+
+        const std::uint64_t i_local =
+            static_cast<std::uint64_t>(ctx.local_intermediate);
+        const std::uint64_t h = static_cast<std::uint64_t>(ctx.hidden);
+        const std::uint64_t w1_bytes = i_local * h * 2;
+        const std::uint64_t w2_bytes = h * i_local * 2;
+        const std::uint64_t expect[kSections] = {w1_bytes, w2_bytes, w1_bytes};
+        if (sb.size() != static_cast<std::size_t>(kSections)) {
+            throw std::runtime_error(
+                "expert pack: Mixtral TP expected " +
+                std::to_string(kSections) + " section_bytes, got " +
+                std::to_string(sb.size()));
+        }
+        for (int i = 0; i < kSections; ++i) {
+            if (sb[static_cast<std::size_t>(i)] != expect[i]) {
+                throw std::runtime_error(
+                    "expert pack: Mixtral TP section_bytes[" +
+                    std::to_string(i) + "]=" +
+                    std::to_string(sb[static_cast<std::size_t>(i)]) +
+                    " != expected " + std::to_string(expect[i]) +
+                    " (I_local=" + std::to_string(ctx.local_intermediate) +
+                    " H=" + std::to_string(ctx.hidden) + ")");
+            }
+        }
+
+        ctx.w1_span = checkpoint.storage_info(w1_name).nbytes;
+        ctx.w2_span = checkpoint.storage_info(w2_name).nbytes;
+        ctx.w3_span = checkpoint.storage_info(w3_name).nbytes;
+        ctx.src_w1 = DeviceBuf(ctx.w1_span);
+        ctx.src_w2 = DeviceBuf(ctx.w2_span);
+        ctx.src_w3 = DeviceBuf(ctx.w3_span);
+        ctx.dst_w1 = DeviceBuf(sb[0]);
+        ctx.dst_w2 = DeviceBuf(sb[1]);
+        ctx.dst_w3 = DeviceBuf(sb[2]);
+        return ctx;
+    }
+
+    static void load_expert(
+        Context& ctx,
+        SafetensorsCheckpointSource& checkpoint,
+        int layer,
+        int expert)
+    {
+        const std::string p =
+            "model.layers." + std::to_string(layer) +
+            ".block_sparse_moe.experts." + std::to_string(expert) + ".";
+        const auto w1 = checkpoint.storage_info(p + "w1.weight");
+        const auto w2 = checkpoint.storage_info(p + "w2.weight");
+        const auto w3 = checkpoint.storage_info(p + "w3.weight");
+        checkpoint.copy_storage_bytes_to_device(
+            w1.shard_id, w1.file_offset, ctx.w1_span, ctx.src_w1.ptr);
+        checkpoint.copy_storage_bytes_to_device(
+            w2.shard_id, w2.file_offset, ctx.w2_span, ctx.src_w2.ptr);
+        checkpoint.copy_storage_bytes_to_device(
+            w3.shard_id, w3.file_offset, ctx.w3_span, ctx.src_w3.ptr);
+    }
+
+    static void transform(Context& ctx)
+    {
+        // w1/w3: [I, H] BF16 — contiguous row slice for local intermediate.
+        const std::size_t row_bytes =
+            static_cast<std::size_t>(ctx.hidden) * 2;
+        const std::size_t row_offset =
+            static_cast<std::size_t>(ctx.local_start) * row_bytes;
+        const std::size_t copy_bytes =
+            static_cast<std::size_t>(ctx.local_intermediate) * row_bytes;
+        CUDA_CHECK(cudaMemcpy(
+            ctx.dst_w1.ptr,
+            static_cast<const std::uint8_t*>(ctx.src_w1.ptr) + row_offset,
+            copy_bytes, cudaMemcpyDeviceToDevice));
+        CUDA_CHECK(cudaMemcpy(
+            ctx.dst_w3.ptr,
+            static_cast<const std::uint8_t*>(ctx.src_w3.ptr) + row_offset,
+            copy_bytes, cudaMemcpyDeviceToDevice));
+
+        // w2: [H, I] BF16 — gather local columns into a dense [H, I_local].
+        const std::size_t full_row_bytes =
+            static_cast<std::size_t>(ctx.full_intermediate) * 2;
+        const std::size_t local_row_bytes =
+            static_cast<std::size_t>(ctx.local_intermediate) * 2;
+        const std::size_t col_offset =
+            static_cast<std::size_t>(ctx.local_start) * 2;
+        CUDA_CHECK(cudaMemcpy2D(
+            ctx.dst_w2.ptr, local_row_bytes,
+            static_cast<const std::uint8_t*>(ctx.src_w2.ptr) + col_offset,
+            full_row_bytes, local_row_bytes,
+            static_cast<std::size_t>(ctx.hidden), cudaMemcpyDeviceToDevice));
+
+        CUDA_CHECK(cudaDeviceSynchronize());
+    }
+
+    static void emit(
+        Context& ctx,
+        ExpertPackWriter& writer,
+        const StreamedExpertTable& table,
+        std::vector<std::uint8_t>& host_bounce)
+    {
+        const DeviceBuf* sections[kSections] = {
+            &ctx.dst_w1,
+            &ctx.dst_w2,
+            &ctx.dst_w3,
+        };
+        expert_pack_emit_slot_sections(
+            writer, table, sections, kSections, host_bounce);
+    }
+};
+
+}  // namespace
+
+bool ensure_mixtral_tp_bf16_expert_pack(
+    StreamedExpertTable& table,
+    const std::string& cache_key,
+    SafetensorsCheckpointSource& checkpoint,
+    bool verbose)
+{
+    return ensure_expert_pack<MixtralTpBf16PackTraits>(
+        table, cache_key, checkpoint, verbose);
+}
+
+}  // namespace pie_cuda_driver

--- a/driver/cuda/src/model/qwen35_moe_tp_bf16_pack.cpp
+++ b/driver/cuda/src/model/qwen35_moe_tp_bf16_pack.cpp
@@ -1,0 +1,221 @@
+#include "model/expert_pack_build.hpp"
+#include "model/expert_pack_cache.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "cuda_check.hpp"
+#include "tensor.hpp"
+
+namespace pie_cuda_driver {
+namespace {
+
+// Contiguous TP-local BF16 sections for Qwen3.5-MoE fused banks under tp>1.
+// HF: gate_up [E, 2I, H] (rows [0,I)=gate, [I,2I)=up), down [E, H, I].
+// Pack densifies gate/up halves and down columns into contiguous local-I
+// sections so the streamer can page them.
+struct Qwen35MoeTpBf16PackTraits {
+    static constexpr int kSections = 2;
+
+    static const char* miss_label()
+    {
+        return "streaming Qwen3.5-MoE TP BF16 pack";
+    }
+
+    static void require_build_support() {}
+
+    struct Context {
+        int full_intermediate = 0;
+        int local_start = 0;
+        int local_intermediate = 0;
+        int hidden = 0;
+        int num_experts = 0;
+        std::string prefix_root;
+        std::uint64_t gu_span = 0;
+        std::uint64_t dn_span = 0;
+        DeviceBuf src_gu;
+        DeviceBuf src_dn;
+        DeviceBuf dst_gu;
+        DeviceBuf dst_dn;
+    };
+
+    static std::string resolve_prefix_root(
+        SafetensorsCheckpointSource& checkpoint)
+    {
+        const std::string lm =
+            "model.language_model.layers.0.mlp.experts.gate_up_proj";
+        if (checkpoint.contains(lm)) {
+            return "model.language_model.layers.";
+        }
+        return "model.layers.";
+    }
+
+    static Context prepare(
+        const StreamedExpertTable& table,
+        SafetensorsCheckpointSource& checkpoint)
+    {
+        const int tp = std::max(1, table.tp_size);
+        const int rank = table.tp_rank;
+        if (tp <= 1) {
+            throw std::runtime_error(
+                "expert pack: Qwen35MoeTpBf16 requires tp_size>1");
+        }
+        const auto& sb = table.section_bytes;
+
+        Context ctx;
+        ctx.prefix_root = resolve_prefix_root(checkpoint);
+        ctx.num_experts = table.num_experts;
+        const std::string gu_name =
+            ctx.prefix_root + "0.mlp.experts.gate_up_proj";
+        const std::string dn_name =
+            ctx.prefix_root + "0.mlp.experts.down_proj";
+        const auto& gu_info = checkpoint.info(gu_name);
+        const auto& dn_info = checkpoint.info(dn_name);
+        if (gu_info.shape.size() != 3 || dn_info.shape.size() != 3) {
+            throw std::runtime_error(
+                "expert pack: unexpected Qwen3.5-MoE fused expert ranks");
+        }
+        if (static_cast<int>(gu_info.shape[0]) != ctx.num_experts ||
+            static_cast<int>(dn_info.shape[0]) != ctx.num_experts) {
+            throw std::runtime_error(
+                "expert pack: Qwen3.5-MoE fused bank expert count mismatch");
+        }
+        if (gu_info.shape[1] % 2 != 0) {
+            throw std::runtime_error(
+                "expert pack: Qwen3.5-MoE gate_up expected [E, 2I, H]");
+        }
+        ctx.full_intermediate = static_cast<int>(gu_info.shape[1] / 2);
+        ctx.hidden = static_cast<int>(gu_info.shape[2]);
+        if (static_cast<int>(dn_info.shape[1]) != ctx.hidden ||
+            static_cast<int>(dn_info.shape[2]) != ctx.full_intermediate) {
+            throw std::runtime_error(
+                "expert pack: Qwen3.5-MoE down expected [E, H, I]");
+        }
+        if (ctx.full_intermediate % tp != 0) {
+            throw std::runtime_error(
+                "expert pack: intermediate not divisible by tp_size");
+        }
+        ctx.local_intermediate = ctx.full_intermediate / tp;
+        ctx.local_start = rank * ctx.local_intermediate;
+
+        const std::uint64_t i_local =
+            static_cast<std::uint64_t>(ctx.local_intermediate);
+        const std::uint64_t h = static_cast<std::uint64_t>(ctx.hidden);
+        const std::uint64_t gu_bytes = 2 * i_local * h * 2;
+        const std::uint64_t dn_bytes = h * i_local * 2;
+        const std::uint64_t expect[kSections] = {gu_bytes, dn_bytes};
+        if (sb.size() != static_cast<std::size_t>(kSections)) {
+            throw std::runtime_error(
+                "expert pack: Qwen3.5-MoE TP expected " +
+                std::to_string(kSections) + " section_bytes, got " +
+                std::to_string(sb.size()));
+        }
+        for (int i = 0; i < kSections; ++i) {
+            if (sb[static_cast<std::size_t>(i)] != expect[i]) {
+                throw std::runtime_error(
+                    "expert pack: Qwen3.5-MoE TP section_bytes[" +
+                    std::to_string(i) + "]=" +
+                    std::to_string(sb[static_cast<std::size_t>(i)]) +
+                    " != expected " + std::to_string(expect[i]) +
+                    " (I_local=" + std::to_string(ctx.local_intermediate) +
+                    " H=" + std::to_string(ctx.hidden) + ")");
+            }
+        }
+
+        const auto gu_store = checkpoint.storage_info(gu_name);
+        const auto dn_store = checkpoint.storage_info(dn_name);
+        ctx.gu_span = gu_store.nbytes / static_cast<std::uint64_t>(ctx.num_experts);
+        ctx.dn_span = dn_store.nbytes / static_cast<std::uint64_t>(ctx.num_experts);
+        ctx.src_gu = DeviceBuf(ctx.gu_span);
+        ctx.src_dn = DeviceBuf(ctx.dn_span);
+        ctx.dst_gu = DeviceBuf(sb[0]);
+        ctx.dst_dn = DeviceBuf(sb[1]);
+        return ctx;
+    }
+
+    static void load_expert(
+        Context& ctx,
+        SafetensorsCheckpointSource& checkpoint,
+        int layer,
+        int expert)
+    {
+        const std::string p =
+            ctx.prefix_root + std::to_string(layer) + ".mlp.experts.";
+        const auto gu = checkpoint.storage_info(p + "gate_up_proj");
+        const auto dn = checkpoint.storage_info(p + "down_proj");
+        const auto e = static_cast<std::uint64_t>(expert);
+        checkpoint.copy_storage_bytes_to_device(
+            gu.shard_id, gu.file_offset + e * ctx.gu_span, ctx.gu_span,
+            ctx.src_gu.ptr);
+        checkpoint.copy_storage_bytes_to_device(
+            dn.shard_id, dn.file_offset + e * ctx.dn_span, ctx.dn_span,
+            ctx.src_dn.ptr);
+    }
+
+    static void transform(Context& ctx)
+    {
+        // gate_up: [2I, H] BF16 — copy gate then up local row halves into
+        // contiguous [2*I_local, H] (matches resident ByteSpan TP layout).
+        const std::size_t row_bytes =
+            static_cast<std::size_t>(ctx.hidden) * 2;
+        const std::size_t half_bytes =
+            static_cast<std::size_t>(ctx.local_intermediate) * row_bytes;
+        const std::size_t gate_off =
+            static_cast<std::size_t>(ctx.local_start) * row_bytes;
+        const std::size_t up_off =
+            static_cast<std::size_t>(ctx.full_intermediate + ctx.local_start) *
+            row_bytes;
+        auto* dst = static_cast<std::uint8_t*>(ctx.dst_gu.ptr);
+        const auto* src = static_cast<const std::uint8_t*>(ctx.src_gu.ptr);
+        CUDA_CHECK(cudaMemcpy(
+            dst, src + gate_off, half_bytes, cudaMemcpyDeviceToDevice));
+        CUDA_CHECK(cudaMemcpy(
+            dst + half_bytes, src + up_off, half_bytes,
+            cudaMemcpyDeviceToDevice));
+
+        // down: [H, I] BF16 — gather local columns into dense [H, I_local].
+        const std::size_t full_row_bytes =
+            static_cast<std::size_t>(ctx.full_intermediate) * 2;
+        const std::size_t local_row_bytes =
+            static_cast<std::size_t>(ctx.local_intermediate) * 2;
+        const std::size_t col_offset =
+            static_cast<std::size_t>(ctx.local_start) * 2;
+        CUDA_CHECK(cudaMemcpy2D(
+            ctx.dst_dn.ptr, local_row_bytes,
+            static_cast<const std::uint8_t*>(ctx.src_dn.ptr) + col_offset,
+            full_row_bytes, local_row_bytes,
+            static_cast<std::size_t>(ctx.hidden), cudaMemcpyDeviceToDevice));
+
+        CUDA_CHECK(cudaDeviceSynchronize());
+    }
+
+    static void emit(
+        Context& ctx,
+        ExpertPackWriter& writer,
+        const StreamedExpertTable& table,
+        std::vector<std::uint8_t>& host_bounce)
+    {
+        const DeviceBuf* sections[kSections] = {
+            &ctx.dst_gu,
+            &ctx.dst_dn,
+        };
+        expert_pack_emit_slot_sections(
+            writer, table, sections, kSections, host_bounce);
+    }
+};
+
+}  // namespace
+
+bool ensure_qwen35_moe_tp_bf16_expert_pack(
+    StreamedExpertTable& table,
+    const std::string& cache_key,
+    SafetensorsCheckpointSource& checkpoint,
+    bool verbose)
+{
+    return ensure_expert_pack<Qwen35MoeTpBf16PackTraits>(
+        table, cache_key, checkpoint, verbose);
+}
+
+}  // namespace pie_cuda_driver

--- a/driver/cuda/src/model/qwen3_moe_tp_bf16_pack.cpp
+++ b/driver/cuda/src/model/qwen3_moe_tp_bf16_pack.cpp
@@ -1,0 +1,210 @@
+#include "model/expert_pack_build.hpp"
+#include "model/expert_pack_cache.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include "cuda_check.hpp"
+#include "tensor.hpp"
+
+namespace pie_cuda_driver {
+namespace {
+
+// Contiguous TP-local BF16 sections for plain Qwen3-MoE under tp_size>1.
+// HF: gate/up [I,H], down [H,I]. Pack densifies the down column shard
+// (strided in HF) so the streamer can page contiguous extents.
+struct Qwen3MoeTpBf16PackTraits {
+    static constexpr int kSections = 3;
+
+    static const char* miss_label()
+    {
+        return "streaming Qwen3-MoE TP BF16 pack";
+    }
+
+    static void require_build_support() {}
+
+    struct Context {
+        int full_intermediate = 0;
+        int local_start = 0;
+        int local_intermediate = 0;
+        int hidden = 0;
+        std::uint64_t gate_span = 0;
+        std::uint64_t up_span = 0;
+        std::uint64_t down_span = 0;
+        DeviceBuf src_gate;
+        DeviceBuf src_up;
+        DeviceBuf src_down;
+        DeviceBuf dst_gate;
+        DeviceBuf dst_up;
+        DeviceBuf dst_down;
+    };
+
+    static Context prepare(
+        const StreamedExpertTable& table,
+        SafetensorsCheckpointSource& checkpoint)
+    {
+        const int tp = std::max(1, table.tp_size);
+        const int rank = table.tp_rank;
+        if (tp <= 1) {
+            throw std::runtime_error(
+                "expert pack: Qwen3MoeTpBf16 requires tp_size>1");
+        }
+        const auto& sb = table.section_bytes;
+
+        const std::string gate_name =
+            "model.layers.0.mlp.experts.0.gate_proj.weight";
+        const std::string up_name =
+            "model.layers.0.mlp.experts.0.up_proj.weight";
+        const std::string down_name =
+            "model.layers.0.mlp.experts.0.down_proj.weight";
+        const auto& gate_info = checkpoint.info(gate_name);
+        const auto& up_info = checkpoint.info(up_name);
+        const auto& down_info = checkpoint.info(down_name);
+        if (gate_info.shape.size() != 2 || up_info.shape.size() != 2 ||
+            down_info.shape.size() != 2) {
+            throw std::runtime_error(
+                "expert pack: unexpected Qwen3-MoE expert weight ranks");
+        }
+
+        Context ctx;
+        ctx.full_intermediate = static_cast<int>(gate_info.shape[0]);
+        ctx.hidden = static_cast<int>(gate_info.shape[1]);
+        if (static_cast<int>(up_info.shape[0]) != ctx.full_intermediate ||
+            static_cast<int>(up_info.shape[1]) != ctx.hidden) {
+            throw std::runtime_error(
+                "expert pack: Qwen3-MoE up shape must match gate");
+        }
+        if (static_cast<int>(down_info.shape[0]) != ctx.hidden ||
+            static_cast<int>(down_info.shape[1]) != ctx.full_intermediate) {
+            throw std::runtime_error(
+                "expert pack: Qwen3-MoE down expected [H, I]");
+        }
+        if (ctx.full_intermediate % tp != 0) {
+            throw std::runtime_error(
+                "expert pack: intermediate not divisible by tp_size");
+        }
+        ctx.local_intermediate = ctx.full_intermediate / tp;
+        ctx.local_start = rank * ctx.local_intermediate;
+
+        const std::uint64_t i_local =
+            static_cast<std::uint64_t>(ctx.local_intermediate);
+        const std::uint64_t h = static_cast<std::uint64_t>(ctx.hidden);
+        const std::uint64_t gate_bytes = i_local * h * 2;
+        const std::uint64_t down_bytes = h * i_local * 2;
+        const std::uint64_t expect[kSections] = {
+            gate_bytes, gate_bytes, down_bytes};
+        if (sb.size() != static_cast<std::size_t>(kSections)) {
+            throw std::runtime_error(
+                "expert pack: Qwen3-MoE TP expected " +
+                std::to_string(kSections) + " section_bytes, got " +
+                std::to_string(sb.size()));
+        }
+        for (int i = 0; i < kSections; ++i) {
+            if (sb[static_cast<std::size_t>(i)] != expect[i]) {
+                throw std::runtime_error(
+                    "expert pack: Qwen3-MoE TP section_bytes[" +
+                    std::to_string(i) + "]=" +
+                    std::to_string(sb[static_cast<std::size_t>(i)]) +
+                    " != expected " + std::to_string(expect[i]) +
+                    " (I_local=" + std::to_string(ctx.local_intermediate) +
+                    " H=" + std::to_string(ctx.hidden) + ")");
+            }
+        }
+
+        ctx.gate_span = checkpoint.storage_info(gate_name).nbytes;
+        ctx.up_span = checkpoint.storage_info(up_name).nbytes;
+        ctx.down_span = checkpoint.storage_info(down_name).nbytes;
+        ctx.src_gate = DeviceBuf(ctx.gate_span);
+        ctx.src_up = DeviceBuf(ctx.up_span);
+        ctx.src_down = DeviceBuf(ctx.down_span);
+        ctx.dst_gate = DeviceBuf(sb[0]);
+        ctx.dst_up = DeviceBuf(sb[1]);
+        ctx.dst_down = DeviceBuf(sb[2]);
+        return ctx;
+    }
+
+    static void load_expert(
+        Context& ctx,
+        SafetensorsCheckpointSource& checkpoint,
+        int layer,
+        int expert)
+    {
+        const std::string p =
+            "model.layers." + std::to_string(layer) + ".mlp.experts." +
+            std::to_string(expert) + ".";
+        const auto gate = checkpoint.storage_info(p + "gate_proj.weight");
+        const auto up = checkpoint.storage_info(p + "up_proj.weight");
+        const auto down = checkpoint.storage_info(p + "down_proj.weight");
+        checkpoint.copy_storage_bytes_to_device(
+            gate.shard_id, gate.file_offset, ctx.gate_span, ctx.src_gate.ptr);
+        checkpoint.copy_storage_bytes_to_device(
+            up.shard_id, up.file_offset, ctx.up_span, ctx.src_up.ptr);
+        checkpoint.copy_storage_bytes_to_device(
+            down.shard_id, down.file_offset, ctx.down_span, ctx.src_down.ptr);
+    }
+
+    static void transform(Context& ctx)
+    {
+        // gate/up: [I, H] BF16 — contiguous row slice for local intermediate.
+        const std::size_t row_bytes =
+            static_cast<std::size_t>(ctx.hidden) * 2;
+        const std::size_t row_offset =
+            static_cast<std::size_t>(ctx.local_start) * row_bytes;
+        const std::size_t copy_bytes =
+            static_cast<std::size_t>(ctx.local_intermediate) * row_bytes;
+        CUDA_CHECK(cudaMemcpy(
+            ctx.dst_gate.ptr,
+            static_cast<const std::uint8_t*>(ctx.src_gate.ptr) + row_offset,
+            copy_bytes, cudaMemcpyDeviceToDevice));
+        CUDA_CHECK(cudaMemcpy(
+            ctx.dst_up.ptr,
+            static_cast<const std::uint8_t*>(ctx.src_up.ptr) + row_offset,
+            copy_bytes, cudaMemcpyDeviceToDevice));
+
+        // down: [H, I] BF16 — gather local columns into a dense [H, I_local].
+        const std::size_t full_row_bytes =
+            static_cast<std::size_t>(ctx.full_intermediate) * 2;
+        const std::size_t local_row_bytes =
+            static_cast<std::size_t>(ctx.local_intermediate) * 2;
+        const std::size_t col_offset =
+            static_cast<std::size_t>(ctx.local_start) * 2;
+        CUDA_CHECK(cudaMemcpy2D(
+            ctx.dst_down.ptr, local_row_bytes,
+            static_cast<const std::uint8_t*>(ctx.src_down.ptr) + col_offset,
+            full_row_bytes, local_row_bytes,
+            static_cast<std::size_t>(ctx.hidden), cudaMemcpyDeviceToDevice));
+
+        CUDA_CHECK(cudaDeviceSynchronize());
+    }
+
+    static void emit(
+        Context& ctx,
+        ExpertPackWriter& writer,
+        const StreamedExpertTable& table,
+        std::vector<std::uint8_t>& host_bounce)
+    {
+        const DeviceBuf* sections[kSections] = {
+            &ctx.dst_gate,
+            &ctx.dst_up,
+            &ctx.dst_down,
+        };
+        expert_pack_emit_slot_sections(
+            writer, table, sections, kSections, host_bounce);
+    }
+};
+
+}  // namespace
+
+bool ensure_qwen3_moe_tp_bf16_expert_pack(
+    StreamedExpertTable& table,
+    const std::string& cache_key,
+    SafetensorsCheckpointSource& checkpoint,
+    bool verbose)
+{
+    return ensure_expert_pack<Qwen3MoeTpBf16PackTraits>(
+        table, cache_key, checkpoint, verbose);
+}
+
+}  // namespace pie_cuda_driver

--- a/driver/weight_loader/include/weight_loader.h
+++ b/driver/weight_loader/include/weight_loader.h
@@ -14,7 +14,7 @@
 
 namespace pie_weight_loader {
 
-constexpr static const uint32_t STORAGE_PROGRAM_VERSION = 5;
+constexpr static const uint32_t STORAGE_PROGRAM_VERSION = 6;
 
 enum class PieLoaderBackendKind {
   Cuda = 0,
@@ -52,6 +52,7 @@ enum class PieLoaderExpertPackKind {
   None = 0,
   GptOssNativeMarlin = 1,
   GptOssEagerBf16 = 2,
+  GptOssRoutedMxfp4 = 3,
 };
 
 enum class PieLoaderMxfp4MoePolicy {

--- a/driver/weight_loader/include/weight_loader.h
+++ b/driver/weight_loader/include/weight_loader.h
@@ -53,6 +53,7 @@ enum class PieLoaderExpertPackKind {
   GptOssNativeMarlin = 1,
   GptOssEagerBf16 = 2,
   GptOssRoutedMxfp4 = 3,
+  MixtralTpBf16 = 4,
 };
 
 enum class PieLoaderMxfp4MoePolicy {

--- a/driver/weight_loader/include/weight_loader.h
+++ b/driver/weight_loader/include/weight_loader.h
@@ -54,6 +54,8 @@ enum class PieLoaderExpertPackKind {
   GptOssEagerBf16 = 2,
   GptOssRoutedMxfp4 = 3,
   MixtralTpBf16 = 4,
+  Qwen35MoeTpBf16 = 5,
+  Qwen3MoeTpBf16 = 6,
 };
 
 enum class PieLoaderMxfp4MoePolicy {

--- a/driver/weight_loader/include/weight_loader.h
+++ b/driver/weight_loader/include/weight_loader.h
@@ -56,6 +56,7 @@ enum class PieLoaderExpertPackKind {
   MixtralTpBf16 = 4,
   Qwen35MoeTpBf16 = 5,
   Qwen3MoeTpBf16 = 6,
+  Dsv4TpMxfp4 = 7,
 };
 
 enum class PieLoaderMxfp4MoePolicy {

--- a/driver/weight_loader/spec/storage_program.md
+++ b/driver/weight_loader/spec/storage_program.md
@@ -71,6 +71,13 @@ stay resident).
 - Mixtral `MixtralTpBf16`: contiguous BF16 `w1`/`w3` row slices and densified
   `w2` columns under `tp_size > 1`; at `tp_size = 1` Mixtral still pages full
   HF experts (`pack_kind = None`).
+- Qwen3.5-MoE `Qwen35MoeTpBf16`: contiguous fused BF16 `gate_up`/`down` local-I
+  sections under `tp_size > 1` (gate/up halves concatenated, down columns
+  densified); shared expert and router stay resident. At `tp_size = 1`, fused
+  banks page as full HF expert slices (`pack_kind = None`).
+- Qwen3-MoE `Qwen3MoeTpBf16`: contiguous named BF16 `gate`/`up`/`down` local-I
+  sections under `tp_size > 1` (down columns densified); at `tp_size = 1`,
+  named experts page as full HF tensors (`pack_kind = None`).
 
 Arches without a per-rank pack still reject `stream_routed_experts &&
 tp_size > 1`.

--- a/driver/weight_loader/spec/storage_program.md
+++ b/driver/weight_loader/spec/storage_program.md
@@ -46,15 +46,30 @@ They are described by `StorageProgram.stream`:
 - `stream.files` / `section_offsets` / `section_bytes` / `slot_bytes`: layout
   the driver's expert stream cache needs to open shards and size the slab.
 - `stream.pack_kind`: selects the driver's offline pack builder (`None`,
-  GPT-OSS Native Marlin, GPT-OSS Eager BF16); set by the same arch selectors
-  that choose section layout.
+  GPT-OSS Native Marlin, GPT-OSS Eager BF16, GPT-OSS RoutedDecode TP MXFP4);
+  set by the same arch selectors that choose section layout.
 
 Boot execution runs `schedule` only. On a cache miss the driver executes the
 template into `slot_base` with sources taken from `bindings` for that
 `(layer, expert)` — deferred loader execution, not a parallel I/O path.
 
 Supported arches today: `deepseek_v4`, `gpt_oss`, `mixtral`, `qwen3_moe`,
-`qwen3_5_moe` (plain ExtentWrite; GPT-OSS RoutedDequant streams HF packs;
-GPT-OSS native streams a Marlin expert pack; GPT-OSS eager_bf16 streams a
-BF16 expert pack; biases stay resident; Qwen shared expert / router stay
-resident).
+`qwen3_5_moe` (plain ExtentWrite; GPT-OSS RoutedDequant streams HF packs at
+`tp_size=1`; GPT-OSS native streams a Marlin expert pack; GPT-OSS eager_bf16
+streams a BF16 expert pack; biases stay resident; Qwen shared expert / router
+stay resident).
+
+## Version 6 — GPT-OSS TP + streaming packs
+
+`STORAGE_PROGRAM_VERSION = 6` adds `ExpertPackKind::GptOssRoutedMxfp4` and
+sizes GPT-OSS stream sections for TP-local intermediate
+(`I_local = I_full / tp_size`). Under `tp_size > 1`, each rank builds a
+contiguous `{cache_key}.experts` pack (cache key already includes
+`tp_rank`/`tp_size`):
+
+- Native Marlin / Eager BF16: pack builders apply the same row/column offsets
+  as resident TP.
+- RoutedDecode: switches from HF bindings to a dense local-I MXFP4 pack
+  (down groups are strided in HF and must be gathered).
+
+Non–GPT-OSS arches still reject `stream_routed_experts && tp_size > 1`.

--- a/driver/weight_loader/spec/storage_program.md
+++ b/driver/weight_loader/spec/storage_program.md
@@ -68,6 +68,10 @@ stay resident).
 - GPT-OSS `GptOssRoutedMxfp4` / Native Marlin / Eager BF16: section sizes use
   `I_local = I_full / tp_size`; builders apply the same row/column offsets as
   resident TP (RoutedDecode densifies strided down groups).
+- DeepSeek-V4 `Dsv4TpMxfp4`: contiguous MXFP4 `w1`/`w3` row slices and densified
+  `w2` columns (weight+scale) under `tp_size > 1`; shared experts / MTP /
+  router stay resident. At `tp_size = 1`, named experts page as full HF
+  tensors (`pack_kind = None`).
 - Mixtral `MixtralTpBf16`: contiguous BF16 `w1`/`w3` row slices and densified
   `w2` columns under `tp_size > 1`; at `tp_size = 1` Mixtral still pages full
   HF experts (`pack_kind = None`).

--- a/driver/weight_loader/spec/storage_program.md
+++ b/driver/weight_loader/spec/storage_program.md
@@ -59,17 +59,18 @@ Supported arches today: `deepseek_v4`, `gpt_oss`, `mixtral`, `qwen3_moe`,
 streams a BF16 expert pack; biases stay resident; Qwen shared expert / router
 stay resident).
 
-## Version 6 — GPT-OSS TP + streaming packs
+## Version 6 — TP + streaming packs
 
-`STORAGE_PROGRAM_VERSION = 6` adds `ExpertPackKind::GptOssRoutedMxfp4` and
-sizes GPT-OSS stream sections for TP-local intermediate
-(`I_local = I_full / tp_size`). Under `tp_size > 1`, each rank builds a
-contiguous `{cache_key}.experts` pack (cache key already includes
-`tp_rank`/`tp_size`):
+`STORAGE_PROGRAM_VERSION = 6` adds TP-local expert packs so
+`stream_routed_experts && tp_size > 1` can page contiguous per-rank extents
+(cache key already includes `tp_rank`/`tp_size`):
 
-- Native Marlin / Eager BF16: pack builders apply the same row/column offsets
-  as resident TP.
-- RoutedDecode: switches from HF bindings to a dense local-I MXFP4 pack
-  (down groups are strided in HF and must be gathered).
+- GPT-OSS `GptOssRoutedMxfp4` / Native Marlin / Eager BF16: section sizes use
+  `I_local = I_full / tp_size`; builders apply the same row/column offsets as
+  resident TP (RoutedDecode densifies strided down groups).
+- Mixtral `MixtralTpBf16`: contiguous BF16 `w1`/`w3` row slices and densified
+  `w2` columns under `tp_size > 1`; at `tp_size = 1` Mixtral still pages full
+  HF experts (`pack_kind = None`).
 
-Non–GPT-OSS arches still reject `stream_routed_experts && tp_size > 1`.
+Arches without a per-rank pack still reject `stream_routed_experts &&
+tp_size > 1`.

--- a/driver/weight_loader/src/abi.rs
+++ b/driver/weight_loader/src/abi.rs
@@ -658,8 +658,8 @@ impl DefaultAbiBuilder<'_> {
         if self.target.tp_size > 1 && arch.pack_kind == crate::storage::ExpertPackKind::None {
             return Err(CompileError::InvalidInput(
                 "stream_routed_experts with tp_size>1 requires a per-rank \
-                 expert pack (supported: gpt_oss, mixtral, qwen3_moe, \
-                 qwen3_5_moe); other arches still require tp_size=1"
+                 expert pack (supported: deepseek_v4, gpt_oss, mixtral, \
+                 qwen3_moe, qwen3_5_moe); other arches still require tp_size=1"
                     .to_string(),
             ));
         }

--- a/driver/weight_loader/src/abi.rs
+++ b/driver/weight_loader/src/abi.rs
@@ -653,10 +653,14 @@ impl DefaultAbiBuilder<'_> {
                 self.cfg.model_type
             )));
         };
-        if self.target.tp_size > 1 {
+        // GPT-OSS packs each rank's TP-local expert slices into a contiguous
+        // on-disk pack. Other arches still need strided HF extents the
+        // streamer cannot page.
+        if self.target.tp_size > 1 && !self.profile().gpt_oss_mxfp4_groups {
             return Err(CompileError::InvalidInput(
-                "stream_routed_experts requires tp_size=1 (per-expert TP shards \
-                 are strided file extents, which streaming does not support yet)"
+                "stream_routed_experts with tp_size>1 is only supported for \
+                 gpt_oss (per-rank expert packs); other arches still require \
+                 tp_size=1"
                     .to_string(),
             ));
         }
@@ -1665,7 +1669,7 @@ impl DefaultAbiBuilder<'_> {
                 if self.target.stream_routed_experts {
                     // Marlin weights live in the offline expert pack; keep
                     // biases resident for bind-time deinterleave.
-                    self.push_direct(bias, format!("{base}.bias"), None);
+                    self.push_gpt_oss_streaming_bias(bias, base)?;
                 } else {
                     self.add_gpt_oss_native_mxfp4_group(block, scale, bias, base)?;
                 }
@@ -1674,7 +1678,7 @@ impl DefaultAbiBuilder<'_> {
             {
                 // Packed weight/scale are deferred to the stream plan; keep
                 // the BF16 bias resident for bind-time deinterleave.
-                self.push_direct(bias, format!("{base}.bias"), None);
+                self.push_gpt_oss_streaming_bias(bias, base)?;
             } else {
                 self.push_direct(block, format!("{base}.weight"), None);
                 self.push_direct(scale, format!("{base}.weight_scale"), None);
@@ -1684,6 +1688,73 @@ impl DefaultAbiBuilder<'_> {
             self.consumed.insert(scale.id);
             self.consumed.insert(bias.id);
         }
+        Ok(())
+    }
+
+    /// Streaming keeps fused gate_up / down biases resident. Under TP, shard
+    /// gate_up bias rows to `{E, 2*I_local}` so bind_gpt_oss deinterleave matches
+    /// local intermediate; down bias stays full `{E, H}`.
+    fn push_gpt_oss_streaming_bias(
+        &mut self,
+        bias: &RawTensor,
+        base: &str,
+    ) -> Result<(), CompileError> {
+        if base.ends_with("down_proj") || self.target.tp_size <= 1 {
+            self.push_direct(bias, format!("{base}.bias"), None);
+            return Ok(());
+        }
+        if !base.ends_with("gate_up_proj") {
+            self.push_direct(bias, format!("{base}.bias"), None);
+            return Ok(());
+        }
+        if bias.shape.len() != 2 {
+            return Err(CompileError::InvalidInput(format!(
+                "GPT-OSS streaming gate_up bias '{base}' expected rank-2, got {:?}",
+                bias.shape
+            )));
+        }
+        let experts = bias.shape[0];
+        let fused_rows = bias.shape[1];
+        if fused_rows % 2 != 0 {
+            return Err(CompileError::InvalidInput(format!(
+                "GPT-OSS streaming gate_up bias '{base}' expected even fused rows, got {fused_rows}"
+            )));
+        }
+        let full_intermediate = fused_rows / 2;
+        let (local_start, local_intermediate) = local_range(full_intermediate, self.target)?;
+        let local_fused = local_intermediate * 2;
+        let source_row_offset = local_start * 2;
+        let (dtype, encoding) = match &bias.encoding {
+            Encoding::Raw(dt) => (*dt, bias.encoding.clone()),
+            other => {
+                return Err(CompileError::InvalidInput(format!(
+                    "GPT-OSS streaming gate_up bias '{base}' expected raw encoding, got {other:?}"
+                )));
+            }
+        };
+        self.push_repack(
+            format!("{base}.bias"),
+            bias,
+            dtype,
+            encoding,
+            vec![experts, local_fused],
+            RepackSpec {
+                layout: RepackLayout::DenseRowGather,
+                row_map: RowMap::Identity,
+                batch: u32_dim(experts, "GPT-OSS experts")?,
+                source_rows: u32_dim(fused_rows, "GPT-OSS gate_up bias source rows")?,
+                source_row_offset: u32_dim(
+                    source_row_offset,
+                    "GPT-OSS gate_up bias source row offset",
+                )?,
+                target_rows: u32_dim(local_fused, "GPT-OSS gate_up bias target rows")?,
+                valid_rows: u32_dim(local_fused, "GPT-OSS gate_up bias valid rows")?,
+                source_stride_cols: 1,
+                source_col_offset: 0,
+                source_cols: 1,
+                target_cols: 1,
+            },
+        );
         Ok(())
     }
 
@@ -2013,7 +2084,7 @@ fn dense_fused_projection_budget_bytes() -> u64 {
         .unwrap_or(DEFAULT_BUDGET)
 }
 
-fn local_range(full: i64, target: &StorageTarget) -> Result<(i64, i64), CompileError> {
+pub(crate) fn local_range(full: i64, target: &StorageTarget) -> Result<(i64, i64), CompileError> {
     let world = i64::from(target.tp_size.max(1));
     let rank = i64::from(target.tp_rank);
     if full % world != 0 {

--- a/driver/weight_loader/src/abi.rs
+++ b/driver/weight_loader/src/abi.rs
@@ -658,8 +658,8 @@ impl DefaultAbiBuilder<'_> {
         if self.target.tp_size > 1 && arch.pack_kind == crate::storage::ExpertPackKind::None {
             return Err(CompileError::InvalidInput(
                 "stream_routed_experts with tp_size>1 requires a per-rank \
-                 expert pack (supported: gpt_oss, mixtral); other arches \
-                 still require tp_size=1"
+                 expert pack (supported: gpt_oss, mixtral, qwen3_moe, \
+                 qwen3_5_moe); other arches still require tp_size=1"
                     .to_string(),
             ));
         }
@@ -1191,6 +1191,11 @@ impl DefaultAbiBuilder<'_> {
 
     fn add_fused_moe_gate_up_tp_slices(&mut self) -> Result<(), CompileError> {
         if self.target.tp_size <= 1 {
+            return Ok(());
+        }
+        // Streamed fused banks are densified offline into a per-rank pack;
+        // do not also emit resident TP ByteSpans from the same HF tensors.
+        if self.target.stream_routed_experts {
             return Ok(());
         }
         let candidates: Vec<RawTensor> = self

--- a/driver/weight_loader/src/abi.rs
+++ b/driver/weight_loader/src/abi.rs
@@ -653,14 +653,13 @@ impl DefaultAbiBuilder<'_> {
                 self.cfg.model_type
             )));
         };
-        // GPT-OSS packs each rank's TP-local expert slices into a contiguous
-        // on-disk pack. Other arches still need strided HF extents the
-        // streamer cannot page.
-        if self.target.tp_size > 1 && !self.profile().gpt_oss_mxfp4_groups {
+        // Under tp_size>1 the streamer needs contiguous per-rank extents, so
+        // the arch recipe must request an offline pack (GPT-OSS / Mixtral).
+        if self.target.tp_size > 1 && arch.pack_kind == crate::storage::ExpertPackKind::None {
             return Err(CompileError::InvalidInput(
-                "stream_routed_experts with tp_size>1 is only supported for \
-                 gpt_oss (per-rank expert packs); other arches still require \
-                 tp_size=1"
+                "stream_routed_experts with tp_size>1 requires a per-rank \
+                 expert pack (supported: gpt_oss, mixtral); other arches \
+                 still require tp_size=1"
                     .to_string(),
             ));
         }

--- a/driver/weight_loader/src/ffi_arena.rs
+++ b/driver/weight_loader/src/ffi_arena.rs
@@ -193,6 +193,12 @@ impl FfiArena {
                     crate::storage::ExpertPackKind::MixtralTpBf16 => {
                         PieLoaderExpertPackKind::MixtralTpBf16
                     }
+                    crate::storage::ExpertPackKind::Qwen35MoeTpBf16 => {
+                        PieLoaderExpertPackKind::Qwen35MoeTpBf16
+                    }
+                    crate::storage::ExpertPackKind::Qwen3MoeTpBf16 => {
+                        PieLoaderExpertPackKind::Qwen3MoeTpBf16
+                    }
                 },
             },
         }

--- a/driver/weight_loader/src/ffi_arena.rs
+++ b/driver/weight_loader/src/ffi_arena.rs
@@ -190,6 +190,9 @@ impl FfiArena {
                     crate::storage::ExpertPackKind::GptOssRoutedMxfp4 => {
                         PieLoaderExpertPackKind::GptOssRoutedMxfp4
                     }
+                    crate::storage::ExpertPackKind::MixtralTpBf16 => {
+                        PieLoaderExpertPackKind::MixtralTpBf16
+                    }
                 },
             },
         }

--- a/driver/weight_loader/src/ffi_arena.rs
+++ b/driver/weight_loader/src/ffi_arena.rs
@@ -187,6 +187,9 @@ impl FfiArena {
                     crate::storage::ExpertPackKind::GptOssEagerBf16 => {
                         PieLoaderExpertPackKind::GptOssEagerBf16
                     }
+                    crate::storage::ExpertPackKind::GptOssRoutedMxfp4 => {
+                        PieLoaderExpertPackKind::GptOssRoutedMxfp4
+                    }
                 },
             },
         }

--- a/driver/weight_loader/src/ffi_arena.rs
+++ b/driver/weight_loader/src/ffi_arena.rs
@@ -199,6 +199,9 @@ impl FfiArena {
                     crate::storage::ExpertPackKind::Qwen3MoeTpBf16 => {
                         PieLoaderExpertPackKind::Qwen3MoeTpBf16
                     }
+                    crate::storage::ExpertPackKind::Dsv4TpMxfp4 => {
+                        PieLoaderExpertPackKind::Dsv4TpMxfp4
+                    }
                 },
             },
         }

--- a/driver/weight_loader/src/ffi_types.rs
+++ b/driver/weight_loader/src/ffi_types.rs
@@ -613,6 +613,7 @@ pub enum PieLoaderExpertPackKind {
     MixtralTpBf16 = 4,
     Qwen35MoeTpBf16 = 5,
     Qwen3MoeTpBf16 = 6,
+    Dsv4TpMxfp4 = 7,
 }
 
 /// Deferred expert-load plan exposed to the C++ stream cache.

--- a/driver/weight_loader/src/ffi_types.rs
+++ b/driver/weight_loader/src/ffi_types.rs
@@ -610,6 +610,7 @@ pub enum PieLoaderExpertPackKind {
     GptOssNativeMarlin = 1,
     GptOssEagerBf16 = 2,
     GptOssRoutedMxfp4 = 3,
+    MixtralTpBf16 = 4,
 }
 
 /// Deferred expert-load plan exposed to the C++ stream cache.

--- a/driver/weight_loader/src/ffi_types.rs
+++ b/driver/weight_loader/src/ffi_types.rs
@@ -611,6 +611,8 @@ pub enum PieLoaderExpertPackKind {
     GptOssEagerBf16 = 2,
     GptOssRoutedMxfp4 = 3,
     MixtralTpBf16 = 4,
+    Qwen35MoeTpBf16 = 5,
+    Qwen3MoeTpBf16 = 6,
 }
 
 /// Deferred expert-load plan exposed to the C++ stream cache.

--- a/driver/weight_loader/src/ffi_types.rs
+++ b/driver/weight_loader/src/ffi_types.rs
@@ -609,6 +609,7 @@ pub enum PieLoaderExpertPackKind {
     None = 0,
     GptOssNativeMarlin = 1,
     GptOssEagerBf16 = 2,
+    GptOssRoutedMxfp4 = 3,
 }
 
 /// Deferred expert-load plan exposed to the C++ stream cache.

--- a/driver/weight_loader/src/storage.rs
+++ b/driver/weight_loader/src/storage.rs
@@ -181,8 +181,8 @@ pub enum StorageInstr {
 ///
 /// When non-[`Self::None`], the CUDA driver builds (or opens) a transformed
 /// host pack with bounded staging before paging sections through the expert
-/// stream cache. Plain ExtentWrite streams (HF packs / Mixtral BF16) leave
-/// this as `None`.
+/// stream cache. Plain ExtentWrite streams (HF packs / Mixtral BF16 at
+/// `tp_size=1`) leave this as `None`.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[repr(u32)]
 pub enum ExpertPackKind {
@@ -192,6 +192,8 @@ pub enum ExpertPackKind {
     GptOssEagerBf16 = 2,
     /// Contiguous TP-local HF MXFP4 sections (RoutedDecode under tp_size>1).
     GptOssRoutedMxfp4 = 3,
+    /// Contiguous TP-local Mixtral BF16 w1/w2/w3 (tp_size>1 densify).
+    MixtralTpBf16 = 4,
 }
 
 /// One deferred source extent for a streamed expert section.

--- a/driver/weight_loader/src/storage.rs
+++ b/driver/weight_loader/src/storage.rs
@@ -194,6 +194,10 @@ pub enum ExpertPackKind {
     GptOssRoutedMxfp4 = 3,
     /// Contiguous TP-local Mixtral BF16 w1/w2/w3 (tp_size>1 densify).
     MixtralTpBf16 = 4,
+    /// Contiguous TP-local Qwen3.5-MoE fused BF16 gate_up/down (tp_size>1).
+    Qwen35MoeTpBf16 = 5,
+    /// Contiguous TP-local Qwen3-MoE named BF16 gate/up/down (tp_size>1).
+    Qwen3MoeTpBf16 = 6,
 }
 
 /// One deferred source extent for a streamed expert section.

--- a/driver/weight_loader/src/storage.rs
+++ b/driver/weight_loader/src/storage.rs
@@ -6,7 +6,7 @@ use crate::types::{
     TensorDecl, TensorId,
 };
 
-pub const STORAGE_PROGRAM_VERSION: u32 = 5;
+pub const STORAGE_PROGRAM_VERSION: u32 = 6;
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MemoryPlan {
@@ -190,6 +190,8 @@ pub enum ExpertPackKind {
     None = 0,
     GptOssNativeMarlin = 1,
     GptOssEagerBf16 = 2,
+    /// Contiguous TP-local HF MXFP4 sections (RoutedDecode under tp_size>1).
+    GptOssRoutedMxfp4 = 3,
 }
 
 /// One deferred source extent for a streamed expert section.

--- a/driver/weight_loader/src/storage.rs
+++ b/driver/weight_loader/src/storage.rs
@@ -198,6 +198,8 @@ pub enum ExpertPackKind {
     Qwen35MoeTpBf16 = 5,
     /// Contiguous TP-local Qwen3-MoE named BF16 gate/up/down (tp_size>1).
     Qwen3MoeTpBf16 = 6,
+    /// Contiguous TP-local DeepSeek-V4 MXFP4 w1/w2/w3 × weight/scale (tp>1).
+    Dsv4TpMxfp4 = 7,
 }
 
 /// One deferred source extent for a streamed expert section.

--- a/driver/weight_loader/src/stream.rs
+++ b/driver/weight_loader/src/stream.rs
@@ -33,9 +33,11 @@ pub struct StreamArchDesc {
     /// Which checkpoint tensors are streamed (and skipped from the resident ABI).
     pub is_streamed: fn(&str) -> bool,
     /// Build flat bindings `[L * E * sections.len()]` in layer-major, then
-    /// expert, then section order.
+    /// expert, then section order. `target` carries TP geometry for recipes
+    /// that emit per-rank local-I section sizes.
     pub collect_bindings: fn(
         &CheckpointMetadata,
+        &crate::storage::StorageTarget,
         num_layers: u32,
         num_experts: u32,
     ) -> Result<Vec<StreamBinding>, CompileError>,
@@ -154,7 +156,8 @@ pub fn attach_stream_plan(
     let sections = arch.sections.len();
     let expected = (num_layers as usize) * (num_experts_u as usize) * sections;
 
-    let bindings = (arch.collect_bindings)(metadata, num_layers, num_experts_u)?;
+    let bindings =
+        (arch.collect_bindings)(metadata, &program.target, num_layers, num_experts_u)?;
     if bindings.len() != expected {
         return Err(CompileError::InvalidInput(format!(
             "stream_routed_experts: collect_bindings returned {} entries, \
@@ -294,6 +297,7 @@ mod tests {
 
     fn fake_collect(
         metadata: &CheckpointMetadata,
+        _target: &crate::storage::StorageTarget,
         num_layers: u32,
         num_experts: u32,
     ) -> Result<Vec<StreamBinding>, CompileError> {

--- a/driver/weight_loader/src/stream_arch.rs
+++ b/driver/weight_loader/src/stream_arch.rs
@@ -644,8 +644,127 @@ pub(crate) const MIXTRAL_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
     pack_kind: ExpertPackKind::None,
 };
 
-pub(crate) fn select_mixtral(_target: &StorageTarget) -> Option<StreamArchDesc> {
-    Some(MIXTRAL_STREAM_ARCH)
+fn mixtral_find_tensor<'a>(
+    metadata: &'a CheckpointMetadata,
+    name: &str,
+) -> Result<&'a RawTensor, CompileError> {
+    metadata
+        .tensors
+        .iter()
+        .find(|t| t.name == name)
+        .ok_or_else(|| {
+            CompileError::InvalidInput(format!(
+                "stream_routed_experts: missing Mixtral expert tensor '{name}'"
+            ))
+        })
+}
+
+/// TP-local BF16 section sizes for Mixtral packs under `tp_size>1`.
+///
+/// HF: w1/w3 `[I, H]`, w2 `[H, I]`. Pack stores dense `I_local` slices so the
+/// streamer can page contiguous extents (w2 columns are strided in HF).
+pub(crate) fn mixtral_tp_section_bytes(
+    w1: &RawTensor,
+    w2: &RawTensor,
+    w3: &RawTensor,
+    target: &StorageTarget,
+) -> Result<[u64; 3], CompileError> {
+    if w1.shape.len() != 2 || w2.shape.len() != 2 || w3.shape.len() != 2 {
+        return Err(CompileError::InvalidInput(
+            "stream_routed_experts: Mixtral TP pack expects 2-D w1/w2/w3 tensors"
+                .to_string(),
+        ));
+    }
+    let i_full = w1.shape[0];
+    let hidden = w1.shape[1];
+    if w3.shape != w1.shape {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: Mixtral w3 shape {:?} must match w1 {:?}",
+            w3.shape, w1.shape
+        )));
+    }
+    if w2.shape[0] != hidden || w2.shape[1] != i_full {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: Mixtral w2 expected [{hidden}, {i_full}], got {:?}",
+            w2.shape
+        )));
+    }
+    let (_local_start, local_intermediate) = tp_local_range(i_full, target)?;
+    let i_local = local_intermediate as u64;
+    let h = hidden as u64;
+    let w1_bytes = i_local * h * 2;
+    let w2_bytes = h * i_local * 2;
+    Ok([w1_bytes, w2_bytes, w1_bytes])
+}
+
+fn mixtral_tp_collect_bindings(
+    metadata: &CheckpointMetadata,
+    target: &StorageTarget,
+    num_layers: u32,
+    num_experts: u32,
+) -> Result<Vec<StreamBinding>, CompileError> {
+    let e = num_experts as u64;
+    if e == 0 {
+        return Err(CompileError::InvalidInput(
+            "stream_routed_experts: Mixtral num_experts must be > 0".to_string(),
+        ));
+    }
+    const SECTION_ALIGN: u64 = 256;
+    let mut bindings = Vec::with_capacity(
+        (num_layers as usize) * (num_experts as usize) * MIXTRAL_EXPERT_SECTIONS.len(),
+    );
+    let mut section_bytes: Option<[u64; 3]> = None;
+    let mut section_offsets = [0u64; 3];
+    let mut slot_bytes = 0u64;
+    for layer in 0..num_layers {
+        let prefix = format!("model.layers.{layer}.block_sparse_moe.experts.0.");
+        let w1 = mixtral_find_tensor(metadata, &format!("{prefix}w1.weight"))?;
+        let w2 = mixtral_find_tensor(metadata, &format!("{prefix}w2.weight"))?;
+        let w3 = mixtral_find_tensor(metadata, &format!("{prefix}w3.weight"))?;
+        let bytes = mixtral_tp_section_bytes(w1, w2, w3, target)?;
+        if let Some(prev) = section_bytes {
+            if prev != bytes {
+                return Err(CompileError::InvalidInput(format!(
+                    "stream_routed_experts: Mixtral TP section sizes differ \
+                     across layers (layer {layer})"
+                )));
+            }
+        } else {
+            let mut off = 0u64;
+            for s in 0..3 {
+                section_offsets[s] = off;
+                off = align_up_u64(off + bytes[s], SECTION_ALIGN);
+            }
+            slot_bytes = off;
+            section_bytes = Some(bytes);
+        }
+        for expert in 0..e {
+            let base = (layer as u64 * e + expert) * slot_bytes;
+            for s in 0..3 {
+                bindings.push(StreamBinding {
+                    file_id: crate::types::FileId(0),
+                    file_offset: base + section_offsets[s],
+                    span_bytes: bytes[s],
+                });
+            }
+        }
+    }
+    Ok(bindings)
+}
+
+pub(crate) const MIXTRAL_TP_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
+    sections: MIXTRAL_EXPERT_SECTIONS,
+    is_streamed: is_mixtral_routed_expert_tensor,
+    collect_bindings: mixtral_tp_collect_bindings,
+    pack_kind: ExpertPackKind::MixtralTpBf16,
+};
+
+pub(crate) fn select_mixtral(target: &StorageTarget) -> Option<StreamArchDesc> {
+    if target.tp_size > 1 {
+        Some(MIXTRAL_TP_STREAM_ARCH)
+    } else {
+        Some(MIXTRAL_STREAM_ARCH)
+    }
 }
 
 /// Plain Qwen3-MoE per-expert BF16 weights — must match `qwen_moe_expert_sections.hpp`.

--- a/driver/weight_loader/src/stream_arch.rs
+++ b/driver/weight_loader/src/stream_arch.rs
@@ -836,8 +836,129 @@ pub(crate) const QWEN3_MOE_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
     pack_kind: ExpertPackKind::None,
 };
 
-pub(crate) fn select_qwen3_moe(_target: &StorageTarget) -> Option<StreamArchDesc> {
-    Some(QWEN3_MOE_STREAM_ARCH)
+fn qwen3_moe_find_tensor<'a>(
+    metadata: &'a CheckpointMetadata,
+    name: &str,
+) -> Result<&'a RawTensor, CompileError> {
+    metadata
+        .tensors
+        .iter()
+        .find(|t| t.name == name)
+        .ok_or_else(|| {
+            CompileError::InvalidInput(format!(
+                "stream_routed_experts: missing Qwen3-MoE expert tensor '{name}'"
+            ))
+        })
+}
+
+/// TP-local BF16 section sizes for plain Qwen3-MoE packs under `tp_size>1`.
+///
+/// HF: gate/up `[I, H]`, down `[H, I]`. Pack stores dense `I_local` slices so
+/// the streamer can page contiguous extents (down columns are strided in HF).
+pub(crate) fn qwen3_moe_tp_section_bytes(
+    gate: &RawTensor,
+    up: &RawTensor,
+    down: &RawTensor,
+    target: &StorageTarget,
+) -> Result<[u64; 3], CompileError> {
+    if gate.shape.len() != 2 || up.shape.len() != 2 || down.shape.len() != 2 {
+        return Err(CompileError::InvalidInput(
+            "stream_routed_experts: Qwen3-MoE TP pack expects 2-D \
+             gate/up/down tensors"
+                .to_string(),
+        ));
+    }
+    let i_full = gate.shape[0];
+    let hidden = gate.shape[1];
+    if up.shape != gate.shape {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: Qwen3-MoE up shape {:?} must match gate {:?}",
+            up.shape, gate.shape
+        )));
+    }
+    if down.shape[0] != hidden || down.shape[1] != i_full {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: Qwen3-MoE down expected [{hidden}, {i_full}], \
+             got {:?}",
+            down.shape
+        )));
+    }
+    let (_local_start, local_intermediate) = tp_local_range(i_full, target)?;
+    let i_local = local_intermediate as u64;
+    let h = hidden as u64;
+    let gate_bytes = i_local * h * 2;
+    let down_bytes = h * i_local * 2;
+    Ok([gate_bytes, gate_bytes, down_bytes])
+}
+
+fn qwen3_moe_tp_collect_bindings(
+    metadata: &CheckpointMetadata,
+    target: &StorageTarget,
+    num_layers: u32,
+    num_experts: u32,
+) -> Result<Vec<StreamBinding>, CompileError> {
+    let e = num_experts as u64;
+    if e == 0 {
+        return Err(CompileError::InvalidInput(
+            "stream_routed_experts: Qwen3-MoE num_experts must be > 0".to_string(),
+        ));
+    }
+    const SECTION_ALIGN: u64 = 256;
+    let mut bindings = Vec::with_capacity(
+        (num_layers as usize) * (num_experts as usize) * QWEN3_MOE_EXPERT_SECTIONS.len(),
+    );
+    let mut section_bytes: Option<[u64; 3]> = None;
+    let mut section_offsets = [0u64; 3];
+    let mut slot_bytes = 0u64;
+    for layer in 0..num_layers {
+        let prefix = format!("model.layers.{layer}.mlp.experts.0.");
+        let gate = qwen3_moe_find_tensor(metadata, &format!("{prefix}gate_proj.weight"))?;
+        let up = qwen3_moe_find_tensor(metadata, &format!("{prefix}up_proj.weight"))?;
+        let down = qwen3_moe_find_tensor(metadata, &format!("{prefix}down_proj.weight"))?;
+        let bytes = qwen3_moe_tp_section_bytes(gate, up, down, target)?;
+        if let Some(prev) = section_bytes {
+            if prev != bytes {
+                return Err(CompileError::InvalidInput(format!(
+                    "stream_routed_experts: Qwen3-MoE TP section sizes differ \
+                     across layers (layer {layer})"
+                )));
+            }
+        } else {
+            let mut off = 0u64;
+            for s in 0..3 {
+                section_offsets[s] = off;
+                off = align_up_u64(off + bytes[s], SECTION_ALIGN);
+            }
+            slot_bytes = off;
+            section_bytes = Some(bytes);
+        }
+        for expert in 0..e {
+            let base = (layer as u64 * e + expert) * slot_bytes;
+            for s in 0..3 {
+                bindings.push(StreamBinding {
+                    file_id: crate::types::FileId(0),
+                    file_offset: base + section_offsets[s],
+                    span_bytes: bytes[s],
+                });
+            }
+        }
+    }
+    Ok(bindings)
+}
+
+pub(crate) const QWEN3_MOE_TP_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
+    sections: QWEN3_MOE_EXPERT_SECTIONS,
+    is_streamed: is_qwen3_moe_routed_expert_tensor,
+    collect_bindings: qwen3_moe_tp_collect_bindings,
+    pack_kind: ExpertPackKind::Qwen3MoeTpBf16,
+};
+
+pub(crate) fn select_qwen3_moe(target: &StorageTarget) -> Option<StreamArchDesc> {
+    if target.tp_size > 1 {
+        Some(QWEN3_MOE_TP_STREAM_ARCH)
+    } else {
+        Some(QWEN3_MOE_STREAM_ARCH)
+    }
 }
 
 /// Qwen3.5/3.6-MoE fused BF16 banks — must match `qwen_moe_expert_sections.hpp`.
@@ -937,8 +1058,139 @@ pub(crate) const QWEN35_MOE_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
     pack_kind: ExpertPackKind::None,
 };
 
-pub(crate) fn select_qwen35_moe(_target: &StorageTarget) -> Option<StreamArchDesc> {
-    Some(QWEN35_MOE_STREAM_ARCH)
+fn qwen35_moe_prefix_root(metadata: &CheckpointMetadata) -> &'static str {
+    if metadata
+        .tensors
+        .iter()
+        .any(|t| t.name.starts_with("model.language_model.layers."))
+    {
+        "model.language_model.layers."
+    } else {
+        "model.layers."
+    }
+}
+
+/// TP-local BF16 section sizes for Qwen3.5-MoE fused packs under `tp_size>1`.
+///
+/// HF: gate_up `[E, 2I, H]`, down `[E, H, I]`. Pack stores dense local slices
+/// so gate/up row halves and down columns can be paged contiguously.
+pub(crate) fn qwen35_moe_tp_section_bytes(
+    gate_up: &RawTensor,
+    down: &RawTensor,
+    target: &StorageTarget,
+) -> Result<[u64; 2], CompileError> {
+    if gate_up.shape.len() != 3 || down.shape.len() != 3 {
+        return Err(CompileError::InvalidInput(
+            "stream_routed_experts: Qwen3.5-MoE TP pack expects 3-D fused \
+             gate_up/down tensors"
+                .to_string(),
+        ));
+    }
+    if gate_up.shape[1] % 2 != 0 {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: Qwen3.5-MoE gate_up expected [E, 2I, H], \
+             got {:?}",
+            gate_up.shape
+        )));
+    }
+    let i_full = gate_up.shape[1] / 2;
+    let hidden = gate_up.shape[2];
+    if down.shape[1] != hidden || down.shape[2] != i_full {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: Qwen3.5-MoE down expected [E, {hidden}, \
+             {i_full}], got {:?}",
+            down.shape
+        )));
+    }
+    if gate_up.shape[0] != down.shape[0] {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: Qwen3.5-MoE expert counts differ \
+             (gate_up E={}, down E={})",
+            gate_up.shape[0], down.shape[0]
+        )));
+    }
+    let (_local_start, local_intermediate) = tp_local_range(i_full, target)?;
+    let i_local = local_intermediate as u64;
+    let h = hidden as u64;
+    let gu_bytes = 2 * i_local * h * 2;
+    let dn_bytes = h * i_local * 2;
+    Ok([gu_bytes, dn_bytes])
+}
+
+fn qwen35_moe_tp_collect_bindings(
+    metadata: &CheckpointMetadata,
+    target: &StorageTarget,
+    num_layers: u32,
+    num_experts: u32,
+) -> Result<Vec<StreamBinding>, CompileError> {
+    let e = num_experts as u64;
+    if e == 0 {
+        return Err(CompileError::InvalidInput(
+            "stream_routed_experts: Qwen3.5-MoE num_experts must be > 0".to_string(),
+        ));
+    }
+    const SECTION_ALIGN: u64 = 256;
+    let prefix_root = qwen35_moe_prefix_root(metadata);
+    let mut bindings = Vec::with_capacity(
+        (num_layers as usize) * (num_experts as usize) * QWEN35_MOE_EXPERT_SECTIONS.len(),
+    );
+    let mut section_bytes: Option<[u64; 2]> = None;
+    let mut section_offsets = [0u64; 2];
+    let mut slot_bytes = 0u64;
+    for layer in 0..num_layers {
+        let prefix = format!("{prefix_root}{layer}.mlp.experts.");
+        let gate_up = qwen35_moe_find_tensor(metadata, &format!("{prefix}gate_up_proj"))?;
+        let down = qwen35_moe_find_tensor(metadata, &format!("{prefix}down_proj"))?;
+        if gate_up.shape[0] as u64 != e || down.shape[0] as u64 != e {
+            return Err(CompileError::InvalidInput(format!(
+                "stream_routed_experts: Qwen3.5-MoE fused bank expert count \
+                 at layer {layer} does not match num_experts={num_experts}"
+            )));
+        }
+        let bytes = qwen35_moe_tp_section_bytes(gate_up, down, target)?;
+        if let Some(prev) = section_bytes {
+            if prev != bytes {
+                return Err(CompileError::InvalidInput(format!(
+                    "stream_routed_experts: Qwen3.5-MoE TP section sizes differ \
+                     across layers (layer {layer})"
+                )));
+            }
+        } else {
+            let mut off = 0u64;
+            for s in 0..2 {
+                section_offsets[s] = off;
+                off = align_up_u64(off + bytes[s], SECTION_ALIGN);
+            }
+            slot_bytes = off;
+            section_bytes = Some(bytes);
+        }
+        for expert in 0..e {
+            let base = (layer as u64 * e + expert) * slot_bytes;
+            for s in 0..2 {
+                bindings.push(StreamBinding {
+                    file_id: crate::types::FileId(0),
+                    file_offset: base + section_offsets[s],
+                    span_bytes: bytes[s],
+                });
+            }
+        }
+    }
+    Ok(bindings)
+}
+
+pub(crate) const QWEN35_MOE_TP_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
+    sections: QWEN35_MOE_EXPERT_SECTIONS,
+    is_streamed: is_qwen35_moe_streamed_expert_tensor,
+    collect_bindings: qwen35_moe_tp_collect_bindings,
+    pack_kind: ExpertPackKind::Qwen35MoeTpBf16,
+};
+
+pub(crate) fn select_qwen35_moe(target: &StorageTarget) -> Option<StreamArchDesc> {
+    if target.tp_size > 1 {
+        Some(QWEN35_MOE_TP_STREAM_ARCH)
+    } else {
+        Some(QWEN35_MOE_STREAM_ARCH)
+    }
 }
 
 fn ends_with_any(value: &str, suffixes: &[&str]) -> bool {

--- a/driver/weight_loader/src/stream_arch.rs
+++ b/driver/weight_loader/src/stream_arch.rs
@@ -65,6 +65,7 @@ pub(crate) fn parse_dsv4_expert_section(name: &str) -> Option<(u32, u32, usize)>
 
 fn dsv4_collect_bindings(
     metadata: &CheckpointMetadata,
+    _target: &StorageTarget,
     num_layers: u32,
     num_experts: u32,
 ) -> Result<Vec<StreamBinding>, CompileError> {
@@ -130,6 +131,7 @@ fn gpt_oss_find_tensor<'a>(
 
 fn gpt_oss_collect_bindings(
     metadata: &CheckpointMetadata,
+    _target: &StorageTarget,
     num_layers: u32,
     num_experts: u32,
 ) -> Result<Vec<StreamBinding>, CompileError> {
@@ -212,10 +214,25 @@ fn align_up_u64(v: u64, a: u64) -> u64 {
     (v + a - 1) / a * a
 }
 
+fn tp_local_range(full: i64, target: &StorageTarget) -> Result<(i64, i64), CompileError> {
+    let world = i64::from(target.tp_size.max(1));
+    let rank = i64::from(target.tp_rank);
+    if full % world != 0 {
+        return Err(CompileError::InvalidInput(format!(
+            "dimension {full} is not divisible by tp_size {}",
+            target.tp_size
+        )));
+    }
+    let local = full / world;
+    Ok((rank * local, local))
+}
+
 /// Marlin per-expert section byte sizes from GPT-OSS fused HF bank shapes.
+/// Uses TP-local intermediate (`I_full / tp_size`), then pads to 128 for Marlin.
 pub(crate) fn gpt_oss_native_section_bytes(
     gate_up_blocks: &RawTensor,
     down_blocks: &RawTensor,
+    target: &StorageTarget,
 ) -> Result<[u64; 6], CompileError> {
     if gate_up_blocks.shape.len() != 4 || down_blocks.shape.len() != 4 {
         return Err(CompileError::InvalidInput(
@@ -234,13 +251,21 @@ pub(crate) fn gpt_oss_native_section_bytes(
             gate_up_blocks.shape
         )));
     }
-    let intermediate = fused_rows / 2;
-    let intermediate_native = align_up_u64(intermediate, 128);
+    let full_intermediate = (fused_rows / 2) as i64;
+    let (_local_start, local_intermediate) =
+        tp_local_range(full_intermediate, target)?;
+    if local_intermediate % 32 != 0 {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: GPT-OSS native TP shard I_local={local_intermediate} \
+             must be divisible by 32"
+        )));
+    }
+    let intermediate_native = align_up_u64(local_intermediate as u64, 128);
     let hidden = gu_groups * 32;
     let down_hidden = down_blocks.shape[1] as u64;
     let down_groups = down_blocks.shape[2] as u64;
     let down_lanes = down_blocks.shape[3] as u64;
-    if down_lanes != 16 || down_hidden != hidden || down_groups * 32 != intermediate {
+    if down_lanes != 16 || down_hidden != hidden || down_groups * 32 != full_intermediate as u64 {
         return Err(CompileError::InvalidInput(format!(
             "stream_routed_experts: GPT-OSS native down shape mismatch \
              (gate_up {:?}, down {:?})",
@@ -257,6 +282,7 @@ pub(crate) fn gpt_oss_native_section_bytes(
 
 fn gpt_oss_native_collect_bindings(
     metadata: &CheckpointMetadata,
+    target: &StorageTarget,
     num_layers: u32,
     num_experts: u32,
 ) -> Result<Vec<StreamBinding>, CompileError> {
@@ -282,7 +308,7 @@ fn gpt_oss_native_collect_bindings(
         // Still require scales to exist (consumed / validated by ABI skip).
         let _ = gpt_oss_find_tensor(metadata, &format!("{prefix}gate_up_proj_scales"))?;
         let _ = gpt_oss_find_tensor(metadata, &format!("{prefix}down_proj_scales"))?;
-        let bytes = gpt_oss_native_section_bytes(gate_up_w, down_w)?;
+        let bytes = gpt_oss_native_section_bytes(gate_up_w, down_w, target)?;
         if let Some(prev) = section_bytes {
             if prev != bytes {
                 return Err(CompileError::InvalidInput(format!(
@@ -322,14 +348,135 @@ pub(crate) const GPT_OSS_NATIVE_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
 };
 
 /// GPT-OSS stream recipe depends on `mxfp4_moe`: HF packs (routed_dequant),
-/// Marlin pack (native), or offline BF16 pack (eager_bf16).
+/// Marlin pack (native), or offline BF16 pack (eager_bf16). Under TP,
+/// RoutedDecode switches to a per-rank MXFP4 pack (strided down shards).
 pub(crate) fn select_gpt_oss(target: &StorageTarget) -> Option<StreamArchDesc> {
     match target.mxfp4_moe {
         Mxfp4MoePolicy::NativeGemm => Some(GPT_OSS_NATIVE_STREAM_ARCH),
         Mxfp4MoePolicy::EagerBf16 => Some(GPT_OSS_EAGER_BF16_STREAM_ARCH),
-        Mxfp4MoePolicy::RoutedDecode => Some(GPT_OSS_STREAM_ARCH),
+        Mxfp4MoePolicy::RoutedDecode => {
+            if target.tp_size > 1 {
+                Some(GPT_OSS_ROUTED_TP_STREAM_ARCH)
+            } else {
+                Some(GPT_OSS_STREAM_ARCH)
+            }
+        }
     }
 }
+
+/// TP-local HF MXFP4 section sizes for RoutedDecode packs.
+pub(crate) fn gpt_oss_routed_tp_section_bytes(
+    gate_up_blocks: &RawTensor,
+    down_blocks: &RawTensor,
+    target: &StorageTarget,
+) -> Result<[u64; 4], CompileError> {
+    if gate_up_blocks.shape.len() != 4 || down_blocks.shape.len() != 4 {
+        return Err(CompileError::InvalidInput(
+            "stream_routed_experts: GPT-OSS RoutedDecode TP pack expects 4-D \
+             gate_up/down _blocks tensors"
+                .to_string(),
+        ));
+    }
+    let fused_rows = gate_up_blocks.shape[1] as u64;
+    let gu_groups = gate_up_blocks.shape[2] as u64;
+    let gu_lanes = gate_up_blocks.shape[3] as u64;
+    if fused_rows % 2 != 0 || gu_lanes != 16 {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: GPT-OSS RoutedDecode gate_up expected \
+             [E, 2I, H/32, 16], got {:?}",
+            gate_up_blocks.shape
+        )));
+    }
+    let full_intermediate = (fused_rows / 2) as i64;
+    let (_local_start, local_intermediate) = tp_local_range(full_intermediate, target)?;
+    if local_intermediate % 32 != 0 {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: GPT-OSS RoutedDecode TP shard \
+             I_local={local_intermediate} must be divisible by 32"
+        )));
+    }
+    let i_local = local_intermediate as u64;
+    let hidden = gu_groups * 32;
+    let down_hidden = down_blocks.shape[1] as u64;
+    let down_groups = down_blocks.shape[2] as u64;
+    let down_lanes = down_blocks.shape[3] as u64;
+    if down_lanes != 16 || down_hidden != hidden || down_groups * 32 != full_intermediate as u64 {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: GPT-OSS RoutedDecode down shape mismatch \
+             (gate_up {:?}, down {:?})",
+            gate_up_blocks.shape, down_blocks.shape
+        )));
+    }
+    // Dense local HF MXFP4: gate_up rows 2*I_local; down groups I_local/32.
+    let gu_w = i_local * hidden; // 2*I_local * (H/32) * 16
+    let gu_s = 2 * i_local * (hidden / 32);
+    let dn_w = hidden * i_local / 2; // H * (I_local/32) * 16
+    let dn_s = hidden * (i_local / 32);
+    Ok([gu_w, gu_s, dn_w, dn_s])
+}
+
+fn gpt_oss_routed_tp_collect_bindings(
+    metadata: &CheckpointMetadata,
+    target: &StorageTarget,
+    num_layers: u32,
+    num_experts: u32,
+) -> Result<Vec<StreamBinding>, CompileError> {
+    let e = num_experts as u64;
+    if e == 0 {
+        return Err(CompileError::InvalidInput(
+            "stream_routed_experts: GPT-OSS num_experts must be > 0".to_string(),
+        ));
+    }
+    const SECTION_ALIGN: u64 = 256;
+    let mut bindings = Vec::with_capacity(
+        (num_layers as usize) * (num_experts as usize) * GPT_OSS_EXPERT_SECTIONS.len(),
+    );
+    let mut section_bytes: Option<[u64; 4]> = None;
+    let mut section_offsets = [0u64; 4];
+    let mut slot_bytes = 0u64;
+    for layer in 0..num_layers {
+        let prefix = format!("model.layers.{layer}.mlp.experts.");
+        let gate_up_w = gpt_oss_find_tensor(metadata, &format!("{prefix}gate_up_proj_blocks"))?;
+        let down_w = gpt_oss_find_tensor(metadata, &format!("{prefix}down_proj_blocks"))?;
+        let _ = gpt_oss_find_tensor(metadata, &format!("{prefix}gate_up_proj_scales"))?;
+        let _ = gpt_oss_find_tensor(metadata, &format!("{prefix}down_proj_scales"))?;
+        let bytes = gpt_oss_routed_tp_section_bytes(gate_up_w, down_w, target)?;
+        if let Some(prev) = section_bytes {
+            if prev != bytes {
+                return Err(CompileError::InvalidInput(format!(
+                    "stream_routed_experts: GPT-OSS RoutedDecode TP section \
+                     sizes differ across layers (layer {layer})"
+                )));
+            }
+        } else {
+            let mut off = 0u64;
+            for s in 0..4 {
+                section_offsets[s] = off;
+                off = align_up_u64(off + bytes[s], SECTION_ALIGN);
+            }
+            slot_bytes = off;
+            section_bytes = Some(bytes);
+        }
+        for expert in 0..e {
+            let base = (layer as u64 * e + expert) * slot_bytes;
+            for s in 0..4 {
+                bindings.push(StreamBinding {
+                    file_id: crate::types::FileId(0),
+                    file_offset: base + section_offsets[s],
+                    span_bytes: bytes[s],
+                });
+            }
+        }
+    }
+    Ok(bindings)
+}
+
+pub(crate) const GPT_OSS_ROUTED_TP_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
+    sections: GPT_OSS_EXPERT_SECTIONS,
+    is_streamed: is_gpt_oss_streamed_expert_tensor,
+    collect_bindings: gpt_oss_routed_tp_collect_bindings,
+    pack_kind: ExpertPackKind::GptOssRoutedMxfp4,
+};
 
 /// Eager-BF16 stream sections — offline dequant pack; biases stay resident.
 /// Must match `gpt_oss_expert_sections.hpp` BF16 helpers.
@@ -339,6 +486,7 @@ pub const GPT_OSS_EAGER_BF16_EXPERT_SECTIONS: &[&str] =
 fn gpt_oss_eager_bf16_section_bytes(
     gate_up_blocks: &RawTensor,
     down_blocks: &RawTensor,
+    target: &StorageTarget,
 ) -> Result<[u64; 3], CompileError> {
     if gate_up_blocks.shape.len() != 4 || down_blocks.shape.len() != 4 {
         return Err(CompileError::InvalidInput(
@@ -357,19 +505,21 @@ fn gpt_oss_eager_bf16_section_bytes(
             gate_up_blocks.shape
         )));
     }
-    let intermediate = fused_rows / 2;
+    let full_intermediate = (fused_rows / 2) as i64;
+    let (_local_start, local_intermediate) = tp_local_range(full_intermediate, target)?;
+    let intermediate = local_intermediate as u64;
     let hidden = gu_groups * 32;
     let down_hidden = down_blocks.shape[1] as u64;
     let down_groups = down_blocks.shape[2] as u64;
     let down_lanes = down_blocks.shape[3] as u64;
-    if down_lanes != 16 || down_hidden != hidden || down_groups * 32 != intermediate {
+    if down_lanes != 16 || down_hidden != hidden || down_groups * 32 != full_intermediate as u64 {
         return Err(CompileError::InvalidInput(format!(
             "stream_routed_experts: GPT-OSS eager BF16 down shape mismatch \
              (gate_up {:?}, down {:?})",
             gate_up_blocks.shape, down_blocks.shape
         )));
     }
-    // BF16: rows * cols * 2.
+    // BF16: rows * cols * 2 (TP-local intermediate).
     let gate = intermediate * hidden * 2;
     let down = hidden * intermediate * 2;
     Ok([gate, gate, down])
@@ -377,6 +527,7 @@ fn gpt_oss_eager_bf16_section_bytes(
 
 fn gpt_oss_eager_bf16_collect_bindings(
     metadata: &CheckpointMetadata,
+    target: &StorageTarget,
     num_layers: u32,
     num_experts: u32,
 ) -> Result<Vec<StreamBinding>, CompileError> {
@@ -401,7 +552,7 @@ fn gpt_oss_eager_bf16_collect_bindings(
         let down_w = gpt_oss_find_tensor(metadata, &format!("{prefix}down_proj_blocks"))?;
         let _ = gpt_oss_find_tensor(metadata, &format!("{prefix}gate_up_proj_scales"))?;
         let _ = gpt_oss_find_tensor(metadata, &format!("{prefix}down_proj_scales"))?;
-        let bytes = gpt_oss_eager_bf16_section_bytes(gate_up_w, down_w)?;
+        let bytes = gpt_oss_eager_bf16_section_bytes(gate_up_w, down_w, target)?;
         if let Some(prev) = section_bytes {
             if prev != bytes {
                 return Err(CompileError::InvalidInput(format!(
@@ -472,6 +623,7 @@ pub(crate) fn parse_mixtral_expert_section(name: &str) -> Option<(u32, u32, usiz
 
 fn mixtral_collect_bindings(
     metadata: &CheckpointMetadata,
+    _target: &StorageTarget,
     num_layers: u32,
     num_experts: u32,
 ) -> Result<Vec<StreamBinding>, CompileError> {
@@ -544,6 +696,7 @@ pub(crate) fn parse_qwen3_moe_expert_section(name: &str) -> Option<(u32, u32, us
 
 fn qwen3_moe_collect_bindings(
     metadata: &CheckpointMetadata,
+    _target: &StorageTarget,
     num_layers: u32,
     num_experts: u32,
 ) -> Result<Vec<StreamBinding>, CompileError> {
@@ -607,6 +760,7 @@ fn qwen35_moe_find_tensor<'a>(
 
 fn qwen35_moe_collect_bindings(
     metadata: &CheckpointMetadata,
+    _target: &StorageTarget,
     num_layers: u32,
     num_experts: u32,
 ) -> Result<Vec<StreamBinding>, CompileError> {

--- a/driver/weight_loader/src/stream_arch.rs
+++ b/driver/weight_loader/src/stream_arch.rs
@@ -169,7 +169,7 @@ pub(crate) fn dsv4_tp_section_bytes(
             w2_scale.shape
         )));
     }
-    let (_local_start, local_intermediate) = tp_local_range(i_full, target)?;
+    let (_local_start, local_intermediate) = crate::abi::local_range(i_full, target)?;
     if local_intermediate % 32 != 0 {
         return Err(CompileError::InvalidInput(format!(
             "stream_routed_experts: DeepSeek-V4 TP shard \
@@ -382,19 +382,6 @@ fn align_up_u64(v: u64, a: u64) -> u64 {
     (v + a - 1) / a * a
 }
 
-fn tp_local_range(full: i64, target: &StorageTarget) -> Result<(i64, i64), CompileError> {
-    let world = i64::from(target.tp_size.max(1));
-    let rank = i64::from(target.tp_rank);
-    if full % world != 0 {
-        return Err(CompileError::InvalidInput(format!(
-            "dimension {full} is not divisible by tp_size {}",
-            target.tp_size
-        )));
-    }
-    let local = full / world;
-    Ok((rank * local, local))
-}
-
 /// Marlin per-expert section byte sizes from GPT-OSS fused HF bank shapes.
 /// Uses TP-local intermediate (`I_full / tp_size`), then pads to 128 for Marlin.
 pub(crate) fn gpt_oss_native_section_bytes(
@@ -421,7 +408,7 @@ pub(crate) fn gpt_oss_native_section_bytes(
     }
     let full_intermediate = (fused_rows / 2) as i64;
     let (_local_start, local_intermediate) =
-        tp_local_range(full_intermediate, target)?;
+        crate::abi::local_range(full_intermediate, target)?;
     if local_intermediate % 32 != 0 {
         return Err(CompileError::InvalidInput(format!(
             "stream_routed_experts: GPT-OSS native TP shard I_local={local_intermediate} \
@@ -556,7 +543,7 @@ pub(crate) fn gpt_oss_routed_tp_section_bytes(
         )));
     }
     let full_intermediate = (fused_rows / 2) as i64;
-    let (_local_start, local_intermediate) = tp_local_range(full_intermediate, target)?;
+    let (_local_start, local_intermediate) = crate::abi::local_range(full_intermediate, target)?;
     if local_intermediate % 32 != 0 {
         return Err(CompileError::InvalidInput(format!(
             "stream_routed_experts: GPT-OSS RoutedDecode TP shard \
@@ -674,7 +661,13 @@ fn gpt_oss_eager_bf16_section_bytes(
         )));
     }
     let full_intermediate = (fused_rows / 2) as i64;
-    let (_local_start, local_intermediate) = tp_local_range(full_intermediate, target)?;
+    let (_local_start, local_intermediate) = crate::abi::local_range(full_intermediate, target)?;
+    if local_intermediate % 32 != 0 {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: GPT-OSS eager BF16 TP shard \
+             I_local={local_intermediate} must be divisible by 32"
+        )));
+    }
     let intermediate = local_intermediate as u64;
     let hidden = gu_groups * 32;
     let down_hidden = down_blocks.shape[1] as u64;
@@ -857,7 +850,7 @@ pub(crate) fn mixtral_tp_section_bytes(
             w2.shape
         )));
     }
-    let (_local_start, local_intermediate) = tp_local_range(i_full, target)?;
+    let (_local_start, local_intermediate) = crate::abi::local_range(i_full, target)?;
     let i_local = local_intermediate as u64;
     let h = hidden as u64;
     let w1_bytes = i_local * h * 2;
@@ -1051,7 +1044,7 @@ pub(crate) fn qwen3_moe_tp_section_bytes(
             down.shape
         )));
     }
-    let (_local_start, local_intermediate) = tp_local_range(i_full, target)?;
+    let (_local_start, local_intermediate) = crate::abi::local_range(i_full, target)?;
     let i_local = local_intermediate as u64;
     let h = hidden as u64;
     let gate_bytes = i_local * h * 2;
@@ -1277,7 +1270,7 @@ pub(crate) fn qwen35_moe_tp_section_bytes(
             gate_up.shape[0], down.shape[0]
         )));
     }
-    let (_local_start, local_intermediate) = tp_local_range(i_full, target)?;
+    let (_local_start, local_intermediate) = crate::abi::local_range(i_full, target)?;
     let i_local = local_intermediate as u64;
     let h = hidden as u64;
     let gu_bytes = 2 * i_local * h * 2;

--- a/driver/weight_loader/src/stream_arch.rs
+++ b/driver/weight_loader/src/stream_arch.rs
@@ -86,8 +86,176 @@ pub(crate) const DSV4_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
     pack_kind: ExpertPackKind::None,
 };
 
-pub(crate) fn select_dsv4(_target: &StorageTarget) -> Option<StreamArchDesc> {
-    Some(DSV4_STREAM_ARCH)
+fn dsv4_find_tensor<'a>(
+    metadata: &'a CheckpointMetadata,
+    name: &str,
+) -> Result<&'a RawTensor, CompileError> {
+    metadata
+        .tensors
+        .iter()
+        .find(|t| t.name == name)
+        .ok_or_else(|| {
+            CompileError::InvalidInput(format!(
+                "stream_routed_experts: missing DeepSeek-V4 expert tensor '{name}'"
+            ))
+        })
+}
+
+/// TP-local MXFP4 section sizes for DeepSeek-V4 packs under `tp_size>1`.
+///
+/// HF: w1/w3 weight `[I, H/2]`, scale `[I, H/32]`; w2 weight `[H, I/2]`,
+/// scale `[H, I/32]`. Pack stores dense `I_local` slices so w2 columns can be
+/// paged contiguously.
+pub(crate) fn dsv4_tp_section_bytes(
+    w1: &RawTensor,
+    w1_scale: &RawTensor,
+    w2: &RawTensor,
+    w2_scale: &RawTensor,
+    w3: &RawTensor,
+    w3_scale: &RawTensor,
+    target: &StorageTarget,
+) -> Result<[u64; 6], CompileError> {
+    if w1.shape.len() != 2
+        || w1_scale.shape.len() != 2
+        || w2.shape.len() != 2
+        || w2_scale.shape.len() != 2
+        || w3.shape.len() != 2
+        || w3_scale.shape.len() != 2
+    {
+        return Err(CompileError::InvalidInput(
+            "stream_routed_experts: DeepSeek-V4 TP pack expects 2-D \
+             w1/w2/w3 weight and scale tensors"
+                .to_string(),
+        ));
+    }
+    let i_full = w1.shape[0];
+    let h_packed = w1.shape[1]; // H/2
+    let hidden = h_packed * 2;
+    if hidden % 32 != 0 {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: DeepSeek-V4 hidden={hidden} must be \
+             divisible by 32"
+        )));
+    }
+    if w3.shape != w1.shape {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: DeepSeek-V4 w3 shape {:?} must match w1 {:?}",
+            w3.shape, w1.shape
+        )));
+    }
+    let scale_cols = hidden / 32;
+    if w1_scale.shape != [i_full, scale_cols]
+        || w3_scale.shape != [i_full, scale_cols]
+    {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: DeepSeek-V4 w1/w3 scale expected \
+             [{i_full}, {scale_cols}], got w1_scale={:?} w3_scale={:?}",
+            w1_scale.shape, w3_scale.shape
+        )));
+    }
+    if w2.shape != [hidden, i_full / 2] || i_full % 2 != 0 {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: DeepSeek-V4 w2 expected [{hidden}, {}], \
+             got {:?}",
+            i_full / 2,
+            w2.shape
+        )));
+    }
+    if w2_scale.shape != [hidden, i_full / 32] || i_full % 32 != 0 {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: DeepSeek-V4 w2 scale expected \
+             [{hidden}, {}], got {:?}",
+            i_full / 32,
+            w2_scale.shape
+        )));
+    }
+    let (_local_start, local_intermediate) = tp_local_range(i_full, target)?;
+    if local_intermediate % 32 != 0 {
+        return Err(CompileError::InvalidInput(format!(
+            "stream_routed_experts: DeepSeek-V4 TP shard \
+             I_local={local_intermediate} must be divisible by 32"
+        )));
+    }
+    let i_local = local_intermediate as u64;
+    let h = hidden as u64;
+    let w13 = i_local * h / 2;
+    let s13 = i_local * h / 32;
+    let w2b = h * i_local / 2;
+    let s2 = h * i_local / 32;
+    Ok([w13, s13, w2b, s2, w13, s13])
+}
+
+fn dsv4_tp_collect_bindings(
+    metadata: &CheckpointMetadata,
+    target: &StorageTarget,
+    num_layers: u32,
+    num_experts: u32,
+) -> Result<Vec<StreamBinding>, CompileError> {
+    let e = num_experts as u64;
+    if e == 0 {
+        return Err(CompileError::InvalidInput(
+            "stream_routed_experts: DeepSeek-V4 num_experts must be > 0".to_string(),
+        ));
+    }
+    const SECTION_ALIGN: u64 = 256;
+    let mut bindings = Vec::with_capacity(
+        (num_layers as usize) * (num_experts as usize) * DSV4_EXPERT_SECTIONS.len(),
+    );
+    let mut section_bytes: Option<[u64; 6]> = None;
+    let mut section_offsets = [0u64; 6];
+    let mut slot_bytes = 0u64;
+    for layer in 0..num_layers {
+        let prefix = format!("layers.{layer}.ffn.experts.0.");
+        let w1 = dsv4_find_tensor(metadata, &format!("{prefix}w1.weight"))?;
+        let w1s = dsv4_find_tensor(metadata, &format!("{prefix}w1.scale"))?;
+        let w2 = dsv4_find_tensor(metadata, &format!("{prefix}w2.weight"))?;
+        let w2s = dsv4_find_tensor(metadata, &format!("{prefix}w2.scale"))?;
+        let w3 = dsv4_find_tensor(metadata, &format!("{prefix}w3.weight"))?;
+        let w3s = dsv4_find_tensor(metadata, &format!("{prefix}w3.scale"))?;
+        let bytes = dsv4_tp_section_bytes(w1, w1s, w2, w2s, w3, w3s, target)?;
+        if let Some(prev) = section_bytes {
+            if prev != bytes {
+                return Err(CompileError::InvalidInput(format!(
+                    "stream_routed_experts: DeepSeek-V4 TP section sizes differ \
+                     across layers (layer {layer})"
+                )));
+            }
+        } else {
+            let mut off = 0u64;
+            for s in 0..6 {
+                section_offsets[s] = off;
+                off = align_up_u64(off + bytes[s], SECTION_ALIGN);
+            }
+            slot_bytes = off;
+            section_bytes = Some(bytes);
+        }
+        for expert in 0..e {
+            let base = (layer as u64 * e + expert) * slot_bytes;
+            for s in 0..6 {
+                bindings.push(StreamBinding {
+                    file_id: crate::types::FileId(0),
+                    file_offset: base + section_offsets[s],
+                    span_bytes: bytes[s],
+                });
+            }
+        }
+    }
+    Ok(bindings)
+}
+
+pub(crate) const DSV4_TP_STREAM_ARCH: StreamArchDesc = StreamArchDesc {
+    sections: DSV4_EXPERT_SECTIONS,
+    is_streamed: is_dsv4_routed_expert_tensor,
+    collect_bindings: dsv4_tp_collect_bindings,
+    pack_kind: ExpertPackKind::Dsv4TpMxfp4,
+};
+
+pub(crate) fn select_dsv4(target: &StorageTarget) -> Option<StreamArchDesc> {
+    if target.tp_size > 1 {
+        Some(DSV4_TP_STREAM_ARCH)
+    } else {
+        Some(DSV4_STREAM_ARCH)
+    }
 }
 
 /// Fixed GPT-OSS section order — must match `gpt_oss_expert_sections.hpp`.

--- a/driver/weight_loader/tests/storage_compiler.rs
+++ b/driver/weight_loader/tests/storage_compiler.rs
@@ -1298,7 +1298,7 @@ fn dsv4_stream_routed_experts_rejects_tensor_parallel() {
     let err = pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target)
         .unwrap_err()
         .to_string();
-    assert!(err.contains("tp_size=1"), "unexpected error: {err}");
+    assert!(err.contains("gpt_oss"), "unexpected error: {err}");
 }
 
 #[test]
@@ -1482,7 +1482,7 @@ fn mixtral_stream_routed_experts_rejects_tensor_parallel() {
     let err = pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target)
         .unwrap_err()
         .to_string();
-    assert!(err.contains("tp_size=1"), "unexpected error: {err}");
+    assert!(err.contains("gpt_oss"), "unexpected error: {err}");
 }
 
 #[test]
@@ -1808,6 +1808,321 @@ fn gpt_oss_native_stream_plan_section_bytes() {
 }
 
 #[test]
+fn gpt_oss_native_stream_plan_tp_local_section_bytes() {
+    // E=2, I_full=256, H=64, tp=2 → I_local=128, I_native=128.
+    // gate/up weight: 128*64/2=4096; scale: 128*2=256;
+    // down weight: 64*128/2=4096; scale: 64*(128/32)=256.
+    let mut offset = 0u64;
+    let mut tensors = Vec::new();
+    let mut push = |id: u32, name: &str, shape: Vec<i64>, span: u64| {
+        tensors.push(RawTensor {
+            id: TensorId(id),
+            name: name.to_string(),
+            file_id: FileId(0),
+            file_offset: offset,
+            span_bytes: span,
+            shape,
+            encoding: Encoding::Raw(DType::U8),
+            layout: Layout::dense(1),
+        });
+        offset += span;
+    };
+    let mut id = 0u32;
+    let mut next = || {
+        let v = id;
+        id += 1;
+        v
+    };
+    push(next(), "model.embed_tokens.weight", vec![64], 64);
+    // gate_up [E=2, 2I=512, H/32=2, 16]
+    push(
+        next(),
+        "model.layers.0.mlp.experts.gate_up_proj_blocks",
+        vec![2, 512, 2, 16],
+        32768,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.gate_up_proj_scales",
+        vec![2, 512, 2],
+        2048,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.gate_up_proj_bias",
+        vec![2, 512],
+        2048,
+    );
+    // down [E=2, H=64, I/32=8, 16]
+    push(
+        next(),
+        "model.layers.0.mlp.experts.down_proj_blocks",
+        vec![2, 64, 8, 16],
+        16384,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.down_proj_scales",
+        vec![2, 64, 8],
+        1024,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.down_proj_bias",
+        vec![2, 64],
+        256,
+    );
+    let meta = CheckpointMetadata {
+        files: vec![CheckpointFile {
+            id: FileId(0),
+            path: "gpt-oss.safetensors".into(),
+            size_bytes: offset,
+            format: CheckpointFormat::Safetensors,
+        }],
+        tensors,
+    };
+    let cfg = pie_weight_loader::config::ModelConfig {
+        model_type: "gpt_oss".to_string(),
+        num_hidden_layers: 1,
+        num_experts: 2,
+        num_experts_per_tok: 2,
+        ..pie_weight_loader::config::ModelConfig::default()
+    };
+    let target = StorageTarget {
+        backend: BackendKind::Cuda,
+        tp_rank: 1,
+        tp_size: 2,
+        stream_routed_experts: true,
+        mxfp4_moe: pie_weight_loader::types::Mxfp4MoePolicy::NativeGemm,
+        native_mxfp4_moe: true,
+        ..StorageTarget::default()
+    };
+    let abi =
+        pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target).unwrap();
+    let streamed = compile_storage_program(&meta, &cfg, &abi, target).unwrap();
+    assert_eq!(streamed.stream.sections_per_expert, 6);
+    assert_eq!(
+        streamed.stream.section_bytes,
+        vec![4096, 256, 4096, 256, 4096, 256]
+    );
+    assert_eq!(
+        streamed.stream.pack_kind,
+        pie_weight_loader::storage::ExpertPackKind::GptOssNativeMarlin
+    );
+    // Gate_up bias sharded to {E, 2*I_local=256}.
+    let bias = streamed
+        .tensors
+        .iter()
+        .find(|t| t.name.contains("gate_up_proj.bias"))
+        .expect("gate_up bias resident");
+    assert_eq!(bias.shape, vec![2, 256]);
+}
+
+#[test]
+fn gpt_oss_eager_bf16_stream_plan_tp_local_section_bytes() {
+    // E=2, I_full=256, H=64, tp=2 → I_local=128.
+    // gate/up: 128*64*2=16384; down: 64*128*2=16384.
+    let mut offset = 0u64;
+    let mut tensors = Vec::new();
+    let mut push = |id: u32, name: &str, shape: Vec<i64>, span: u64| {
+        tensors.push(RawTensor {
+            id: TensorId(id),
+            name: name.to_string(),
+            file_id: FileId(0),
+            file_offset: offset,
+            span_bytes: span,
+            shape,
+            encoding: Encoding::Raw(DType::U8),
+            layout: Layout::dense(1),
+        });
+        offset += span;
+    };
+    let mut id = 0u32;
+    let mut next = || {
+        let v = id;
+        id += 1;
+        v
+    };
+    push(next(), "model.embed_tokens.weight", vec![64], 64);
+    push(
+        next(),
+        "model.layers.0.mlp.experts.gate_up_proj_blocks",
+        vec![2, 512, 2, 16],
+        32768,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.gate_up_proj_scales",
+        vec![2, 512, 2],
+        2048,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.gate_up_proj_bias",
+        vec![2, 512],
+        2048,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.down_proj_blocks",
+        vec![2, 64, 8, 16],
+        16384,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.down_proj_scales",
+        vec![2, 64, 8],
+        1024,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.down_proj_bias",
+        vec![2, 64],
+        256,
+    );
+    let meta = CheckpointMetadata {
+        files: vec![CheckpointFile {
+            id: FileId(0),
+            path: "gpt-oss.safetensors".into(),
+            size_bytes: offset,
+            format: CheckpointFormat::Safetensors,
+        }],
+        tensors,
+    };
+    let cfg = pie_weight_loader::config::ModelConfig {
+        model_type: "gpt_oss".to_string(),
+        num_hidden_layers: 1,
+        num_experts: 2,
+        num_experts_per_tok: 2,
+        ..pie_weight_loader::config::ModelConfig::default()
+    };
+    let target = StorageTarget {
+        backend: BackendKind::Cuda,
+        tp_rank: 0,
+        tp_size: 2,
+        stream_routed_experts: true,
+        mxfp4_moe: pie_weight_loader::types::Mxfp4MoePolicy::EagerBf16,
+        ..StorageTarget::default()
+    };
+    let abi =
+        pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target).unwrap();
+    let streamed = compile_storage_program(&meta, &cfg, &abi, target).unwrap();
+    assert_eq!(streamed.stream.sections_per_expert, 3);
+    assert_eq!(
+        streamed.stream.section_bytes,
+        vec![16384, 16384, 16384]
+    );
+    assert_eq!(
+        streamed.stream.pack_kind,
+        pie_weight_loader::storage::ExpertPackKind::GptOssEagerBf16
+    );
+}
+
+#[test]
+fn gpt_oss_routed_decode_stream_plan_tp_pack() {
+    // E=2, I_full=128, H=64, tp=2 → I_local=64.
+    // gu_w=64*64=4096; gu_s=2*64*2=256; dn_w=64*64/2=2048; dn_s=64*2=128.
+    let mut offset = 0u64;
+    let mut tensors = Vec::new();
+    let mut push = |id: u32, name: &str, shape: Vec<i64>, span: u64| {
+        tensors.push(RawTensor {
+            id: TensorId(id),
+            name: name.to_string(),
+            file_id: FileId(0),
+            file_offset: offset,
+            span_bytes: span,
+            shape,
+            encoding: Encoding::Raw(DType::U8),
+            layout: Layout::dense(1),
+        });
+        offset += span;
+    };
+    let mut id = 0u32;
+    let mut next = || {
+        let v = id;
+        id += 1;
+        v
+    };
+    push(next(), "model.embed_tokens.weight", vec![64], 64);
+    push(
+        next(),
+        "model.layers.0.mlp.experts.gate_up_proj_blocks",
+        vec![2, 256, 2, 16],
+        16384,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.gate_up_proj_scales",
+        vec![2, 256, 2],
+        1024,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.gate_up_proj_bias",
+        vec![2, 256],
+        1024,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.down_proj_blocks",
+        vec![2, 64, 4, 16],
+        8192,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.down_proj_scales",
+        vec![2, 64, 4],
+        512,
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.down_proj_bias",
+        vec![2, 64],
+        256,
+    );
+    let meta = CheckpointMetadata {
+        files: vec![CheckpointFile {
+            id: FileId(0),
+            path: "gpt-oss.safetensors".into(),
+            size_bytes: offset,
+            format: CheckpointFormat::Safetensors,
+        }],
+        tensors,
+    };
+    let cfg = pie_weight_loader::config::ModelConfig {
+        model_type: "gpt_oss".to_string(),
+        num_hidden_layers: 1,
+        num_experts: 2,
+        num_experts_per_tok: 2,
+        ..pie_weight_loader::config::ModelConfig::default()
+    };
+    let target = StorageTarget {
+        backend: BackendKind::Cuda,
+        tp_rank: 0,
+        tp_size: 2,
+        stream_routed_experts: true,
+        mxfp4_moe: pie_weight_loader::types::Mxfp4MoePolicy::RoutedDecode,
+        ..StorageTarget::default()
+    };
+    let abi =
+        pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target).unwrap();
+    let streamed = compile_storage_program(&meta, &cfg, &abi, target).unwrap();
+    assert_eq!(streamed.stream.sections_per_expert, 4);
+    assert_eq!(
+        streamed.stream.section_bytes,
+        vec![4096, 256, 2048, 128]
+    );
+    assert_eq!(
+        streamed.stream.pack_kind,
+        pie_weight_loader::storage::ExpertPackKind::GptOssRoutedMxfp4
+    );
+    // Pack-relative bindings (virtual file 0).
+    assert_eq!(streamed.stream.bindings[0].file_id.0, 0);
+    assert_eq!(streamed.stream.bindings[0].file_offset, 0);
+    assert_eq!(streamed.stream.bindings[0].span_bytes, 4096);
+}
+
+#[test]
 fn qwen35_moe_stream_routed_experts_fused_plan() {
     // Minimal Qwen3.5-MoE fused banks: 1 layer × 2 experts + shared expert.
     let mut offset = 0u64;
@@ -1964,7 +2279,7 @@ fn qwen35_moe_stream_routed_experts_rejects_tensor_parallel() {
     let err = pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target)
         .unwrap_err()
         .to_string();
-    assert!(err.contains("tp_size=1"), "unexpected error: {err}");
+    assert!(err.contains("gpt_oss"), "unexpected error: {err}");
 }
 
 #[test]
@@ -2098,6 +2413,6 @@ fn qwen3_moe_stream_routed_experts_rejects_tensor_parallel() {
     let err = pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target)
         .unwrap_err()
         .to_string();
-    assert!(err.contains("tp_size=1"), "unexpected error: {err}");
+    assert!(err.contains("gpt_oss"), "unexpected error: {err}");
 }
 

--- a/driver/weight_loader/tests/storage_compiler.rs
+++ b/driver/weight_loader/tests/storage_compiler.rs
@@ -1298,7 +1298,7 @@ fn dsv4_stream_routed_experts_rejects_tensor_parallel() {
     let err = pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target)
         .unwrap_err()
         .to_string();
-    assert!(err.contains("gpt_oss"), "unexpected error: {err}");
+    assert!(err.contains("per-rank"), "unexpected error: {err}");
 }
 
 #[test]
@@ -1437,6 +1437,10 @@ fn mixtral_stream_routed_experts_excludes_expert_tensors_from_program() {
     assert_eq!(streamed.stream.num_layers, 1);
     assert_eq!(streamed.stream.num_experts, 2);
     assert_eq!(streamed.stream.sections_per_expert, 3);
+    assert_eq!(
+        streamed.stream.pack_kind,
+        pie_weight_loader::storage::ExpertPackKind::None
+    );
     assert_eq!(streamed.stream.template.len(), 3);
     assert_eq!(streamed.stream.bindings.len(), 1 * 2 * 3);
     for id in &streamed.stream.template {
@@ -1446,24 +1450,50 @@ fn mixtral_stream_routed_experts_excludes_expert_tensors_from_program() {
 }
 
 #[test]
-fn mixtral_stream_routed_experts_rejects_tensor_parallel() {
+fn mixtral_stream_plan_tp_local_section_bytes() {
+    // w1/w3: [I=32, H=16], w2: [H=16, I=32], tp=2 → I_local=16.
+    let mut offset = 0u64;
+    let mut tensors = Vec::new();
+    let mut push = |id: u32, name: &str, shape: Vec<i64>| {
+        let bytes = shape.iter().fold(2u64, |acc, d| acc * *d as u64);
+        tensors.push(RawTensor {
+            id: TensorId(id),
+            name: name.to_string(),
+            file_id: FileId(0),
+            file_offset: offset,
+            span_bytes: bytes,
+            shape,
+            encoding: Encoding::Raw(DType::BF16),
+            layout: Layout::dense(1),
+        });
+        offset += bytes;
+    };
+    let mut id = 0u32;
+    let mut next = || {
+        let v = id;
+        id += 1;
+        v
+    };
+    push(next(), "model.embed_tokens.weight", vec![64]);
+    push(
+        next(),
+        "model.layers.0.block_sparse_moe.gate.weight",
+        vec![2, 16],
+    );
+    for e in 0..2 {
+        let prefix = format!("model.layers.0.block_sparse_moe.experts.{e}");
+        push(next(), &format!("{prefix}.w1.weight"), vec![32, 16]);
+        push(next(), &format!("{prefix}.w2.weight"), vec![16, 32]);
+        push(next(), &format!("{prefix}.w3.weight"), vec![32, 16]);
+    }
     let meta = CheckpointMetadata {
         files: vec![CheckpointFile {
             id: FileId(0),
             path: "mixtral.safetensors".into(),
-            size_bytes: 64,
+            size_bytes: offset,
             format: CheckpointFormat::Safetensors,
         }],
-        tensors: vec![RawTensor {
-            id: TensorId(0),
-            name: "model.layers.0.block_sparse_moe.experts.0.w1.weight".into(),
-            file_id: FileId(0),
-            file_offset: 0,
-            span_bytes: 64,
-            shape: vec![32, 1],
-            encoding: Encoding::Raw(DType::BF16),
-            layout: Layout::dense(1),
-        }],
+        tensors,
     };
     let cfg = pie_weight_loader::config::ModelConfig {
         model_type: "mixtral".to_string(),
@@ -1479,10 +1509,23 @@ fn mixtral_stream_routed_experts_rejects_tensor_parallel() {
         stream_routed_experts: true,
         ..StorageTarget::default()
     };
-    let err = pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target)
-        .unwrap_err()
-        .to_string();
-    assert!(err.contains("gpt_oss"), "unexpected error: {err}");
+    let abi =
+        pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target).unwrap();
+    let streamed = compile_storage_program(&meta, &cfg, &abi, target).unwrap();
+    assert_eq!(streamed.stream.sections_per_expert, 3);
+    // I_local=16, H=16 → [I*H*2, H*I*2, I*H*2] = [512, 512, 512]
+    assert_eq!(streamed.stream.section_bytes, vec![512, 512, 512]);
+    assert_eq!(
+        streamed.stream.pack_kind,
+        pie_weight_loader::storage::ExpertPackKind::MixtralTpBf16
+    );
+    assert_eq!(streamed.stream.bindings[0].file_id.0, 0);
+    assert_eq!(streamed.stream.bindings[0].file_offset, 0);
+    assert_eq!(streamed.stream.bindings[0].span_bytes, 512);
+    assert!(
+        !streamed.tensors.iter().any(|t| t.name.contains("block_sparse_moe.experts.")),
+        "TP stream plan must exclude Mixtral expert tensors from resident ABI"
+    );
 }
 
 #[test]
@@ -2279,7 +2322,7 @@ fn qwen35_moe_stream_routed_experts_rejects_tensor_parallel() {
     let err = pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target)
         .unwrap_err()
         .to_string();
-    assert!(err.contains("gpt_oss"), "unexpected error: {err}");
+    assert!(err.contains("per-rank"), "unexpected error: {err}");
 }
 
 #[test]
@@ -2413,6 +2456,6 @@ fn qwen3_moe_stream_routed_experts_rejects_tensor_parallel() {
     let err = pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target)
         .unwrap_err()
         .to_string();
-    assert!(err.contains("gpt_oss"), "unexpected error: {err}");
+    assert!(err.contains("per-rank"), "unexpected error: {err}");
 }
 

--- a/driver/weight_loader/tests/storage_compiler.rs
+++ b/driver/weight_loader/tests/storage_compiler.rs
@@ -1231,6 +1231,10 @@ fn dsv4_stream_routed_experts_excludes_expert_tensors_from_program() {
     assert_eq!(streamed.stream.num_layers, 1);
     assert_eq!(streamed.stream.num_experts, 2);
     assert_eq!(streamed.stream.sections_per_expert, 6);
+    assert_eq!(
+        streamed.stream.pack_kind,
+        pie_weight_loader::storage::ExpertPackKind::None
+    );
     assert_eq!(streamed.stream.template.len(), 6);
     assert_eq!(streamed.stream.bindings.len(), 1 * 2 * 6);
     assert!(streamed.stream.slot_bytes > 0);
@@ -1261,25 +1265,49 @@ fn dsv4_stream_routed_experts_excludes_expert_tensors_from_program() {
 }
 
 #[test]
-fn dsv4_stream_routed_experts_rejects_tensor_parallel() {
-    // Enough of a streamed tensor for skip_streamed to fire before the TP check.
+fn dsv4_stream_plan_tp_local_section_bytes() {
+    // I=64, H=64, tp=2 → I_local=32. MXFP4: w1/w3 [I,H/2]+[I,H/32], w2 [H,I/2]+[H,I/32].
+    let mut offset = 0u64;
+    let mut tensors = Vec::new();
+    let mut push = |id: u32, name: &str, shape: Vec<i64>| {
+        let bytes = shape.iter().fold(1u64, |acc, d| acc * *d as u64);
+        tensors.push(RawTensor {
+            id: TensorId(id),
+            name: name.to_string(),
+            file_id: FileId(0),
+            file_offset: offset,
+            span_bytes: bytes,
+            shape,
+            encoding: Encoding::Raw(DType::U8),
+            layout: Layout::dense(1),
+        });
+        offset += bytes;
+    };
+    let mut id = 0u32;
+    let mut next = || {
+        let v = id;
+        id += 1;
+        v
+    };
+    push(next(), "layers.0.ffn.gate.weight", vec![2, 64]);
+    push(next(), "layers.0.ffn.shared_experts.w1.weight", vec![32, 64]);
+    for e in 0..2 {
+        let prefix = format!("layers.0.ffn.experts.{e}");
+        push(next(), &format!("{prefix}.w1.weight"), vec![64, 32]);
+        push(next(), &format!("{prefix}.w1.scale"), vec![64, 2]);
+        push(next(), &format!("{prefix}.w2.weight"), vec![64, 32]);
+        push(next(), &format!("{prefix}.w2.scale"), vec![64, 2]);
+        push(next(), &format!("{prefix}.w3.weight"), vec![64, 32]);
+        push(next(), &format!("{prefix}.w3.scale"), vec![64, 2]);
+    }
     let meta = CheckpointMetadata {
         files: vec![CheckpointFile {
             id: FileId(0),
             path: "model.safetensors".into(),
-            size_bytes: 32,
+            size_bytes: offset,
             format: CheckpointFormat::Safetensors,
         }],
-        tensors: vec![RawTensor {
-            id: TensorId(0),
-            name: "layers.0.ffn.experts.0.w1.weight".into(),
-            file_id: FileId(0),
-            file_offset: 0,
-            span_bytes: 32,
-            shape: vec![32],
-            encoding: Encoding::Raw(DType::U8),
-            layout: Layout::dense(1),
-        }],
+        tensors,
     };
     let cfg = pie_weight_loader::config::ModelConfig {
         model_type: "deepseek_v4".to_string(),
@@ -1295,10 +1323,36 @@ fn dsv4_stream_routed_experts_rejects_tensor_parallel() {
         stream_routed_experts: true,
         ..StorageTarget::default()
     };
-    let err = pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target)
-        .unwrap_err()
-        .to_string();
-    assert!(err.contains("per-rank"), "unexpected error: {err}");
+    let abi =
+        pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target).unwrap();
+    let streamed = compile_storage_program(&meta, &cfg, &abi, target).unwrap();
+    assert_eq!(streamed.stream.sections_per_expert, 6);
+    // I_local=32, H=64 → [I*H/2, I*H/32, H*I/2, H*I/32, ...]
+    assert_eq!(
+        streamed.stream.section_bytes,
+        vec![1024, 64, 1024, 64, 1024, 64]
+    );
+    assert_eq!(
+        streamed.stream.pack_kind,
+        pie_weight_loader::storage::ExpertPackKind::Dsv4TpMxfp4
+    );
+    assert_eq!(streamed.stream.bindings[0].file_id.0, 0);
+    assert_eq!(streamed.stream.bindings[0].file_offset, 0);
+    assert_eq!(streamed.stream.bindings[0].span_bytes, 1024);
+    assert!(
+        streamed
+            .tensors
+            .iter()
+            .any(|t| t.name == "layers.0.ffn.shared_experts.w1.weight"),
+        "shared expert must remain resident under TP+streaming"
+    );
+    assert!(
+        !streamed
+            .tensors
+            .iter()
+            .any(|t| t.name.starts_with("layers.") && t.name.contains(".ffn.experts.")),
+        "main-stack routed experts must not be resident under TP stream plan"
+    );
 }
 
 #[test]

--- a/driver/weight_loader/tests/storage_compiler.rs
+++ b/driver/weight_loader/tests/storage_compiler.rs
@@ -2283,27 +2283,72 @@ fn qwen35_moe_stream_routed_experts_fused_plan() {
     assert_eq!(streamed.stream.bindings.len(), 1 * 2 * 2);
     // Per-expert slices: gate_up 2*I*H*2 bytes, down H*I*2 bytes.
     assert_eq!(streamed.stream.section_bytes, vec![8192, 4096]);
+    assert_eq!(
+        streamed.stream.pack_kind,
+        pie_weight_loader::storage::ExpertPackKind::None
+    );
 }
 
 #[test]
-fn qwen35_moe_stream_routed_experts_rejects_tensor_parallel() {
+fn qwen35_moe_stream_plan_tp_local_section_bytes() {
+    // Fused [E=2, 2I=64, H=64] / [E=2, H=64, I=32], tp=2 → I_local=16.
+    let mut offset = 0u64;
+    let mut tensors = Vec::new();
+    let mut push = |id: u32, name: &str, shape: Vec<i64>| {
+        let bytes = shape.iter().fold(2u64, |acc, d| acc * *d as u64);
+        tensors.push(RawTensor {
+            id: TensorId(id),
+            name: name.to_string(),
+            file_id: FileId(0),
+            file_offset: offset,
+            span_bytes: bytes,
+            shape,
+            encoding: Encoding::Raw(DType::BF16),
+            layout: Layout::dense(1),
+        });
+        offset += bytes;
+    };
+    let mut id = 0u32;
+    let mut next = || {
+        let v = id;
+        id += 1;
+        v
+    };
+    push(next(), "model.embed_tokens.weight", vec![64]);
+    push(next(), "model.layers.0.mlp.gate.weight", vec![2, 64]);
+    push(
+        next(),
+        "model.layers.0.mlp.experts.gate_up_proj",
+        vec![2, 64, 64],
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.experts.down_proj",
+        vec![2, 64, 32],
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.shared_expert.gate_proj.weight",
+        vec![32, 64],
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.shared_expert.up_proj.weight",
+        vec![32, 64],
+    );
+    push(
+        next(),
+        "model.layers.0.mlp.shared_expert.down_proj.weight",
+        vec![64, 32],
+    );
     let meta = CheckpointMetadata {
         files: vec![CheckpointFile {
             id: FileId(0),
             path: "qwen35-moe.safetensors".into(),
-            size_bytes: 64,
+            size_bytes: offset,
             format: CheckpointFormat::Safetensors,
         }],
-        tensors: vec![RawTensor {
-            id: TensorId(0),
-            name: "model.layers.0.mlp.experts.gate_up_proj".into(),
-            file_id: FileId(0),
-            file_offset: 0,
-            span_bytes: 64,
-            shape: vec![32, 1],
-            encoding: Encoding::Raw(DType::BF16),
-            layout: Layout::dense(1),
-        }],
+        tensors,
     };
     let cfg = pie_weight_loader::config::ModelConfig {
         model_type: "qwen3_5_moe".to_string(),
@@ -2319,10 +2364,34 @@ fn qwen35_moe_stream_routed_experts_rejects_tensor_parallel() {
         stream_routed_experts: true,
         ..StorageTarget::default()
     };
-    let err = pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target)
-        .unwrap_err()
-        .to_string();
-    assert!(err.contains("per-rank"), "unexpected error: {err}");
+    let abi =
+        pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target).unwrap();
+    let streamed = compile_storage_program(&meta, &cfg, &abi, target).unwrap();
+    assert_eq!(streamed.stream.sections_per_expert, 2);
+    // I_local=16, H=64 → [2*I*H*2, H*I*2] = [4096, 2048]
+    assert_eq!(streamed.stream.section_bytes, vec![4096, 2048]);
+    assert_eq!(
+        streamed.stream.pack_kind,
+        pie_weight_loader::storage::ExpertPackKind::Qwen35MoeTpBf16
+    );
+    assert_eq!(streamed.stream.bindings[0].file_id.0, 0);
+    assert_eq!(streamed.stream.bindings[0].file_offset, 0);
+    assert_eq!(streamed.stream.bindings[0].span_bytes, 4096);
+    assert!(
+        streamed
+            .tensors
+            .iter()
+            .any(|t| t.name.contains("mlp.shared_expert.")),
+        "shared expert must remain resident under TP+streaming"
+    );
+    assert!(
+        !streamed
+            .tensors
+            .iter()
+            .any(|t| t.name.contains("mlp.experts.gate_up_proj")
+                || t.name.contains("mlp.experts.down_proj")),
+        "fused routed banks must not be resident under TP stream plan"
+    );
 }
 
 #[test]
@@ -2411,6 +2480,10 @@ fn qwen3_moe_stream_routed_experts_named_plan() {
     assert_eq!(streamed.stream.num_layers, 1);
     assert_eq!(streamed.stream.num_experts, 2);
     assert_eq!(streamed.stream.sections_per_expert, 3);
+    assert_eq!(
+        streamed.stream.pack_kind,
+        pie_weight_loader::storage::ExpertPackKind::None
+    );
     assert_eq!(streamed.stream.template.len(), 3);
     assert_eq!(streamed.stream.bindings.len(), 1 * 2 * 3);
     for id in &streamed.stream.template {
@@ -2420,24 +2493,46 @@ fn qwen3_moe_stream_routed_experts_named_plan() {
 }
 
 #[test]
-fn qwen3_moe_stream_routed_experts_rejects_tensor_parallel() {
+fn qwen3_moe_stream_plan_tp_local_section_bytes() {
+    // gate/up: [I=32, H=16], down: [H=16, I=32], tp=2 → I_local=16.
+    let mut offset = 0u64;
+    let mut tensors = Vec::new();
+    let mut push = |id: u32, name: &str, shape: Vec<i64>| {
+        let bytes = shape.iter().fold(2u64, |acc, d| acc * *d as u64);
+        tensors.push(RawTensor {
+            id: TensorId(id),
+            name: name.to_string(),
+            file_id: FileId(0),
+            file_offset: offset,
+            span_bytes: bytes,
+            shape,
+            encoding: Encoding::Raw(DType::BF16),
+            layout: Layout::dense(1),
+        });
+        offset += bytes;
+    };
+    let mut id = 0u32;
+    let mut next = || {
+        let v = id;
+        id += 1;
+        v
+    };
+    push(next(), "model.embed_tokens.weight", vec![64]);
+    push(next(), "model.layers.0.mlp.gate.weight", vec![2, 16]);
+    for e in 0..2 {
+        let prefix = format!("model.layers.0.mlp.experts.{e}");
+        push(next(), &format!("{prefix}.gate_proj.weight"), vec![32, 16]);
+        push(next(), &format!("{prefix}.up_proj.weight"), vec![32, 16]);
+        push(next(), &format!("{prefix}.down_proj.weight"), vec![16, 32]);
+    }
     let meta = CheckpointMetadata {
         files: vec![CheckpointFile {
             id: FileId(0),
             path: "qwen3-moe.safetensors".into(),
-            size_bytes: 64,
+            size_bytes: offset,
             format: CheckpointFormat::Safetensors,
         }],
-        tensors: vec![RawTensor {
-            id: TensorId(0),
-            name: "model.layers.0.mlp.experts.0.gate_proj.weight".into(),
-            file_id: FileId(0),
-            file_offset: 0,
-            span_bytes: 64,
-            shape: vec![32, 1],
-            encoding: Encoding::Raw(DType::BF16),
-            layout: Layout::dense(1),
-        }],
+        tensors,
     };
     let cfg = pie_weight_loader::config::ModelConfig {
         model_type: "qwen3_moe".to_string(),
@@ -2453,9 +2548,22 @@ fn qwen3_moe_stream_routed_experts_rejects_tensor_parallel() {
         stream_routed_experts: true,
         ..StorageTarget::default()
     };
-    let err = pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target)
-        .unwrap_err()
-        .to_string();
-    assert!(err.contains("per-rank"), "unexpected error: {err}");
+    let abi =
+        pie_weight_loader::abi::RuntimeAbi::default_for_target(&meta, &cfg, &target).unwrap();
+    let streamed = compile_storage_program(&meta, &cfg, &abi, target).unwrap();
+    assert_eq!(streamed.stream.sections_per_expert, 3);
+    // I_local=16, H=16 → [I*H*2, I*H*2, H*I*2] = [512, 512, 512]
+    assert_eq!(streamed.stream.section_bytes, vec![512, 512, 512]);
+    assert_eq!(
+        streamed.stream.pack_kind,
+        pie_weight_loader::storage::ExpertPackKind::Qwen3MoeTpBf16
+    );
+    assert_eq!(streamed.stream.bindings[0].file_id.0, 0);
+    assert_eq!(streamed.stream.bindings[0].file_offset, 0);
+    assert_eq!(streamed.stream.bindings[0].span_bytes, 512);
+    assert!(
+        !streamed.tensors.iter().any(|t| t.name.contains("mlp.experts.")),
+        "TP stream plan must exclude Qwen3-MoE expert tensors from resident ABI"
+    );
 }
 

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -816,8 +816,8 @@ pub struct CudaNativeDriverOptions {
     /// keep routed MoE expert weights on disk and page them into a bounded
     /// LRU GPU cache on demand at forward time instead of materializing
     /// them in VRAM at startup. Combined with `tensor_parallel_size > 1`,
-    /// only GPT-OSS is supported (per-rank packs); other arches fail in the
-    /// CUDA driver after the model type is known.
+    /// GPT-OSS and Mixtral are supported (per-rank packs); other arches fail
+    /// in the CUDA driver after the model type is known.
     pub stream_routed_experts: bool,
     /// Expert stream cache budget in GiB. 0 (default) = auto: half of the
     /// post-weights free VRAM, capped at the full routed expert set. Only

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -501,11 +501,6 @@ impl DriverConfig {
                     })?;
                 opts.validate()?;
                 validate_kv_cache_dtype(&opts.kv_cache_dtype)?;
-                ensure!(
-                    !opts.stream_routed_experts || self.tensor_parallel_size == 1,
-                    "model.driver.options.stream_routed_experts requires \
-                     tensor_parallel_size = 1"
-                );
             }
             DriverKind::Dummy => {
                 let _: DummyDriverOptions = toml::Value::Table(self.options.clone())
@@ -817,10 +812,12 @@ pub struct CudaNativeDriverOptions {
     /// latency-regime win (helps at low batch, costs at compute saturation), so
     /// it's off unless explicitly enabled — matching vLLM/SGLang convention.
     pub enable_system_speculation: bool,
-    /// SSD expert streaming (DeepSeek-V4 / GPT-OSS, tensor_parallel_size = 1):
+    /// SSD expert streaming (DeepSeek-V4 / GPT-OSS / Mixtral / Qwen MoE):
     /// keep routed MoE expert weights on disk and page them into a bounded
     /// LRU GPU cache on demand at forward time instead of materializing
-    /// them in VRAM at startup.
+    /// them in VRAM at startup. Combined with `tensor_parallel_size > 1`,
+    /// only GPT-OSS is supported (per-rank packs); other arches fail in the
+    /// CUDA driver after the model type is known.
     pub stream_routed_experts: bool,
     /// Expert stream cache budget in GiB. 0 (default) = auto: half of the
     /// post-weights free VRAM, capped at the full routed expert set. Only
@@ -1027,11 +1024,11 @@ expert_cache_gb = 24.0
     }
 
     #[test]
-    fn cuda_rejects_stream_routed_experts_with_tensor_parallel() {
+    fn cuda_accepts_stream_routed_experts_with_tensor_parallel() {
         let text = r#"
 [[model]]
 name = "default"
-hf_repo = "org/DeepSeek-V4"
+hf_repo = "org/gpt-oss"
 
 [model.driver]
 type = "cuda_native"
@@ -1042,9 +1039,7 @@ tensor_parallel_size = 2
 stream_routed_experts = true
 "#;
         let cfg: Config = toml::from_str(text).unwrap();
-        let err = cfg.validate().unwrap_err().to_string();
-        assert!(err.contains("stream_routed_experts"), "got: {err}");
-        assert!(err.contains("tensor_parallel_size"), "got: {err}");
+        cfg.validate().unwrap();
     }
 
     #[test]

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -816,8 +816,8 @@ pub struct CudaNativeDriverOptions {
     /// keep routed MoE expert weights on disk and page them into a bounded
     /// LRU GPU cache on demand at forward time instead of materializing
     /// them in VRAM at startup. Combined with `tensor_parallel_size > 1`,
-    /// GPT-OSS and Mixtral are supported (per-rank packs); other arches fail
-    /// in the CUDA driver after the model type is known.
+    /// GPT-OSS, Mixtral, and Qwen MoE are supported (per-rank packs); other
+    /// arches fail in the CUDA driver after the model type is known.
     pub stream_routed_experts: bool,
     /// Expert stream cache budget in GiB. 0 (default) = auto: half of the
     /// post-weights free VRAM, capped at the full routed expert set. Only

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -816,8 +816,9 @@ pub struct CudaNativeDriverOptions {
     /// keep routed MoE expert weights on disk and page them into a bounded
     /// LRU GPU cache on demand at forward time instead of materializing
     /// them in VRAM at startup. Combined with `tensor_parallel_size > 1`,
-    /// GPT-OSS, Mixtral, and Qwen MoE are supported (per-rank packs); other
-    /// arches fail in the CUDA driver after the model type is known.
+    /// DeepSeek-V4, GPT-OSS, Mixtral, and Qwen MoE are supported (per-rank
+    /// packs); other arches fail in the CUDA driver after the model type is
+    /// known.
     pub stream_routed_experts: bool,
     /// Expert stream cache budget in GiB. 0 (default) = auto: half of the
     /// post-weights free VRAM, capped at the full routed expert set. Only


### PR DESCRIPTION
Allow `stream_routed_experts` with `tensor_parallel_size > 1` for GPT-OSS, Mixtral, Qwen3/3.5-MoE, and DeepSeek-V4 by emitting per-rank offline expert packs sized to `I_local`, so the streamer can page contiguous TP-local sections instead of strided HF extents. Storage program version changed to 6, with new pack kinds for GPT-OSS RoutedDecode TP MXFP4, Mixtral BF16, Qwen named/fused BF16, and DSv4 MXFP4. Also fix DeepSeek-V4 MQA KV sizing under TP so the memory planner no longer divides the single KV head by `tp_size` and computes zero page bytes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tensor-parallel routed-expert streaming for GPT-OSS, DeepSeek-V4, Mixtral, Qwen3, and Qwen3.5 MoE models.
  * Added BF16 and MXFP4 expert-pack support with per-rank packing.
  * Improved model-specific tensor-parallel memory and KV-cache handling.
  * Added clearer validation for unsupported architecture and parallelism combinations.

* **Bug Fixes**
  * Improved CUDA stream usage, RoPE selection, synchronization options, and logits-capacity validation.
  * Updated streaming and storage compatibility versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->