### PR TITLE
driver/cuda: gate FlashInfer's Mamba TMA kernels per arch pass

### DIFF
--- a/driver/cuda/CMakeLists.txt
+++ b/driver/cuda/CMakeLists.txt
@@ -221,6 +221,69 @@ if(EXISTS "${_FI_PATCH_FILE}" AND NOT EXISTS "${_FI_PATCH_SENTINEL}")
   message(STATUS "Patched FlashInfer narrowing conversion in ${_FI_PATCH_FILE}")
 endif()
 
+# FlashInfer gates its Mamba TMA kernels on FLASHINFER_MAMBA_ENABLE_SM90 and
+# nothing else, which is sound for the way upstream builds: a translation unit
+# compiled for sm_90 and no other architecture. We compile ONE translation unit
+# for every entry in CMAKE_CUDA_ARCHITECTURES, and a compile definition reaches
+# every -gencode pass, so defining it hands the TMA kernels to the sm_80/86/89
+# passes as well -- and libcu++ does not expose the APIs they call there.
+# `nv/detail/__target_macros` defines __CUDA_MINIMUM_ARCH__ as __CUDA_ARCH__
+# under nvcc, i.e. PER PASS rather than the minimum of the arch list, and
+# `cuda/std/__cccl/ptx_isa.h` withholds __cccl_lib_experimental_ctk12_cp_async_exposure
+# below 900. The sub-900 passes then fail on cp_async_bulk_tensor_4d_*,
+# cp_async_bulk_commit_group, cp_async_bulk_wait_group_read and
+# fence_proxy_async_shared_cta.
+#
+# So make the guard per-pass as well as per-build. Every site takes the SAME
+# condition, and that is what makes it sound rather than merely quieter: the
+# horizontal kernel's definition sits at namespace scope and the only code that
+# launches it sits in the host launcher, so under one shared condition they
+# appear and vanish together in every pass. The vertical kernel keeps its
+# definition with an empty body on the passes that cannot launch it. The host
+# pass has no __CUDA_ARCH__ at all and therefore keeps everything, which is what
+# the launcher needs in order to compile.
+#
+# This takes nothing away from sm_80/86/89. `src/ops/flashinfer_mamba.cu` only
+# enters FlashInfer's SSU at all when the device's major version is >= 9, and
+# FlashInfer's own selector independently sends sm_major < 9 to kSimple, so
+# these kernels were unreachable on those architectures before this patch.
+#
+# The site COUNT is asserted, not just the presence of the text: a FlashInfer
+# bump that adds or drops a guard would otherwise patch a different set and
+# still configure cleanly, which is the silent half-patch this must not become.
+# A missing file is fatal here for the same reason, rather than the skip the
+# patches above take -- upstream moving this header would otherwise read as
+# "nothing to patch" and hand the TMA kernels straight back to sm_80.
+set(_FI_ARCH_SENTINEL "${flashinfer_SOURCE_DIR}/.pie_mamba_arch_guarded")
+# Deliberately not _FI_PATCH_FILE: that one belongs to the narrowing patch
+# above, which its own comment says to delete once upstream fixes it, and this
+# patch must not quietly stop applying when that happens.
+set(_FI_ARCH_FILE
+  "${flashinfer_SOURCE_DIR}/include/flashinfer/mamba/kernel_selective_state_update_stp.cuh")
+set(_FI_ARCH_GUARD_OLD "#ifdef FLASHINFER_MAMBA_ENABLE_SM90")
+set(_FI_ARCH_GUARD_NEW
+  "#if defined(FLASHINFER_MAMBA_ENABLE_SM90) && (!defined(__CUDA_ARCH__) || __CUDA_ARCH__ >= 900)")
+if(NOT EXISTS "${_FI_ARCH_SENTINEL}")
+  if(NOT EXISTS "${_FI_ARCH_FILE}")
+    message(FATAL_ERROR
+      "FlashInfer Mamba arch-guard patch cannot find ${_FI_ARCH_FILE}")
+  endif()
+  file(READ "${_FI_ARCH_FILE}" _fi_arch_src)
+  string(REGEX MATCHALL "${_FI_ARCH_GUARD_OLD}" _fi_arch_sites "${_fi_arch_src}")
+  list(LENGTH _fi_arch_sites _fi_arch_count)
+  if(NOT _fi_arch_count EQUAL 6)
+    message(FATAL_ERROR
+      "FlashInfer Mamba arch-guard patch expects 6 `${_FI_ARCH_GUARD_OLD}` sites in "
+      "${_FI_ARCH_FILE}, found ${_fi_arch_count}")
+  endif()
+  string(REPLACE "${_FI_ARCH_GUARD_OLD}" "${_FI_ARCH_GUARD_NEW}"
+    _fi_arch_src "${_fi_arch_src}")
+  file(WRITE "${_FI_ARCH_FILE}" "${_fi_arch_src}")
+  file(WRITE "${_FI_ARCH_SENTINEL}" "patched")
+  message(STATUS
+    "Guarded FlashInfer Mamba SM90 kernels per arch pass in ${_FI_ARCH_FILE}")
+endif()
+
 # `finalizeMoeRoutingKernel` unpermutes GEMM2's output and does the topk-weighted
 # reduction. Its launcher asks for exactly `num_rows` blocks and the kernel reads
 # the token count back out of `gridDim.x`, so the grid is pinned to the batch
