### PR TITLE
Disable DSV4 graph capture for routed dequantization

### DIFF
--- a/driver/cuda/src/model/deepseek_v4/deepseek_v4_model.cpp
+++ b/driver/cuda/src/model/deepseek_v4/deepseek_v4_model.cpp
@@ -57,7 +57,9 @@ DsV4Model::DsV4Model(
         // rather than into a lost optimisation.
         bool capturable = on;
         for (const auto& L : weights_.layers) {
-            if (L.expert_cache != nullptr) {
+            // Streamed and per-expert dequantized weights share the host-routing
+            // branch, whose device-to-host read requires a stream synchronize.
+            if (L.expert_cache != nullptr || !L.experts.empty()) {
                 capturable = false;
                 break;
             }


### PR DESCRIPTION
DeepSeek V4 routed dequantization fails during CUDA graph capture on a real 4x H200 tensor-parallel model load. Every rank reports CUDA error 900 ("operation not permitted when stream is capturing") at driver/cuda/src/model/deepseek_v4/deepseek_v4_forward.cpp:1273, where the per-expert branch synchronizes after copying top-k routing data to the host.

Both streamed experts and individually bound routed-dequantized experts enter that same host-routing branch. The model capability check already disables graph capture for the streamed form, but omitted the routed-dequantized form.

This change makes the capability predicate cover both representations. The synchronize is required by the current algorithm: build_routing and subsequent expert selection consume the device-produced top-k indices and weights on the host, so removing it would require a separate device-side routing/dispatch design.