### PR TITLE
Fix two CI jobs: stale package/target names, and a silently truncated encode blob

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,18 +37,22 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      # Cheap structural check: every workspace member compiles. Skips
-      # the cmake-driven C++ build by checking pie-worker with
-      # `--no-default-features` (the default features pull in ggml).
+      # Cheap structural check: the composition root compiles, and with it the
+      # runtime and every role lib it pulls in. `pie-bin` depends on `pie-worker`
+      # with `default-features = false`, so this reaches a no-driver worker and
+      # skips the cmake-driven C++ build. `pie-client` is checked separately
+      # because the binary does not depend on it.
       - name: cargo check (runtime, client, no-driver pie-worker)
         run: |
-          cargo check -p pie
-          cargo check -p pie --no-default-features
+          cargo check -p pie-bin
+          cargo check -p pie-bin --no-default-features
           cargo check -p pie-client
 
+      # `pie-engine` is the runtime library; the `pie` package it was split out
+      # of no longer exists.
       - name: cargo test (runtime, client)
         run: |
-          cargo test -p pie --lib
+          cargo test -p pie-engine --lib
           cargo test -p pie-client --lib
 
       # `pie-ir` and `pie-plan` declare `#![no_std]` behind `not(feature =
@@ -300,9 +304,13 @@ jobs:
           cargo build -p pie-worker \
             --no-default-features --features driver-dummy
 
+      # `pie-worker` is a library and has no bin target; the `pie` command lives
+      # in `bin/pie`. The old `--bin pie` here named a target this package has
+      # never had, so the step could only ever fail. Test what the step above
+      # just built.
       - name: cargo test (pie-worker, dummy)
         run: |
-          cargo test -p pie-worker --bin pie \
+          cargo test -p pie-worker \
             --no-default-features --features driver-dummy
 
   # macOS Metal driver build. Verifies driver/metal's cmake + link

