### PR TITLE
ci: run the workspace checks only for pull requests into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
The `push` trigger on the CI workflow is already scoped to `main`, but `pull_request` carries no branch filter, so a pull request into any long-lived integration branch runs the full battery as well. This gives `pull_request` the same `branches: [main]` filter that the push trigger already has, so both halves of the trigger agree and the checks run at the one boundary they are meant to gate.

The whole change is one line:

    on:
      push:
        branches: [main]
      pull_request:
        branches: [main]     # added

Worth knowing what this turns off: `ci.yml` is the only file under `.github/workflows/` with a `pull_request` trigger at all. `build.yml`, `release-cargo.yml`, `release-npm.yml` and `release-pypi.yml` are `workflow_dispatch`-only, and `deploy-website.yml` triggers on `push` to `main` under `website/**`. So after this lands, pull requests into branches other than `main` run no automated checks of any kind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pull-request checks now run only for changes targeting the `main` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->