### PR TITLE
rng-contract: drop the shift width from the magic set, it detects nothing

### DIFF
--- a/compiler/tests/tests/rng_contract.rs
+++ b/compiler/tests/tests/rng_contract.rs
@@ -220,12 +220,23 @@ fn rng_magic_is_owned_by_the_contract() {
     ];
     let stride = ["9e37", "79b9", "7f4a", "7c15"].concat();
     let ambient_mask = ["a5a5", "a5a5"].concat();
+    // Every needle here is a CONSTANT the contract chose. The right-shift width
+    // used to sit in this list and is deliberately absent: it is not a constant
+    // but the shift implied by taking the top 24 bits of a 64-bit hash, which
+    // is what every hash-to-float writes. It also had no detection power to
+    // lose — in `ptir_rng_hash_uniform` that shift sits three lines from the
+    // scale divisor and the golden-ratio stride, so a real transcription trips
+    // those needles anyway. A needle that catches nothing the others miss while
+    // inventing false positives is not a guard rail.
+    //
+    // Needles are assembled from fragments because this file is itself walked:
+    // spelling one out in source — even in a comment — makes the test report
+    // itself. Keep it that way.
     let magic = [
         ["3c79", "ac49", "2ba7", "b653"].concat(),
         ["1c69", "b3f7", "4ac4", "ae35"].concat(),
         stride.clone(),
         ambient_mask.clone(),
-        [">>", "40"].concat(),
         ["16777216", ".0"].concat(),
     ];
 


### PR DESCRIPTION
The PTIR RNG ownership guard fails on `driver/metal/tests/llama_numerics_test.cpp`, and the reported reason is wrong. Nothing in that file is transcribed from the contract. Scanning it for each needle, only the right-shift width matches; the two splitmix multipliers, the golden-ratio stride, the ambient mask and the scale divisor are all absent. The single hit sits inside `hashf`, whose multipliers are the MurmurHash3 finalizer words and which maps to [-1, 1) with a different divisor. It shares no constant with the contract, so there was no drift and nothing to single-source.

The needle itself is the defect. Every other entry in the set is a constant the contract chose, and re-typing one of those is real evidence of a copy. A right shift by 40 is not a constant — it is what taking the top 24 bits of a 64-bit hash forces anyone to write. It also had nothing left to detect: in `ptir_rng_hash_uniform` that shift sits three lines from the stride and the scale divisor, and each of the three generated homes carries all of them, so a genuine transcription trips needles that are constants regardless. A needle that catches nothing the others miss, while firing on unrelated hash-to-float code, is not a guard rail.

This is deliberately not the `unrelated_*_users` exemption case. Those lists exist for needles that do carry detection power and also collide coincidentally. Exempting the Metal test would keep a needle with no upside and leave the same trap for the next hash-to-float anyone writes, so the needle goes instead of the file.

A repo-wide scan of all 1286 files the walker visits confirms this is the whole class rather than one instance: afterwards nothing outside the four declared homes matches any needle. The scale divisor, which is what actually pins the uniform conversion, matches in three files and all three are owners.

Verified locally on this branch: `cargo test -p pie-compiler-tests --test rng_contract` gives 6 passed / 0 failed, with `rng_magic_is_owned_by_the_contract` passing.

Scope note: this is one commit touching one file. The same fix is also present inside a larger branch that carries unrelated Metal kernel work it inherited from its base; this PR isolates it onto the current branch tip so it can be reviewed and reverted on its own.