--- a/runtime/engine/src/pipeline/offload.rs
+++ b/runtime/engine/src/pipeline/offload.rs
@@ -586,6 +586,17 @@ fn publish_encode_blob(
 }
 
 fn serve_encode_blob(mut stream: TcpStream) {
+    // The listener is non-blocking so the accept loop can poll for shutdown.
+    // On macOS/BSD `accept` hands that flag down to the accepted socket, while
+    // on Linux it does not — so without this the same code serves blobs one way
+    // on one platform and another way on the other. This handler is blocking by
+    // construction (four dedicated worker threads, one connection each), so put
+    // the socket back into the mode it is written for rather than leaving it to
+    // the platform.
+    if let Err(error) = stream.set_nonblocking(false) {
+        tracing::warn!(%error, "encode blob connection could not be made blocking");
+        return;
+    }
     let mut request = Vec::with_capacity(1024);
     let mut chunk = [0u8; 1024];
     while request.len() <= 8192 && !request.windows(4).any(|bytes| bytes == b"\r\n\r\n") {
@@ -622,8 +633,16 @@ fn serve_encode_blob(mut stream: TcpStream) {
             "HTTP/1.1 200 OK\r\ncontent-type: application/octet-stream\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
             bytes.len()
         );
-        let _ = stream.write_all(header.as_bytes());
-        let _ = stream.write_all(&bytes);
+        // A discarded write error here is worse than a failed fetch: the header
+        // has already promised `content-length`, so a short body reaches the
+        // peer as a well-formed response that is quietly truncated, and the
+        // content-address check on the other side is what ends up reporting it.
+        if let Err(error) = stream
+            .write_all(header.as_bytes())
+            .and_then(|()| stream.write_all(&bytes))
+        {
+            tracing::warn!(%error, len = bytes.len(), "encode blob response was not fully written");
+        }
     } else {
         let _ = stream
             .write_all(b"HTTP/1.1 404 Not Found\r\ncontent-length: 0\r\nconnection: close\r\n\r\n");


### PR DESCRIPTION
Two independent fixes to jobs that could not pass. They are separate commits because they
are separate faults, and either reverts cleanly without the other.

## `ci: name the packages and targets that actually exist`

Two steps named a package and a binary the workspace no longer has, so they failed before
running anything.

`pie` was the old `runtime/` crate. The layered crate extraction split it into `pie-engine`
plus the role libs, and the composition root owning the user-facing `pie` command is now
`pie-bin` in `bin/pie`. The structural check becomes `-p pie-bin`, which is what the step
name already described: `bin/pie/Cargo.toml` takes `pie-worker` with
`default-features = false`, so checking it reaches a no-driver worker and skips the
cmake-driven C++ build. The comment attributed that skip to ggml being a pie-worker default;
pie-worker's defaults are empty, so it now says where the skip really comes from. Library
tests move to `-p pie-engine`, where the runtime's tests went. `pie-client` is unchanged.

The worker job is a **different** fault, not the same rename. `pie-worker` declares only a
`[lib]` and has never had a bin target, so `--bin pie` could not be corrected by renaming
the package. Dropping it leaves the step testing exactly what the build step above it just
built — the form the metal job already uses.

## `offload: serve encode blobs on a blocking socket, and notice a short write`

The encode blob server truncated every response larger than a socket send buffer, on macOS
only, and reported nothing.

Its listener is non-blocking so the accept loop can poll for shutdown. Linux does not pass
that flag to an accepted socket; macOS and the BSDs do. `serve_encode_blob` is written for a
blocking socket — four dedicated worker threads take one connection each and write it to
completion — so on macOS every accepted stream was in the wrong mode for the code handling
it. `write_all` of an 8 MiB body returned `WouldBlock` once the send buffer filled, the
result was discarded, and the stream was dropped at end of function.

The header had already promised a `content-length` the body did not deliver, so the peer
received a well-formed HTTP response that was quietly short — measured at **327212 bytes of
a declared 8388608**. The fetch side does validate status, content-length, declared size and
a blake3 content address, but the body stream errors first and surfaces as a decode failure
from the HTTP client, wrapped as `Driver: error decoding response body`. That message points
nowhere near the writer, which is what made it read as a driver or transport fault.

The fix puts the accepted socket into the mode the handler is written for rather than
leaving it to the platform, and logs a write that does not complete instead of discarding
it. The truncation is the defect; the silence is what made it expensive to find.

## The platform asymmetry, and what to expect from CI

This matters for reading the results, so it is worth stating up front: **the truncation
reproduces on macOS only.**

- `pie-worker (driver-dummy) (ubuntu-latest)` was failing for the stale-flag reason alone.
  It may well go green on the first commit by itself.
- `pie-worker (driver-metal)` runs on macOS and needed the engine fix.
- `pie-worker (driver-dummy) (macos-latest)` needed both.

Every measurement below was taken on macOS, because that is the only host available to me.
The Linux half of the claim is untested and this PR is the first thing that will test it.
If ubuntu's driver-dummy job goes green while macOS's does too, the asymmetry is confirmed;
if ubuntu fails, my platform reasoning is wrong and the engine commit deserves another look.

Separately, `workspace verify` should stay red. Its `cargo test -p pie-worker --lib` step
was previously unreachable behind an earlier failure in that job, and nothing here addresses
that failure.

## Evidence

`oversized_encode_media_uses_content_addressed_pull`, before and after, on macOS:

| | before | after |
| --- | --- | --- |
| the test alone, driver-dummy, 10 runs | 0 pass / 10 fail | 10 pass / 0 fail |
| pie-worker library suite, driver-dummy | 68 passed / 1 failed | 69 passed / 0 failed |
| pie-worker library suite, default features | 68 passed / 1 failed | 69 passed / 0 failed |
| `executor::tests`, driver-metal | 16 passed / 1 failed | 17 passed / 0 failed |

Integration targets and doc-tests green (the CUDA ones ignore themselves without hardware).
The corrected workflow commands were run verbatim: `cargo check -p pie-bin`, the same with
`--no-default-features`, `-p pie-client`; `cargo test -p pie-engine --lib` at 403 passed;
`-p pie-client --lib` at 2 passed; and the dummy job's build-then-test pair.

Full log: `logs/test/test-20260804-181419.log`.

Two supporting measurements for the mechanism, taken on this host:

- A listener with `O_NONBLOCK` yields an accepted socket with `O_NONBLOCK` set (`Darwin`).
- Rust `std` specifically: `set_nonblocking(true)`, `accept()`, then `write_all(8 MiB)`
  returns `Err(WouldBlock)`. The flag is not cleared.

## On the test

`oversized_encode_media_uses_content_addressed_pull` was asserting the right contract all
along and **is not modified** — no test file is touched anywhere in this PR. It was reporting
a real truncation in the write path, and the failure it caught would corrupt a genuine 8 MiB
blob served to a genuine worker exactly the same way.
