### PR TITLE
gemm: let a run ask for a dense GEMM tactic that is not a race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,9 +410,10 @@ jobs:
             -path '*/out/cuda/build' -print -quit)"
           test -n "$CUDA_BUILD_DIR"
           cmake --build "$CUDA_BUILD_DIR" \
-            --target test_entry_validation test_pipeline_dispatch_bind
+            --target test_entry_validation test_pipeline_dispatch_bind \
+                    test_gemm_determinism
           ctest --test-dir "$CUDA_BUILD_DIR" --output-on-failure \
-            -R '^(entry_validation|pipeline_dispatch_bind)$'
+            -R '^(entry_validation|pipeline_dispatch_bind|gemm_determinism)$'
 
       - name: Verify no CUDA shared deps
         run: |

--- a/driver/cuda/CMakeLists.txt
+++ b/driver/cuda/CMakeLists.txt
@@ -1231,6 +1231,11 @@ pie_add_cuda_target(test_flashinfer_decode_head_dim_guard
   SOURCES tests/test_flashinfer_decode_head_dim_guard.cpp
   LIBS pie_driver_cuda_lib)
 pie_add_cuda_target(test_graph_variant SOURCES tests/graph_variant_test.cpp)
+# PIE_GEMM_DETERMINISTIC is still read from the environment. Names no src/ file
+# because the switch is header-only, and no device because it is host C++; it
+# re-execs itself, so it must stay a standalone executable.
+pie_add_cuda_target(test_gemm_determinism
+  SOURCES tests/gemm_determinism_test.cpp)
 # Reaches `pie/driver/fire/descriptor.hpp`, which pulls in `launch/program.hpp`
 # and so `pie_driver_abi.h` — the ABI include dir is not optional here even
 # though nothing in the test names it directly.

--- a/driver/cuda/src/ops/gemm.cpp
+++ b/driver/cuda/src/ops/gemm.cpp
@@ -24,6 +24,7 @@
 #include "kernels/gemv.hpp"
 #include "kernels/quant_bf16_to_fp8.hpp"
 #include "kernels/residual_add.hpp"
+#include "ops/gemm_determinism.hpp"
 #include "ops/tuning_cache.hpp"
 
 #ifdef PIE_CUDA_HAS_MARLIN