@@ -387,6 +450,12 @@ endif()
 # Without it, sm_90+ runs would silently fall back to the slow simple
 # algorithm even though the runtime SM check would otherwise pick
 # vertical/horizontal.
+#
+# "Contains sm_90" is the right question for this define and the wrong one for
+# the compiler: the define reaches every -gencode pass, including the ones that
+# cannot compile TMA. Which passes keep the kernels is settled per pass by the
+# arch guard patched into the FlashInfer header above, so a mixed arch list can
+# enable this without the sm_80/86/89 passes failing on it.
 if(PIE_HAS_SM90 OR PIE_HAS_SM100)
   set(PIE_CUDA_FLASHINFER_MAMBA_SM90 ON)
   message(STATUS "Enabling FlashInfer Mamba SM90 vertical/horizontal SSU kernels")


### PR DESCRIPTION
## What breaks today

`cargo build --release --bin pie --features driver-cuda` fails for any
`CMAKE_CUDA_ARCHITECTURES` that mixes sm_90 with anything below it -- including
`80;86;89;90`, which is what the published pre-Blackwell GPU image is built for.
24 errors of the form:

```
flashinfer/mamba/kernel_selective_state_update_stp.cuh(700): error:
  namespace "cuda::device::experimental" has no member "fence_proxy_async_shared_cta"
```

plus `cp_async_bulk_tensor_4d_global_to_shared`, `..._shared_to_global`,
`cp_async_bulk_commit_group` and `cp_async_bulk_wait_group_read`, each
"detected during instantiation of `flashinfer::mamba::invokeSelectiveStateUpdate<...>`".

## Why

`FLASHINFER_MAMBA_ENABLE_SM90` is the only guard on FlashInfer's Mamba TMA
kernels. That is sound for upstream, which compiles them in a translation unit
built for sm_90 and nothing else. We compile one translation unit for the whole
arch list, and `target_compile_definitions` applies to every `-gencode` pass --
so defining it hands the TMA kernels to the sm_80/86/89 passes too, where
libcu++ does not expose the APIs they call.

The exposure is decided **per pass**, which is the fact this fix turns on:

