### PR TITLE
compiler crates: satisfy the clippy and rustfmt gates they are held to

### DIFF
--- a/compiler/dsl/tests/lowering.rs
+++ b/compiler/dsl/tests/lowering.rs
@@ -499,8 +499,7 @@ fn put_drains_a_peeked_port_and_leaves_a_consuming_one_alone() {
     );
 
     // The drain precedes the put it makes room for.
-    let pos_of =
-        |pred: &dyn Fn(&Op) -> bool| c.stages[0].ops.iter().position(|op| pred(op)).expect("op");
+    let pos_of = |pred: &dyn Fn(&Op) -> bool| c.stages[0].ops.iter().position(pred).expect("op");
     assert!(
         pos_of(&|op| matches!(op, Op::ChanTake(c) if *c == dense(pidx)))
             < pos_of(&|op| matches!(op, Op::ChanPut { chan, .. } if *chan == dense(pidx))),

--- a/compiler/ir/src/registry.rs
+++ b/compiler/ir/src/registry.rs
@@ -163,7 +163,11 @@ impl Port {
     pub fn consumes(self) -> bool {
         matches!(
             self,
-            Port::EmbedTokens | Port::Positions | Port::WSlot | Port::WOff | Port::RsWSlot
+            Port::EmbedTokens
+                | Port::Positions
+                | Port::WSlot
+                | Port::WOff
+                | Port::RsWSlot
                 | Port::RsWOff
         )
     }

--- a/compiler/plan/src/compile/symbolic.rs
+++ b/compiler/plan/src/compile/symbolic.rs
@@ -353,9 +353,7 @@ pub(crate) fn symbolic_port_type(port: Port, value_type: ValueType) -> SymbolicT
         Port::RsBufferIndptr | Port::RsBufferLen | Port::RsFoldLen => {
             set_first_symbolic(&mut ty, SymbolicExtent::RowCount)
         }
-        Port::RsWSlot | Port::RsWOff => {
-            set_first_symbolic(&mut ty, SymbolicExtent::TokenCount)
-        }
+        Port::RsWSlot | Port::RsWOff => set_first_symbolic(&mut ty, SymbolicExtent::TokenCount),
     }
     ty
 }


### PR DESCRIPTION
Two steps guard the same six compiler crates, and both were failing. Neither is a new
regression: the job they live in aborted at an earlier step naming a package the workspace
no longer has, so nothing after it ever ran. Correcting that name lets the job reach these,
and they fail on arrival.

Both were measured at the dev tip before being touched, running the commands **read off
ci.yml** rather than transcribed.

## clippy — `redundant closure`, compiler/dsl/tests/lowering.rs:503

```rust
- |pred: &dyn Fn(&Op) -> bool| c.stages[0].ops.iter().position(|op| pred(op)).expect("op")
+ |pred: &dyn Fn(&Op) -> bool| c.stages[0].ops.iter().position(pred).expect("op")
```

The closure only forwards its argument. `pred` is `&dyn Fn(&Op) -> bool` while `position`
wants `FnMut(&Op) -> bool` — that holds through the blanket impl for references to callables.
Compiled and the test run rather than taken on clippy's word: `cargo test -p pie-dsl --test
lowering` passes 10/10.

## rustfmt — two line wrappings

`compiler/ir/src/registry.rs:163` — a `matches!` alternation that rustfmt wants one arm per
line now that the list grew past the width. `compiler/plan/src/compile/symbolic.rs:353` — a
match arm whose body now fits inline. Both are line breaks; no code moves. Full diff is
**7 insertions, 6 deletions** across three files.

The formatter was run over only the two crates rustfmt named, and `git diff --name-only`
was checked afterwards: it lists exactly `compiler/ir/src/registry.rs`,
`compiler/plan/src/compile/symbolic.rs`, and the clippy fix. Nothing else was reformatted.

## Verification

Both gate commands, verbatim from ci.yml:

| gate | before | after |
| --- | --- | --- |
| `cargo clippy --no-deps --all-targets -p pie-ir -p pie-plan -p pie-eval -p pie-codegen -p pie-dsl -p pie-compiler-tests -- -D warnings` | fails | **exit 0** |
| `cargo fmt --check` over the same six | 2 diffs | **exit 0** |

Tests for all three touched crates pass: pie-ir 36 + 17, pie-plan 28 + 3, pie-dsl across 9
binaries including the 10 in `lowering`.

## What this does NOT do

**The job will still be red**, and that is expected. Two other failures live in
`cargo check / test (workspace)` and belong elsewhere: the pie-engine scheduler test — whose
library suite had no CI coverage at all until the same package-name correction — and the
workspace test step. Chasing a green job here would mean fixing things outside this change.

Deliberately not done: `-D warnings` untouched, the `-p` list unchanged, no `#[allow]` added,
no drive-by refactor. These failures were invisible because the job aborted early; hiding
them a different way would repeat that mistake one layer down.