@@ -819,6 +820,29 @@ DenseTactic tune_dense(cublasHandle_t caller, const Bf16LtPlan* plan,
 bool dense_tactic_for(cublasHandle_t caller, const void* W, int M, int N,
                       int K, float beta, cudaStreamCaptureStatus capturing,
                       const Bf16LtPlan** out_plan, DenseTactic* out) {
+    // PIE_GEMM_DETERMINISTIC declines every shape here: nothing is measured,
+    // nothing is read back from `dense_gemm.txt`, and nothing is written to
+    // it. The caller then takes the shape ladder at the bottom of
+    // `gemm_bf16_impl`, which is what this file did before the tuner existed
+    // and is a pure function of (M, N, K, beta): the GEMV at M=1, cuBLASLt's
+    // shape-derived algorithm above the `min_m`/`min_n`/`min_k` thresholds,
+    // `cublasGemmEx` otherwise. A cold cache then decodes what a warm one
+    // does, a fresh pod what an old one does, and -- because the `seen`
+    // counter below is skipped too -- a shape's first occurrence what its
+    // second does. See ops/gemm_determinism.hpp for why that is worth a knob.
+    //
+    // What this deliberately does not do is make a token independent of the
+    // batch it decoded in. `dense_key` hashes M, so a peer joining the batch
+    // still moves the shape; dropping M from the key would not fix that and
+    // would break the cache, because a tactic's `algo` is an index into
+    // `Bf16LtPlan::heuristics` and that plan is built per (M, N, K) -- index 3
+    // at M=1 and index 3 at M=8 are different algorithms, and a key shared
+    // across M would replay whichever one happened to be measured first. M is
+    // a real axis of the arithmetic in any case: an M=8 GEMM tiles its K
+    // reduction differently from an M=1 GEMV whatever tactic either is handed.
+    // Batch-invariant logits are a larger change than this one.
+    if (dense_gemm_deterministic()) return false;
+
     // The arena allocates an M x N output. Tuning a shape whose output alone
     // would rival the KV cache is not worth the memory; those shapes are large
     // enough that cuBLAS's own choice is close to optimal anyway.

--- a/driver/cuda/src/ops/gemm_determinism.hpp
+++ b/driver/cuda/src/ops/gemm_determinism.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+// The opt-in reproducibility switch for the dense bf16 GEMM path.
+//
+// `DenseGemmTuner` in ops/gemm.cpp picks each shape's kernel by racing the
+// candidates on the wall clock, and keeps the winner in `dense_gemm.txt` for
+// the life of the machine. Candidates within `kGemmTacticMargin` of one
+// another are separated by whatever else the GPU was doing during the probe,
+// and a different kernel accumulates K in a different order, so the last bit
+// of a logit -- and with it a greedy decode's choice between two close tokens
+// -- can depend on when the tuner happened to run. It is the same failure the
+// in-place split-K ban a few hundred lines up in gemm.cpp is written against:
+// that ban fixed the reduction order *inside* a kernel and left the choice
+// *of* kernel racing.
+//
+// For serving that is the right trade; the fastest kernel is worth a last bit.
+// For a parity run, a determinism check, or a bisect against a reference the
+// answer has to be a function of the input alone, and there is no amount of
+// care at the call site that recovers it. `PIE_GEMM_DETERMINISTIC=1` is how a
+// run says which of the two it is.
+//
+// Everything that wants the answer asks `dense_gemm_deterministic()`, so there
+// is exactly one line to look at to see whether the knob is still wired to the
+// environment. A knob whose `getenv` is later replaced by a constant leaves
+// its documentation true and its behaviour dead, which is why
+// tests/gemm_determinism_test.cpp re-execs itself with the variable set and
+// unset and asserts this function follows it.
+
+#include <cstdlib>
+
+namespace pie_cuda_driver::ops {
+
+inline constexpr char kDenseGemmDeterministicEnv[] = "PIE_GEMM_DETERMINISTIC";
+
+// Set, non-empty, and not "0". Split out from the lookup so the spelling rules
+// can be checked without an environment to mutate.
+constexpr bool dense_gemm_deterministic_value(const char* v) {
+    return v != nullptr && v[0] != '\0' && v[0] != '0';
+}
+
+// Cached: a process's environment does not change under it, and this sits in
+// front of every dense bf16 GEMM.
+inline bool dense_gemm_deterministic() {
+    static const bool on =
+        dense_gemm_deterministic_value(std::getenv(kDenseGemmDeterministicEnv));
+    return on;
+}
+
+}  // namespace pie_cuda_driver::ops

--- a/driver/cuda/tests/gemm_determinism_test.cpp
+++ b/driver/cuda/tests/gemm_determinism_test.cpp
@@ -1,0 +1,95 @@
+// PIE_GEMM_DETERMINISTIC, checked the only way that catches the failure this
+// project keeps meeting: a knob that is documented, believed, and no longer
+// read. Asserting the parser alone would not catch it -- the parser would keep
+// returning true while the reader had been replaced by a constant -- so the
+// live `dense_gemm_deterministic()` is exercised in a child process per case,
+// with the variable actually set or actually cleared. It caches its answer in
+// a function-local static, which is why each case needs its own process.
+//
+// No device and no GPU: the switch is host C++, so this runs anywhere the
+// driver compiles.
+
+#include <stdlib.h>  // setenv/unsetenv are POSIX, not in <cstdlib>
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include "ops/gemm_determinism.hpp"
+
+using pie_cuda_driver::ops::dense_gemm_deterministic;
+using pie_cuda_driver::ops::dense_gemm_deterministic_value;
+using pie_cuda_driver::ops::kDenseGemmDeterministicEnv;
+
+namespace {
+
+struct Case {
+    const char* value;  // nullptr = the variable is not set at all
+    bool deterministic;
+};
+
+constexpr Case kCases[] = {
+    {nullptr, false},
+    {"", false},
+    {"0", false},
+    {"1", true},
+    {"true", true},
+    {"yes", true},
+};
+
+const char* spelling(const char* value) { return value ? value : "<unset>"; }
+
+// argv[2] is what the parent set the environment to; assert the reader agrees.
+int run_child(const char* expected) {
+    const bool want = std::strcmp(expected, "on") == 0;
+    const bool got = dense_gemm_deterministic();
+    if (got != want) {
+        std::fprintf(stderr,
+            "gemm_determinism_test: %s=%s -> dense_gemm_deterministic()=%d, "
+            "expected %d. The switch is no longer read from the environment, "
+            "so a deterministic run is silently a tuned one.\n",
+            kDenseGemmDeterministicEnv,
+            spelling(getenv(kDenseGemmDeterministicEnv)), got, want);
+        return 1;
+    }
+    return 0;
+}
+
+int run_parent(const char* self) {
+    int failures = 0;
+    for (const Case& c : kCases) {
+        if (dense_gemm_deterministic_value(c.value) != c.deterministic) {
+            std::fprintf(stderr,
+                "gemm_determinism_test: dense_gemm_deterministic_value(%s) "
+                "should be %d\n", spelling(c.value), c.deterministic);
+            ++failures;
+        }
+        if (c.value == nullptr) {
+            unsetenv(kDenseGemmDeterministicEnv);
+        } else {
+            setenv(kDenseGemmDeterministicEnv, c.value, 1);
+        }
+        const std::string cmd = std::string("'") + self + "' child " +
+                                (c.deterministic ? "on" : "off");
+        if (std::system(cmd.c_str()) != 0) {
+            std::fprintf(stderr,
+                "gemm_determinism_test: live read failed for %s=%s\n",
+                kDenseGemmDeterministicEnv, spelling(c.value));
+            ++failures;
+        }
+    }
+    if (failures != 0) return 1;
+    std::printf("gemm_determinism_test: OK (%zu cases)\n",
+                sizeof(kCases) / sizeof(kCases[0]));
+    return 0;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc >= 3 && std::strcmp(argv[1], "child") == 0) {
+        return run_child(argv[2]);
+    }
+    return run_parent(argv[0]);
+}


### PR DESCRIPTION
`DenseGemmTuner` picks each bf16 GEMM's kernel by racing the candidates on the
wall clock and taking the first one within `kGemmTacticMargin` (0.98) of the
fastest, in candidate order. Two percent is jitter on a shared GPU, so the
winner is decided by what else the device was doing during the probe. A
different kernel is a different order of accumulation over K, and the model's
last GEMM before the argmax is inside the tuned range at every serving shape,
so a greedy decode can silently take a different token from one run to the
next.

Three properties make that stick rather than average out:

- the verdict is written to `dense_gemm.txt` under the pod's `PIE_HOME` and
  replayed forever, so one noisy measurement is frozen into every later run on
  that machine;
- `dense_key` hashes **M**, the fire's token count, so a shape's tactic depends
  on who else was in the batch the first time it was measured;
- a shape outside graph capture must be `seen` twice before it is tuned, so its
  first occurrence runs different arithmetic from its second.

This is the same failure the in-place split-K ban ~470 lines up in the same
file is written against — the one that flipped GLM-5.2's step-13 argmax about
half the time through the LM head's reduction order. That fix pinned the
reduction scheme *inside* a kernel and left the choice *of* kernel racing. And
there was no way to turn the race off: the only `getenv` in the file is
`PIE_GEMM_TUNE_LOG`, which only logs.

## The change

`PIE_GEMM_DETERMINISTIC=1` makes `dense_tactic_for` decline every shape.
Nothing is measured, nothing is read back from the disk cache, and nothing is
written to it. The caller falls to the shape ladder at the bottom of
`gemm_bf16_impl` — the GEMV at M=1, cuBLASLt's shape-derived algorithm above
the `min_m`/`min_n`/`min_k` thresholds, `cublasGemmEx` otherwise — which is
what this file did before the tuner existed and is a pure function of
(M, N, K, beta).

Unset, nothing changes. The addition on the default path is one predictable
branch on a cached `static bool`, in front of work that already includes a
`cudaMalloc` and a stream sync.

Cost when it *is* set: the tuner's measured wins are given up, so a
deterministic run is a pre-tuner-speed run. That is the intended trade for a
parity or bisect run and is stated in the header.

## Why `dense_key` still hashes M

Considered and rejected. Dropping M would not buy batch-invariance and would
actively corrupt the cache: a tactic's `algo` is an index into
`Bf16LtPlan::heuristics`, and `build_lt_plan`/`Bf16LtKey` build that plan per
(M, N, K) — index 3 at M=1 and index 3 at M=8 name different algorithms, so a
key shared across M replays whichever one happened to be measured first.
Bucketing M has the same defect at every bucket boundary.

M is a real axis of the arithmetic in any case: an M=8 GEMM tiles its K
reduction differently from an M=1 GEMV whatever tactic either is handed. Logits
that do not move with batch composition are a strictly larger change than this
one, and this PR does not claim it.

## Evidence, and what is *not* evidence

**Reasoned from the code, not measured.** The determinism claim here is an
argument about the code — that with the tuner declined, the surviving path is a
function of the shape alone — and no token stream was compared to check it.
This is a Mac; the build host has no GPU.

Verified:

- `tests/gemm_determinism_test.cpp` compiles clean under
  `clang++ -std=c++20 -Wall -Wextra` and passes, 6 cases.
- It is non-vacuous: replacing the reader's body with a hardcoded `false`
  turns it red on all three truthy spellings, with the message naming the
  cause. The pure-parser assertions stay green through that mutation, which is
  exactly why the test re-execs instead of only parsing.

Not verified:

- `driver/cuda/src/ops/gemm.cpp` is **uncompiled**. The change there is one
  `#include` and one `if`, but no nvcc has seen it. Please run the CUDA build
  (or apply the `ci-cuda` label) before merging.
- Nothing was run on a GPU.

**The experiment that would confirm the claim:** same prompt, same pod, greedy
decode, `PIE_GEMM_DETERMINISTIC=1`. Delete `dense_gemm.txt`, run once, run
again against the now-warm cache, and diff the token ids. They should be
identical, and identical to a third run from a cold cache under load. Without
the switch the same procedure is the reproduction: run cold and warm and expect
the streams to diverge at the first near-tie.

## Also noticed, not touched

`dense_tactic_already_gemv` (gemm.cpp:~888) has no callers anywhere in the
tree. Pre-existing and unrelated; left alone.


## Scope of the guarantee (added after cross-machine testing)

`PIE_GEMM_DETERMINISTIC=1` delivers **boot-invariance on one machine**: the
default path is a pure function of (M, N, K, beta), so two runs on the same
pod produce the same arithmetic. It does **not** claim machine-invariance.
A separately observed cross-machine divergence (bimodal outputs across four
same-image, same-config pods; cause under investigation) enters at a layer
whose GEMMs are already on the default path — if that lands inside
cuBLAS/cuBLASLt kernel dispatch, this mode will not cure it, and curing it
would need a pinned-ALGORITHM mode rather than a no-tuner mode. Cite this
flag as "same machine, any boot", never as "any machine".
