### PR TITLE
rng-contract: drop the shift width from the magic set, it detects nothing

### DIFF
--- a/compiler/tests/tests/rng_contract.rs
+++ b/compiler/tests/tests/rng_contract.rs
@@ -220,12 +220,23 @@ fn rng_magic_is_owned_by_the_contract() {
     ];
     let stride = ["9e37", "79b9", "7f4a", "7c15"].concat();
     let ambient_mask = ["a5a5", "a5a5"].concat();
+    // Every needle here is a CONSTANT the contract chose. The right-shift width
+    // used to sit in this list and is deliberately absent: it is not a constant
+    // but the shift implied by taking the top 24 bits of a 64-bit hash, which
+    // is what every hash-to-float writes. It also had no detection power to
+    // lose — in `ptir_rng_hash_uniform` that shift sits three lines from the
+    // scale divisor and the golden-ratio stride, so a real transcription trips
+    // those needles anyway. A needle that catches nothing the others miss while
+    // inventing false positives is not a guard rail.
+    //
+    // Needles are assembled from fragments because this file is itself walked:
+    // spelling one out in source — even in a comment — makes the test report
+    // itself. Keep it that way.
     let magic = [
         ["3c79", "ac49", "2ba7", "b653"].concat(),
         ["1c69", "b3f7", "4ac4", "ae35"].concat(),
         stride.clone(),
         ambient_mask.clone(),
-        [">>", "40"].concat(),
         ["16777216", ".0"].concat(),
     ];
 


### PR DESCRIPTION
The ownership guard was failing on `driver/metal/tests/llama_numerics_test.cpp`, and the
reported reason was wrong. This corrects the guard, not the file it accused.

## Nothing is transcribed there

Scanning that file for each needle individually, under the test's own normalization
(lowercase, underscores and whitespace stripped):

| needle | present in llama_numerics_test.cpp |
| --- | --- |
| splitmix multiplier 1 | no |
| splitmix multiplier 2 | no |
| golden-ratio stride | no |
| ambient mask | no |
| scale divisor | no |
| right-shift width | **yes**, one hit, line 124 |

The hit is inside `hashf`, whose multipliers are the MurmurHash3 finalizer words and which
maps to `[-1, 1)` using a different divisor. It shares no constant with the contract. There
was no drift, and nothing to single-source.

## Why the needle is the defect

Every other entry in the set is a constant the contract *chose* — re-typing one is real
evidence. A right shift by 40 is not a constant. It is what taking the top 24 bits of a
64-bit hash forces anyone to write.

It also had no detection power to lose. In `ptir_rng_hash_uniform` that shift sits three
lines from the stride and the scale divisor, and each of the four declared homes carries all
of them together, so a genuine transcription trips needles that *are* constants regardless:

| file | mult1 | mult2 | stride | mask | shift | divisor |
| --- | --- | --- | --- | --- | --- | --- |
| `compiler/ir/src/rng.rs` | Y | Y | Y | Y | – | – |
| `compiler/codegen/include/rng_contract.generated.h` | Y | Y | Y | Y | Y | Y |
| `compiler/codegen/include/ptir_rng.generated.metal` | Y | Y | Y | Y | Y | Y |
| `driver/metal/src/kernels/ptir_rng.generated.metal` | Y | Y | Y | Y | Y | Y |
| `driver/metal/tests/llama_numerics_test.cpp` | – | – | – | – | **Y** | – |

The shift never appears alone in a real transcription, and appears alone in the only false
positive. A needle that catches nothing the others miss while firing on unrelated
hash-to-float code is not a guard rail.

## Why not an exemption, and why not editing the Metal test

`unrelated_stride_users` / `unrelated_mask_users` exist for needles that *do* carry detection
power and also collide coincidentally — the golden-ratio word and the ambient mask are
contract constants that legitimately appear in a splitmix id generator and a boost-style
`hash_combine`. Exempting the Metal test would keep a needle with no upside and leave the
same trap for the next hash-to-float anyone writes. Adding it to `owners` would be worse: that
list means "this file is a declared home for the contract", and a fifth home legitimizes the
duplication the test exists to prevent. Editing `hashf` would bend correct code to satisfy a
bad check.

## The whole class, not one instance

The guard `panic!`s on the first offender, so a fix can uncover the next. A repo-wide scan of
all **1286** files the walker visits, for all six needles, confirms this is the complete set:
after this change nothing outside the four declared homes matches any needle. The scale
divisor — what actually pins the uniform conversion — matches in three files, all owners.

## Verification

- `cargo test -p pie-compiler-tests` in full: 16 test binaries, all green. `rng_contract`
  goes from 5 passed / 1 failed to **6 passed / 0 failed**.
- `cargo test --workspace --exclude pie-server-py --exclude pie-worker`: **exit 0**, and it
  now runs `pie_engine`'s unit tests. That step used to abort at `pie-compiler-tests`, which
  is why the engine suite was never reached in that job.
- `cargo clippy --no-deps --all-targets -p pie-compiler-tests -- -D warnings`: clean.
- `cargo fmt --check -p pie-compiler-tests`: clean.

## One note on the comment

The new comment describes the needles rather than spelling them out. This file is walked like
any other, so writing one literally — even in a comment — makes the test report itself. The
first draft of this change did exactly that and failed; the guard caught it.