- `nv/detail/__target_macros:136` (CCCL 3.3.2, the copy FlashInfer vendors and
  we deliberately put ahead of the toolkit's) defines
  `__CUDA_MINIMUM_ARCH__` as `__CUDA_ARCH__` under nvcc -- **not** the minimum of
  `__CUDA_ARCH_LIST__`.
- `cuda/std/__cccl/ptx_isa.h:111` defines
  `__cccl_lib_experimental_ctk12_cp_async_exposure` only when
  `__CUDA_MINIMUM_ARCH__` is absent or `>= 900`.

So the host pass (no `__CUDA_ARCH__`) and the sm_90 pass see the APIs; sm_80/86/89
do not. Worth stating plainly because the obvious reading -- that a newer CUDA
toolkit would supply the symbols -- is wrong. 12.9.1 gates them identically, and
the governing header is FlashInfer's vendored CCCL rather than the toolkit's.

## The fix

Give all six `#ifdef FLASHINFER_MAMBA_ENABLE_SM90` sites the same per-pass
condition. Sharing one condition is what makes it sound rather than just
quieter: the horizontal kernel's definition is at namespace scope and the
launcher arm that is its only caller is inside the host launcher, so under a
single condition they appear and vanish together on every pass. The vertical
kernel keeps its definition with an empty body where it cannot be launched, and
the host pass keeps everything, which is what the launcher needs to compile.

## The alternative, and why not

Widening the CMake predicate from "the list contains 90" to "every arch >= 90"
also builds -- by turning the define off for the mixed list. It costs the H100s
in that image their fast SSU path: with the define off, the only algorithm left
is `simple`, and `src/ops/flashinfer_mamba.cu` records that `simple` loses to the
legacy warp_kernel past R~144 (microbenched 2026-05-25). A scoped source guard
gives up nothing on any architecture, so it wins.

Nothing is taken away from sm_80/86/89 either way: `flashinfer_mamba_ssu_enabled()`
only enters FlashInfer's SSU when the device major version is >= 9, and
FlashInfer's own selector independently routes `sm_major < 9` to `kSimple`. These
kernels were never reachable on those architectures.

## Patch mechanics

Patched in place rather than vendored, for the reason the narrowing patch
directly above already gives. Two differences from that one, both deliberate:
the site **count** is asserted rather than just the presence of the text, and a
missing header is fatal rather than skipped. A FlashInfer bump that renames the
macro, adds a seventh site or moves the file stops the configure instead of
silently handing the TMA kernels back to sm_80.

Verified by extracting the shipped block and running it under `cmake -P` against
the real v0.6.15 header: pristine header patches all 6 sites and is idempotent;
6->5 sites, 6->0 sites and a missing file each `FATAL_ERROR` without writing a
sentinel or half-patching; the patched header's preprocessor blocks still
balance.

## Unrelated, but noticed while debugging this

`driver/cuda/CMakeLists.txt:109` is `find_package(CUDAToolkit REQUIRED)` with no
minimum version. A toolkit too old for what `driver/cuda` uses therefore fails
nineteen minutes into the compile as a "was not declared in this scope" error
that reads like a source bug -- `gemm.cpp`'s use of the cuBLASLt block-scaling
enums needs 12.9. A minimum version there would turn that class of failure into
a first-minute configure error.

## CI on this PR is red, and none of it is this change

Recording this so the next reader does not have to re-derive it.

Failing: `workspace verify (all crates + all targets)`, `cargo check / test
(workspace)`, `pie-worker (driver-dummy)` on both `macos-latest` and
`ubuntu-latest`, and `pie-worker (driver-metal)`. Passing: `guest inferlets`,
`schema header drift`, `wit drift`.

| job | what it actually fails on |
| --- | --- |
| workspace verify | `pie-compiler-tests --test rng_contract` panics at `compiler/tests/tests/rng_contract.rs:249` |
| cargo check / test | `package ID specification 'pie' did not match any packages` -- before any compile |
| driver-dummy (macos) | `worker/src/executor/mod.rs:4267` unit test panic |
| driver-dummy (ubuntu) | `worker/src/executor/mod.rs:4509` unit test panic |
| driver-metal | Native Metal entrypoint validation, exit 8 |

The complete changed set of this PR against its own base is **one file**,
`driver/cuda/CMakeLists.txt`. The changed-file count against the base is **zero**
for every path those jobs read -- `compiler/tests/tests/rng_contract.rs`,
`worker/src/executor/mod.rs`, `Cargo.toml`, `Cargo.lock`, and
`.github/workflows`. Those files are byte-identical to the base here, so those
jobs are running the base's code and reporting the base's result. That is
identity rather than "the diff looks unrelated".

No CI run exists for the base commit to compare against, because the workflows
are `pull_request`-triggered and therefore never test a branch head on its own.

## The job that would exercise this change is skipped

`pie-worker (driver-cuda)` reports **skipping**. `driver/cuda/CMakeLists.txt` is
configured only by the CUDA driver build, so CI cannot turn this PR green or red
on its merits -- it never compiles the thing the PR changes.

That is worth stating plainly, because it is also the reason the breakage this
PR fixes went unnoticed in the first place: a CUDA driver that nothing in CI
compiles will accept a commit that does not build, on any arch list, and say
nothing. The verification above was therefore done out-of-band, as a `docker
build` of the downstream GPU image against this exact commit, fetched from this
remote.

## Fetchability of this commit

Checked rather than assumed, because the downstream image build resolves the pin
with a bare-SHA `git fetch --depth 1 <repo> <sha>` against the real remote and
then asserts `FETCH_HEAD` equals it. Reproduced verbatim in an empty directory
with no access to any local checkout: the fetch resolves, `FETCH_HEAD` matches,
and the resulting tree carries this patch. A commit that exists only locally
would have passed on the authoring machine and failed for everyone else.


## Verified: built, and the guard measurably applied

A downstream GPU image was built from this exact commit with
`CMAKE_CUDA_ARCHITECTURES=80;86;89;90` — the mixed list that fails without this
patch. The CUDA build step ran 1171.8s and completed; none of the prior failure
signatures appear.

The configure-time `message(STATUS ...)` is not observable on a green build:
`worker/build.rs` drives the CUDA build through the `cmake` crate, so CMake's
output goes to the build script's stdio, which cargo captures and prints only on
failure. So the artifact was measured instead — all 348 cubins extracted from the
resulting `pie` binary with `cuobjdump -xelf`, counting kernel symbols per arch:

| arch | `producer_consumer_vertical` | `producer_consumer_horizontal` | `kernel_simple` (ungated control) |
| --- | --- | --- | --- |
| sm_80 | 0 | 0 | 2 |
| sm_86 | 0 | 0 | 2 |
| sm_89 | 0 | 0 | 2 |
| sm_90a | 1 | 7 | 2 |

The control row is what makes this conclusive rather than suggestive: the mamba
translation unit *was* compiled for all four architectures, so the absence of the
TMA kernels from sm_80/86/89 is the guard, not a TU that went missing. And
sm_90a keeps them — Hopper does not lose its vertical/horizontal SSU path, which
is the regression the CMake-predicate alternative would have caused.

(The cubins are `sm_90a`, the architecture-specific Hopper variant CUTLASS/TMA
code requires. `__CUDA_ARCH__` is 900 there, so the `>= 900` guard admits it.)
