### PR TITLE
engine: one-shot channel poison + FP8-GDN scale-factor load fix

### DIFF
--- a/driver/cuda/src/loader/transcode_engine.hpp
+++ b/driver/cuda/src/loader/transcode_engine.hpp
@@ -413,16 +413,31 @@ private:
         }
         // MXFP4 pairs E2M1 elements with E8M0 exponents; Int4B8 pairs
         // biased nibbles with plain BF16 factors; FP8 pairs a byte per element
-        // with F32 reciprocal scales. No kernel reads another's factor format.
+        // with reciprocal scales the kernel reads as F32 — shipped either F32
+        // or BF16 (Qwen3.6-FP8 stores `weight_scale_inv` BF16), and a BF16
+        // slab is widened here with the cast kernel rather than in the plan,
+        // where the cast's staged operand would be untyped bytes. No kernel
+        // reads another's factor format.
+        const bool fp8_bf16_factors = fp8 && factors.dtype() == DType::BF16;
         const DType want_factors =
             mxfp4 ? DType::E8M0 : (int4b8 ? DType::BF16 : DType::FP32);
-        if (factors.dtype() != want_factors) {
+        if (factors.dtype() != want_factors && !fp8_bf16_factors) {
             throw std::runtime_error(
                 "rust storage executor: this scheme's block scales are " +
                 std::string(dtype_name(want_factors)) +
                 ", but the factor operand declares " +
                 std::string(dtype_name(factors.dtype())));
         }
+        DeviceTensor widened_factors;
+        const void* factor_data = factors.data();
+#if PIE_CUDA_TRANSCODE_ENGINE_HAS_CUDA
+        if (fp8_bf16_factors) {
+            widened_factors = DeviceTensor::allocate(DType::FP32, factors.shape());
+            // Stream 0, like the dequant launch below that reads it.
+            cast_tensor_to_ptr(factors, widened_factors.data(), DType::FP32);
+            factor_data = widened_factors.data();
+        }
+#endif
 
         DeviceTensor scratch = acquire_scale_source(
             instr, source, fp8 ? rows * cols : rows * cols / 2);
@@ -439,7 +454,7 @@ private:
             kernels::launch_dequant_fp8_e4m3_to_bf16_blocked(
                 static_cast<const std::uint8_t*>(scratch.data()),
                 dst,
-                static_cast<const float*>(factors.data()),
+                static_cast<const float*>(factor_data),
                 static_cast<int>(rows),
                 static_cast<int>(cols),
                 static_cast<int>(row_block),
@@ -469,6 +484,7 @@ private:
         (void)scratch;
         (void)dst;
         (void)row_block;
+        (void)factor_data;
         throw std::runtime_error(
             "rust storage executor: CUDA TileMap Scale compiled without CUDA "
             "headers");

--- a/model/qwen_3_5/src/contract.rs
+++ b/model/qwen_3_5/src/contract.rs
@@ -71,9 +71,9 @@ pub fn author_qwen3_5_moe(b: &mut Builder<'_>) -> Result<(), Error> {
 /// each projection with a 2-D `weight_scale_inv` block-scale tensor, and
 /// `Expr::Scale`/`ScaleFactor::PerBlock` is exactly `weight = fp8 * scale`
 /// executed by the load-time dequant kernel both executors implement. The
-/// factors are declared as an `Internal` F32 tensor (the FP8 dequant kernel
-/// reads F32 factors), so the driver's bind table sees only the bf16 weight
-/// under its usual name.
+/// factors are declared as an `Internal` tensor at their checkpoint dtype
+/// (BF16 or F32; the CUDA engine widens BF16 factors itself), so the
+/// driver's bind table sees only the bf16 weight under its usual name.
 ///
 /// Sharding folds in *before* the multiply, on scale-block boundaries only.
 /// `in_proj_qkv` stacks `[K | K | V]` on axis 0 and each band splits per
@@ -109,15 +109,17 @@ fn gdn_fp8_dequant(b: &mut Builder<'_>) -> Result<(), Error> {
         let Some(scale) = b.find(&scale_name) else {
             return refuse(b, "its `weight_scale_inv` companion is missing".to_string());
         };
+        // BF16 or F32 only: the factors ship at their checkpoint dtype (a
+        // cast in the plan would hand the CUDA engine an operand it cannot
+        // type — a staged buffer is untyped bytes to it), and its dequant
+        // reads exactly these two.
         if scale.shape.len() != 2
-            || !(is_raw(&scale.encoding, DType::BF16)
-                || is_raw(&scale.encoding, DType::F16)
-                || is_raw(&scale.encoding, DType::F32))
+            || !(is_raw(&scale.encoding, DType::BF16) || is_raw(&scale.encoding, DType::F32))
         {
             return refuse(
                 b,
                 format!(
-                    "'{scale_name}' must be a 2-D F32/F16/BF16 scale tensor, \
+                    "'{scale_name}' must be a 2-D F32/BF16 scale tensor, \
                      got {:?} {:?}",
                     scale.encoding, scale.shape
                 ),
@@ -216,21 +218,17 @@ fn gdn_fp8_dequant(b: &mut Builder<'_>) -> Result<(), Error> {
             let (sexpr, sshape) = b.shard(Expr::src(&scale.name), scale.shape.clone(), axis);
             (wexpr, wshape, sexpr, sshape)
         };
-        // The factors must be a declared tensor, and the CUDA dequant kernel
-        // reads them as F32; a checkpoint that ships them F32 already may not
-        // be handed an identity cast.
-        let sexpr = if is_raw(&scale.encoding, DType::F32) {
-            sexpr
-        } else {
-            sexpr.cast(Encoding::Raw(DType::F32))
-        };
+        // The factors keep their checkpoint dtype, deliberately. A `.cast`
+        // here compiled to a TileMap whose operand — the gathered bands — is
+        // an anonymous staging buffer, which the CUDA executor types as u8
+        // ("unsupported TileMap Cast u8 -> fp32" on the real checkpoint at
+        // tp 2), and whose strided single-source form its cast path refuses
+        // as non-compact. An `Internal` declaration is always a *typed*
+        // buffer on both executors, so the Scale kernel is handed BF16
+        // factors and widens them itself.
         let scale_out = b.output_name(&scale.name);
-        if let Some(index) = b.define(
-            scale_out.clone(),
-            sexpr,
-            Encoding::Raw(DType::F32),
-            Some(sshape),
-        ) {
+        if let Some(index) = b.define(scale_out.clone(), sexpr, scale.encoding.clone(), Some(sshape))
+        {
             b.mark_internal(index);
         }
         b.define(

--- a/model/tests/family_contracts.rs
+++ b/model/tests/family_contracts.rs
@@ -554,11 +554,15 @@ fn gdn_scale(j: usize) -> f32 {
 /// An FP8-GDN checkpoint with *real bytes*: every `linear_attn` projection
 /// ships E4M3 beside a bf16 `weight_scale_inv` in 4x4 blocks, and the file
 /// holds the values `gdn_value`/`gdn_scale` state so the host executor can be
-/// checked against arithmetic done here. K = V = 8 with 4-row blocks keeps
-/// every tp=2 band on a block boundary; everything else is zero-filled bf16.
+/// checked against arithmetic done here. K = 8 and V = 16 with 4-row blocks
+/// keep every tp=2 band on a block boundary while making the three bands
+/// *unequal* — the real checkpoint's geometry (K/128=16, V/128=48), whose
+/// per-rank scale rows are runs of unequal length that no single strided
+/// walk covers, so the gathered factors go through a staging buffer exactly
+/// as they do on the pod. Everything else is zero-filled bf16.
 fn qwen3_5_fp8_gdn_checkpoint() -> CheckpointMetadata {
     let hidden = 8i64;
-    let (k_dim, v_dim) = (8i64, 8i64);
+    let (k_dim, v_dim) = (8i64, 16i64);
     let conv_dim = 2 * k_dim + v_dim;
     let block = 4i64;
     let fp8 = Encoding::Raw(DType::F8E4M3);
@@ -679,6 +683,15 @@ fn qwen3_5_fp8_gdn_dequantizes_to_expected_bf16() {
                 Visibility::Internal,
                 "{leaf}: factors are load-time only, not a bind name"
             );
+            // At the checkpoint's own dtype: a cast to F32 in the plan hands
+            // the CUDA executor an operand it cannot type — a staged gather
+            // is untyped bytes to it — so the widening belongs to the Scale
+            // kernel, not the contract.
+            assert_eq!(
+                scales.encoding,
+                Encoding::Raw(DType::BF16),
+                "{leaf}: factors ship as the checkpoint stores them"
+            );
         }
         let plan = compile_load_plan(&checkpoint, &contract, target.clone())
             .expect("compiling failed");
@@ -710,6 +723,44 @@ fn qwen3_5_fp8_gdn_dequantizes_to_expected_bf16() {
             assert_eq!(transform.scale_blocks, vec![4, 4]);
             assert_eq!(transform.from, Some(QuantScheme::Fp8E4M3));
         }
+        // Every Cast must be one the CUDA engine can actually run: a *dense*
+        // file source (its cast path refuses non-compact sources), or an
+        // input buffer backed by a declared tensor (an anonymous buffer is
+        // typed u8 there, and u8 -> fp32 is — correctly — unsupported).
+        // This is the regression the real checkpoint caught at tp 2: the
+        // factors' cast read a staged, untyped gather of unequal bands.
+        for instr in &plan.instrs {
+            let StorageInstr::TileMap {
+                kind: TileMapKind::Cast,
+                source,
+                inputs,
+                ..
+            } = instr
+            else {
+                continue;
+            };
+            match source {
+                Some(source) => assert!(
+                    source.stride.is_dense(),
+                    "tp{tp_size} rank {tp_rank}: a Cast source the CUDA engine \
+                     refuses as non-compact: {source:?}"
+                ),
+                None => {
+                    let input = inputs.first().expect("Cast with no source has an input");
+                    let typed = plan
+                        .buffers
+                        .iter()
+                        .find(|decl| decl.id == *input)
+                        .is_some_and(|decl| decl.tensor.is_some());
+                    assert!(
+                        typed,
+                        "tp{tp_size} rank {tp_rank}: a Cast reads buffer \
+                         {input:?}, which no tensor declaration types — the \
+                         CUDA engine would run it as u8"
+                    );
+                }
+            }
+        }
 
         // The CUDA plan above pins what the driver will run; the host replay
         // executes the same contract compiled against the host's own mask.
@@ -723,24 +774,29 @@ fn qwen3_5_fp8_gdn_dequantizes_to_expected_bf16() {
         )
         .expect("host execution failed");
         // This rank's global rows/cols per projection: at tp=2 the qkv rows
-        // are the rank's half of each of the [K|K|V] bands, z splits rows,
-        // out_proj splits columns.
-        let half = |base: i64| -> Vec<i64> {
-            (base + i64::from(tp_rank) * 4..base + i64::from(tp_rank) * 4 + 4).collect()
+        // are the rank's half of each of the [K=8 | K=8 | V=16] bands, z
+        // splits rows, out_proj splits columns.
+        let half = |base: i64, len: i64| -> Vec<i64> {
+            let start = base + i64::from(tp_rank) * len / 2;
+            (start..start + len / 2).collect()
         };
         let (qkv_rows, z_rows, out_cols) = if tp_size == 1 {
-            ((0..24).collect::<Vec<i64>>(), all8.clone(), all8.clone())
+            (
+                (0..32).collect::<Vec<i64>>(),
+                (0..16).collect::<Vec<i64>>(),
+                (0..16).collect::<Vec<i64>>(),
+            )
         } else {
             (
-                [half(0), half(8), half(16)].concat(),
-                half(0),
-                half(0),
+                [half(0, 8), half(8, 8), half(16, 16)].concat(),
+                half(0, 16),
+                half(0, 16),
             )
         };
         for (leaf, rows, cols, full_cols) in [
             ("in_proj_qkv", &qkv_rows, &all8, 8),
             ("in_proj_z", &z_rows, &all8, 8),
-            ("out_proj", &all8, &out_cols, 8),
+            ("out_proj", &all8, &out_cols, 16),
         ] {
             let name = format!("{la}{leaf}.weight");
             let bytes = storage
@@ -757,8 +813,8 @@ fn qwen3_5_fp8_gdn_dequantizes_to_expected_bf16() {
 }
 
 /// A tp that splits inside a scale block has no representable scale slice —
-/// K = V = 8 in 4-row blocks cannot split 4 ways — and must be refused
-/// rather than approximated.
+/// K = 8 in 4-row blocks cannot split 4 ways — and must be refused rather
+/// than approximated.
 #[test]
 fn qwen3_5_fp8_gdn_refuses_misaligned_tp() {
     let mut facts = facts("qwen3_5", 2);

--- a/runtime/engine/src/pipeline/channel.rs
+++ b/runtime/engine/src/pipeline/channel.rs
@@ -103,9 +103,13 @@ pub struct ChannelCell {
     /// Reader channel. Submission completion publishes each endpoint's visible tail; the
     /// guest host operation copies only then.
     reader: Option<ReaderMirror>,
-    /// `Some(reason)` once a fire that feeds this channel failed: every later
-    /// host `take`/`read` errors with the reason. Under run-ahead the submit
-    /// returns before the fire resolves, so poison IS the error channel.
+    /// `Some(reason)` once a fire that feeds this channel failed: host
+    /// `take`/`read` error with the reason until a `take` consumes it. Under
+    /// run-ahead the submit returns before the fire resolves, so poison IS
+    /// the error channel — and like an error channel it is drained by the
+    /// consuming read, so a long-lived session channel recovers once the
+    /// failed fire's waiter has observed the error. Driver-published poison
+    /// epochs (device faults) are separate and stay sticky.
     poisoned: Option<String>,
     /// Host replacement for the current committed front. The per-pass host
     /// shadow consults this after a staged Writer put, so `set` changes the
@@ -748,8 +752,8 @@ impl ChannelCell {
     /// simply empty.
     pub fn take(&mut self) -> Result<Vec<u8>, ChannelError> {
         self.refresh_reader_mirrors()?;
-        if let Some(reason) = &self.poisoned {
-            return Err(ChannelError::Poisoned(reason.clone()));
+        if let Some(reason) = self.poisoned.take() {
+            return Err(ChannelError::Poisoned(reason));
         }
         if let Some(role) = self.role {
             if role != HostRole::Reader {
@@ -779,9 +783,11 @@ impl ChannelCell {
         self.produced.front().cloned().ok_or(ChannelError::Empty)
     }
 
-    /// Poison the cell with the failed fire's error: every later host
-    /// `take`/`read` errors with it. First poison wins (the earliest failure
-    /// is the root cause).
+    /// Poison the cell with the failed fire's error: host `take`/`read`
+    /// error with it until a `take` consumes the poison. First poison wins
+    /// (the earliest failure is the root cause). One-shot delivery keeps a
+    /// long-lived session channel usable after an admission-time rejection
+    /// (e.g. an over-budget frame) instead of failing every later request.
     pub fn poison(&mut self, reason: &str) {
         if self.poisoned.is_none() {
             self.poisoned = Some(reason.to_string());
@@ -1578,20 +1584,25 @@ mod tests {
         let out_id = cells[1].lock().unwrap().global_id;
         publish_wire(&cells[1], out_id, &7i32.to_le_bytes());
         cells[1].lock().unwrap().poison("fire 3 failed: OOM");
-        assert_eq!(
-            cells[1].lock().unwrap().take().unwrap_err(),
-            ChannelError::Poisoned("fire 3 failed: OOM".into())
-        );
+        // First poison wins — a later failure doesn't mask the root cause.
+        cells[1].lock().unwrap().poison("fire 4 cascade");
+        // `read` peeks the poison without consuming it.
         assert_eq!(
             cells[1].lock().unwrap().read().unwrap_err(),
             ChannelError::Poisoned("fire 3 failed: OOM".into())
         );
-        // First poison wins — a later failure doesn't mask the root cause.
-        cells[1].lock().unwrap().poison("fire 4 cascade");
+        // `take` delivers the poison exactly once...
         assert_eq!(
             cells[1].lock().unwrap().take().unwrap_err(),
             ChannelError::Poisoned("fire 3 failed: OOM".into())
         );
+        // ...after which the session channel is usable again: the cell the
+        // wire published is still there for the next fire's waiter.
+        assert_eq!(
+            cells[1].lock().unwrap().take().unwrap(),
+            7i32.to_le_bytes().to_vec()
+        );
+        assert_eq!(cells[1].lock().unwrap().take().unwrap_err(), ChannelError::Empty);
     }
 
     #[test]


### PR DESCRIPTION
Two lane fixes from #2017 debugging.

**1. Deliver channel poison once, then recover.** A failed fire poisons its pass's host-reader channels so the parked reader observes the error. The poison was sticky for the life of the channel, and decoder sessions keep channels across requests — so one admission-time rejection (a frame over the physical budget ceiling, which never touched the device) permanently poisoned the session: every later request failed with 'channel is poisoned' until a restage. Host-side poison is now one-shot: take delivers the error and clears it, read peeks it, first-poison-wins unchanged, driver-published poison epochs (real device faults) stay sticky. All 426 pie-engine lib tests pass; the poison unit test now asserts recovery after delivery.

**2. Ship FP8-GDN scale factors at their checkpoint dtype; widen in the engine** (cherry-pick 0452d7a5 from the score lane). The real Qwen3.6-27B-FP8 load at tp2 threw 'unsupported TileMap Cast u8 -> fp32' because the plan cast gathered weight_scale_inv bands to F32 through an anonymous staged buffer the executor types as u8. Factors now ship at checkpoint dtype (BF16) and the engine widens them with the existing cast kernel. The C++ hunk is the same code already running in the score/f9a62b81-rope-fix binary that produced the graded parity results; family_contracts tests (35) pass on this branch.