### PR TITLE
FP8-GDN serving + engine wedge fixes, GPU-verified

### DIFF
--- a/driver/cuda/src/context.cpp
+++ b/driver/cuda/src/context.cpp
@@ -2252,8 +2252,20 @@ int Context::Impl::launch_body(
     if (needs_growth) {
         recalibrate_elastic_budget(/*reset_hard_ceiling=*/false);
     }
-    const auto commit = pie_cuda_driver::commit_cuda_arena_targets_atomically(
+    auto commit = pie_cuda_driver::commit_cuda_arena_targets_atomically(
         elastic_pool_, targets);
+    if (commit.outcome != pie_cuda_driver::CudaCommitOutcome::Committed) {
+        // The budget is a cached view of free device memory, captured the
+        // last time a growing frame recalibrated. A transient external
+        // allocation (a large prefill's workspace peak) can depress that
+        // snapshot, and frames that fit inside committed arenas never
+        // refresh it — leaving every later frame rejected against a stale
+        // number while the device memory is actually free. Refresh from the
+        // device and retry once before declaring the frame unservable.
+        recalibrate_elastic_budget(/*reset_hard_ceiling=*/false);
+        commit = pie_cuda_driver::commit_cuda_arena_targets_atomically(
+            elastic_pool_, targets);
+    }
     if (commit.outcome == pie_cuda_driver::CudaCommitOutcome::Exhausted) {
         return PIE_STATUS_EXHAUSTED;
     }

--- a/driver/cuda/src/model/qwen3_5/qwen3_5.cpp
+++ b/driver/cuda/src/model/qwen3_5/qwen3_5.cpp
@@ -102,6 +102,11 @@ Qwen3_5Weights bind_qwen3_5(LoadedModel& engine) {
             Lw.la_in_proj_z = maybe(engine, la + "in_proj_z.weight");
             Lw.la_in_proj_b = maybe(engine, la + "in_proj_b.weight");
             Lw.la_in_proj_a = maybe(engine, la + "in_proj_a.weight");
+            // FP8 checkpoints publish these raw with paired block scales;
+            // bf16 checkpoints have no attachment and the meta stays empty.
+            Lw.la_in_proj_qkv_quant = engine.quant_meta(la + "in_proj_qkv.weight");
+            Lw.la_in_proj_z_quant = engine.quant_meta(la + "in_proj_z.weight");
+            Lw.la_out_proj_quant = engine.quant_meta(la + "out_proj.weight");
             // This rank's `[K/T | K/T | V/T]`: the contract states the
             // per-block shard, so the whole tensor is never resident here.
             Lw.la_conv1d_w = &must(engine, la + "conv1d.weight");

--- a/driver/cuda/src/model/qwen3_5/qwen3_5.hpp
+++ b/driver/cuda/src/model/qwen3_5/qwen3_5.hpp
@@ -75,8 +75,9 @@ struct Qwen3_5LayerWeights {
     const DeviceTensor* gate_up_proj_fused = nullptr;  // [2*I, H] bf16
     // Optional QuantMeta companions for the GEMM-fed projections. The
     // materialized WeightStore owns this metadata after LoadPlan execution.
-    // Linear-attn weights stay bf16 for now (their fused [K1|K2|V] block
-    // layout needs per-block scale handling that isn't wired yet).
+    // The linear-attn projections carry them too: the contract republishes
+    // the [K1|K2|V]-banded in_proj_qkv with its block scales banded by the
+    // same offsets, so an FP8 checkpoint's GDN GEMMs run natively.
     std::optional<QuantMeta> fa_q_proj_quant;
     std::optional<QuantMeta> fa_k_proj_quant;
     std::optional<QuantMeta> fa_v_proj_quant;
@@ -84,6 +85,9 @@ struct Qwen3_5LayerWeights {
     std::optional<QuantMeta> gate_proj_quant;
     std::optional<QuantMeta> up_proj_quant;
     std::optional<QuantMeta> down_proj_quant;
+    std::optional<QuantMeta> la_in_proj_qkv_quant;
+    std::optional<QuantMeta> la_in_proj_z_quant;
+    std::optional<QuantMeta> la_out_proj_quant;
 
     // KV cache slot for full-attn layers; -1 for linear-attn layers
     // (their state lives in the recurrent/conv rs_cache slabs).

--- a/driver/cuda/src/model/qwen3_5/qwen3_5_forward.cpp
+++ b/driver/cuda/src/model/qwen3_5/qwen3_5_forward.cpp
@@ -591,13 +591,13 @@ void linear_attn_layer_body(
                 static_cast<std::size_t>(src0) * H;
             // mixed_qkv [rows, conv_dim] = norm_x @ in_proj_qkv.T
             ops::gemm_act_x_w(cublas.handle(),
-                x, *Lw.la_in_proj_qkv,
+                x, make_weight_view(Lw.la_in_proj_qkv, Lw.la_in_proj_qkv_quant),
                 la.mixed_qkv.data() +
                     static_cast<std::size_t>(dst0) * conv_dim,
                 rows, conv_dim, H);
             // z [rows, V_dim] = norm_x @ in_proj_z.T
             ops::gemm_act_x_w(cublas.handle(),
-                x, *Lw.la_in_proj_z,
+                x, make_weight_view(Lw.la_in_proj_z, Lw.la_in_proj_z_quant),
                 la.z.data() + static_cast<std::size_t>(src0) * V_dim,
                 rows, V_dim, H);
             // a [rows, V_h] = norm_x @ in_proj_a.T   (b symmetric)
@@ -1264,11 +1264,13 @@ void linear_attn_layer_body(
     profile_forward_stage_ptr(profile, &ForwardProfile::linear_out_ms, stream, [&] {
         if (T == 1) {
             ops::gemm_act_x_w(cublas.handle(),
-                la.core_out_bf16.data(), *Lw.la_out_proj,
+                la.core_out_bf16.data(),
+                make_weight_view(Lw.la_out_proj, Lw.la_out_proj_quant),
                 ws.y.data(), N_new, H, V_dim, /*beta=*/1.f);
         } else {
             ops::gemm_act_x_w(cublas.handle(),
-                la.core_out_bf16.data(), *Lw.la_out_proj,
+                la.core_out_bf16.data(),
+                make_weight_view(Lw.la_out_proj, Lw.la_out_proj_quant),
                 ws.norm_y.data(), N_new, H, V_dim, /*beta=*/0.f);
             tp->all_reduce_bf16(ws.norm_y.data(),
                 static_cast<std::size_t>(N_new) * H, ncclSum, stream);

--- a/loader/src/contract/rewrite.rs
+++ b/loader/src/contract/rewrite.rs
@@ -191,12 +191,22 @@ fn emit_row_shard_bank(
 
     for (slot, &old_index) in indices.iter().enumerate() {
         let original = &contract.tensors[old_index];
-        new_tensors.push(TensorContract::new(
+        let mut rebuilt = TensorContract::new(
             original.name.clone(),
             Expr::out(bank_name.clone()).slice(0, slot as i64 * local_rows, local_rows),
             vec![local_rows, cols],
             original.encoding.clone(),
-        ));
+        );
+        // "Declares exactly the same tensors" is this module's whole license,
+        // and a declaration is more than a name and a shape. Rebuilding a
+        // member without its `scales` silently unpaired every coalesced
+        // block-scale tensor from its FP8 weight — 230 of Qwen3.6-27B-FP8's
+        // 263 quant attachments gone at tp 2, and every affected GEMM threw
+        // "quant scale data is null" — and dropping `visibility` promoted
+        // internal factors into the bind table.
+        rebuilt.scales = original.scales.clone();
+        rebuilt.visibility = original.visibility;
+        new_tensors.push(rebuilt);
     }
     Ok(())
 }
@@ -246,4 +256,93 @@ fn checked_mul_i64(lhs: i64, rhs: u64, context: &str) -> Result<u64, Error> {
         u64::try_from(lhs).map_err(|_| Error::Contract(format!("{context}: negative value")))?;
     lhs.checked_mul(rhs)
         .or_overflow(format!("{context}: byte overflow"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::checkpoint::{CheckpointFile, RawTensor};
+    use crate::contract::Scales;
+    use crate::types::{
+        CheckpointFormat, DType, FileId, QuantGranularity, ScaleForm, TensorId, Visibility,
+    };
+
+    /// A coalesced member is still the declaration it was: its `scales`
+    /// pairing and its `visibility` ride along into the bank view. Losing the
+    /// first silently unpaired 230 of Qwen3.6-27B-FP8's 263 block-scale
+    /// attachments at tp 2 ("quant scale data is null" in every affected
+    /// GEMM); losing the second promoted internal factors into the bind table.
+    #[test]
+    fn a_coalesced_member_keeps_its_scales_and_visibility() {
+        let mut tensors = Vec::new();
+        let mut contract_tensors = Vec::new();
+        let mut offset = 0u64;
+        // 16 members: `coalesce_direct_row_shards`'s MIN_GROUP_TENSORS.
+        for index in 0..16 {
+            let name = format!("layer.{index}.weight_scale_inv");
+            let span = 8 * 4 * 2;
+            tensors.push(RawTensor {
+                id: TensorId(index as u32),
+                name: name.clone(),
+                file_id: FileId(0),
+                file_offset: offset,
+                span_bytes: span,
+                shape: vec![8, 4],
+                encoding: Encoding::Raw(DType::BF16),
+            });
+            offset += span;
+            let mut entry = TensorContract::new(
+                name.clone(),
+                Expr::src(&name).shard(0),
+                vec![4, 4],
+                Encoding::Raw(DType::BF16),
+            );
+            entry.scales = Some(Scales {
+                of: format!("layer.{index}.weight"),
+                granularity: QuantGranularity::PerGroup,
+                group_size: 128,
+                channel_axis: 0,
+                form: ScaleForm::F32Factors,
+            });
+            entry.visibility = Visibility::Internal;
+            contract_tensors.push(entry);
+        }
+        let metadata = CheckpointMetadata {
+            files: vec![CheckpointFile {
+                id: FileId(0),
+                path: "model.safetensors".to_string(),
+                size_bytes: offset,
+                format: CheckpointFormat::Safetensors,
+            }],
+            tensors,
+        };
+        let contract = ModelContract {
+            alignment: 1,
+            tensors: contract_tensors,
+            groups: Vec::new(),
+        };
+        let target = StorageTarget {
+            tp_rank: 0,
+            tp_size: 2,
+            ..StorageTarget::default()
+        };
+
+        let rewritten = coalesce_direct_row_shards(&contract, &metadata, &target).unwrap();
+        assert!(
+            rewritten
+                .tensors
+                .iter()
+                .any(|tensor| tensor.name.starts_with("__pie.row_shard_bank.")),
+            "the fixture must actually trigger the coalesce"
+        );
+        for original in &contract.tensors {
+            let member = rewritten
+                .tensors
+                .iter()
+                .find(|tensor| tensor.name == original.name)
+                .expect("every member is still declared");
+            assert_eq!(member.scales, original.scales, "{}", original.name);
+            assert_eq!(member.visibility, original.visibility, "{}", original.name);
+        }
+    }
 }

--- a/model/qwen_3_5/src/contract.rs
+++ b/model/qwen_3_5/src/contract.rs
@@ -8,9 +8,9 @@
 //! stacks.
 
 use pie_loader::checkpoint::RawTensor;
-use pie_loader::contract::{Expr, TensorType};
+use pie_loader::contract::{Expr, Scales};
 use pie_loader::error::Error;
-use pie_loader::types::{Axis, DType, Encoding, QuantScheme, QuantSpec};
+use pie_loader::types::{DType, Encoding, QuantGranularity, QuantScheme, ScaleForm};
 
 use pie_model_common::builder::{Builder, is_raw};
 use pie_model_common::mlx;
@@ -23,7 +23,7 @@ pub fn author_qwen3_5(b: &mut Builder<'_>) -> Result<(), Error> {
     // do not. Both are this row, so the prefix is asked for rather than
     // declared.
     b.decoder_layer_prefix_any_of(&["model.language_model.layers.", "model.layers."]);
-    gdn_fp8_dequant(b)?;
+    gdn_fp8_native_scales(b)?;
     gdn_kkv_blocked_shards(b)?;
     gdn_fp32_parameters(b)?;
     // The speculative-decoding head is a full-attention layer with the same
@@ -47,7 +47,7 @@ pub fn author_qwen3_5(b: &mut Builder<'_>) -> Result<(), Error> {
 pub fn author_qwen3_5_moe(b: &mut Builder<'_>) -> Result<(), Error> {
     b.allow_bf16_runtime_quant();
     b.decoder_layer_prefix_any_of(&["model.language_model.layers.", "model.layers."]);
-    gdn_fp8_dequant(b)?;
+    refuse_gdn_fp8_moe(b)?;
     gdn_kkv_blocked_shards(b)?;
     gdn_fp32_parameters(b)?;
     // The MoE decode runs through flashinfer's CUTLASS grouped GEMM, which
@@ -62,28 +62,55 @@ pub fn author_qwen3_5_moe(b: &mut Builder<'_>) -> Result<(), Error> {
     b.publish_remaining()
 }
 
-/// Dequantize the FP8 Gated DeltaNet projections to bf16 at load time.
+/// Refuse an FP8 Gated DeltaNet checkpoint on the MoE bind path.
 ///
-/// The CUDA forward feeds every `linear_attn` projection to `gemm_act_x_w`
-/// as a bare bf16 tensor — the layer struct has `QuantMeta` ports for the
-/// attention and MLP projections only — so a shipped F8E4M3 GDN weight
-/// cannot serve quantized. It can serve *dequantized*: the checkpoint pairs
-/// each projection with a 2-D `weight_scale_inv` block-scale tensor, and
-/// `Expr::Scale`/`ScaleFactor::PerBlock` is exactly `weight = fp8 * scale`
-/// executed by the load-time dequant kernel both executors implement. The
-/// factors are declared as an `Internal` tensor at their checkpoint dtype
-/// (BF16 or F32; the CUDA engine widens BF16 factors itself), so the
-/// driver's bind table sees only the bf16 weight under its usual name.
+/// The dense forward serves these natively (`gdn_fp8_native_scales`), but
+/// the MoE forward still hands `la_in_proj_qkv->data()` and friends to the
+/// bf16 GEMMs with no `QuantMeta` port — an F8E4M3 weight bound there is
+/// read as bf16 and serves noise. Refuse at authoring time until the MoE
+/// forward grows the same ports the dense one has.
+fn refuse_gdn_fp8_moe(b: &Builder<'_>) -> Result<(), Error> {
+    for raw in b.tensors() {
+        if raw.name.contains(".linear_attn.") && is_raw(&raw.encoding, DType::F8E4M3) {
+            return Err(Error::Contract(format!(
+                "model_type='{}' tp_size={}: '{}' ships F8E4M3, but the MoE \
+                 forward has no quant-scale port for the Gated DeltaNet \
+                 projections; FP8 GDN weights are unsupported on this bind \
+                 path — use a BF16 checkpoint",
+                b.facts().model_type,
+                b.target().tp_size,
+                raw.name,
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Serve the FP8 Gated DeltaNet projections natively, paired with their
+/// block scales.
 ///
-/// Sharding folds in *before* the multiply, on scale-block boundaries only.
-/// `in_proj_qkv` stacks `[K | K | V]` on axis 0 and each band splits per
-/// rank, so its rows keep their scale rows only when `K` and `V` are whole
-/// multiples of `row_block * tp`; the other projections split on their usual
-/// axis, which keeps its blocks only when tp divides the scale extent. A
-/// split that lands inside a 128-row block has no representable scale slice,
-/// so it is refused rather than approximated — as is a projection whose
-/// scale companion is missing altogether.
-fn gdn_fp8_dequant(b: &mut Builder<'_>) -> Result<(), Error> {
+/// The forward feeds `in_proj_qkv`/`in_proj_z`/`out_proj` to `gemm_act_x_w`
+/// through `QuantMeta` ports, the same way the attention and MLP projections
+/// go, so an F8E4M3 GDN weight is published *raw* beside its 2-D
+/// `weight_scale_inv` factors — vLLM parity, not a load-time dequant. For
+/// most of the module the generic tail already does this: `publish_remaining`
+/// shards weight and scales on the same axis and
+/// `state_shipped_block_scales` states the pairing. What this pass adds is
+/// the one case the tail cannot know and the refusals that keep the pairing
+/// honest:
+///
+/// * At tp > 1, `in_proj_qkv` stacks `[K | K | V]` on axis 0 and must be
+///   banded per rank (`gdn_kkv_blocked_shards`' whole reason to exist). Its
+///   scale rows are banded by the same offsets divided by the row block, and
+///   the pairing is stated on the republished pair — the drop that
+///   originally forced the FP8 refusal.
+/// * Bands and shards are representable only on scale-block boundaries: `K`
+///   and `V` must be whole multiples of `row_block * tp`, and a sharded
+///   projection's scale extent must divide by tp. A split inside a 128-wide
+///   block has no scale slice, so it is refused rather than approximated —
+///   as is a projection whose scale companion is missing, mis-shaped, or a
+///   dtype (anything but BF16/F32) the CUDA scale conversion does not read.
+fn gdn_fp8_native_scales(b: &mut Builder<'_>) -> Result<(), Error> {
     let tp = i64::from(b.target().tp_size.max(1));
     for raw in b.tensors().to_vec() {
         if !raw.name.contains(".linear_attn.") || !is_raw(&raw.encoding, DType::F8E4M3) {
@@ -92,8 +119,8 @@ fn gdn_fp8_dequant(b: &mut Builder<'_>) -> Result<(), Error> {
         let refuse = |b: &Builder<'_>, why: String| -> Result<(), Error> {
             Err(Error::Contract(format!(
                 "model_type='{}' tp_size={}: '{}' ships F8E4M3, and the Gated \
-                 DeltaNet path runs bf16 (no quant-scale port), but the weight \
-                 cannot be dequantized at load: {why}",
+                 DeltaNet path serves it through a quant port, but the weight \
+                 cannot be paired with its block scales: {why}",
                 b.facts().model_type,
                 b.target().tp_size,
                 raw.name,
@@ -109,9 +136,7 @@ fn gdn_fp8_dequant(b: &mut Builder<'_>) -> Result<(), Error> {
         let Some(scale) = b.find(&scale_name) else {
             return refuse(b, "its `weight_scale_inv` companion is missing".to_string());
         };
-        // BF16 or F32 only: the factors ship at their checkpoint dtype (a
-        // cast in the plan would hand the CUDA engine an operand it cannot
-        // type — a staged buffer is untyped bytes to it), and its dequant
+        // BF16 or F32 only: `convert_block_scale_to_f32` on the bind side
         // reads exactly these two.
         if scale.shape.len() != 2
             || !(is_raw(&scale.encoding, DType::BF16) || is_raw(&scale.encoding, DType::F32))
@@ -140,65 +165,13 @@ fn gdn_fp8_dequant(b: &mut Builder<'_>) -> Result<(), Error> {
             }
             block[axis] = w / s;
         }
-        // The payload's bytes reread as a block-scaled scheme: what tells the
-        // planner this `Scale` also *decodes* (`TransformSpec::from`), and the
-        // executors to unpack E4M3 before the multiply.
-        let fp8 = Encoding::Quant(QuantSpec {
-            scheme: QuantScheme::Fp8E4M3,
-            logical_dtype: DType::BF16,
-            bits_per_element: 8,
-            group_size: u32::try_from(block[1]).unwrap_or(0),
-            channel_axis: Some(Axis(1)),
-        });
         let is_qkv = raw.name.ends_with(".in_proj_qkv.weight");
-        let (wexpr, wshape, sexpr, sshape) = if is_qkv && tp > 1 {
-            // The [K|K|V] bands, from the same sibling `gdn_kkv_blocked_shards`
-            // reads them off.
-            let base = &raw.name[..raw.name.len() - "in_proj_qkv.weight".len()];
-            let z_dim = b
-                .find(&format!("{base}in_proj_z.weight"))
-                .and_then(|z| z.shape.first().copied());
-            let conv_dim = raw.shape[0];
-            let Some(v_dim) =
-                z_dim.filter(|&v| v > 0 && conv_dim > v && (conv_dim - v) % 2 == 0)
-            else {
-                return refuse(
-                    b,
-                    "the [K|K|V] split needs `in_proj_z.weight` to state V, \
-                     and it does not"
-                        .to_string(),
-                );
-            };
-            let k_dim = (conv_dim - v_dim) / 2;
-            let rb = block[0];
-            if k_dim % (rb * tp) != 0 || v_dim % (rb * tp) != 0 {
-                return refuse(
-                    b,
-                    format!(
-                        "the [K|K|V] bands (K={k_dim}, V={v_dim}) split {tp} \
-                         ways do not fall on {rb}-row scale-block boundaries; \
-                         use a tp_size where {rb}*tp divides both, or a BF16 \
-                         checkpoint"
-                    ),
-                );
-            }
-            let w = || Expr::src(&raw.name).transmute(TensorType::new(raw.shape.clone(), fp8.clone()));
-            let (key_lo, key_rows) = b.band(w(), 0, 0, k_dim);
-            let (key_hi, _) = b.band(w(), 0, k_dim, k_dim);
-            let (value, value_rows) = b.band(w(), 0, 2 * k_dim, v_dim);
-            let s = || Expr::src(&scale.name);
-            let (skey_lo, skey_rows) = b.band(s(), 0, 0, k_dim / rb);
-            let (skey_hi, _) = b.band(s(), 0, k_dim / rb, k_dim / rb);
-            let (svalue, svalue_rows) = b.band(s(), 0, 2 * (k_dim / rb), v_dim / rb);
-            (
-                Expr::concat(0, vec![key_lo, key_hi, value]),
-                vec![2 * key_rows + value_rows, raw.shape[1]],
-                Expr::concat(0, vec![skey_lo, skey_hi, svalue]),
-                vec![2 * skey_rows + svalue_rows, scale.shape[1]],
-            )
-        } else {
-            let axis = b.shard_axis(&raw.name)?;
-            if let Some(axis) = axis {
+        if !is_qkv || tp <= 1 {
+            // The generic tail publishes weight and scales on the same shard
+            // axis and states the pairing; only the boundary check is ours.
+            if tp > 1
+                && let Some(axis) = b.shard_axis(&raw.name)?
+            {
                 let index = usize::from(axis);
                 if scale.shape[index] % tp != 0 {
                     return refuse(
@@ -212,31 +185,69 @@ fn gdn_fp8_dequant(b: &mut Builder<'_>) -> Result<(), Error> {
                     );
                 }
             }
-            let wexpr = Expr::src(&raw.name)
-                .transmute(TensorType::new(raw.shape.clone(), fp8.clone()));
-            let (wexpr, wshape) = b.shard(wexpr, raw.shape.clone(), axis);
-            let (sexpr, sshape) = b.shard(Expr::src(&scale.name), scale.shape.clone(), axis);
-            (wexpr, wshape, sexpr, sshape)
-        };
-        // The factors keep their checkpoint dtype, deliberately. A `.cast`
-        // here compiled to a TileMap whose operand — the gathered bands — is
-        // an anonymous staging buffer, which the CUDA executor types as u8
-        // ("unsupported TileMap Cast u8 -> fp32" on the real checkpoint at
-        // tp 2), and whose strided single-source form its cast path refuses
-        // as non-compact. An `Internal` declaration is always a *typed*
-        // buffer on both executors, so the Scale kernel is handed BF16
-        // factors and widens them itself.
-        let scale_out = b.output_name(&scale.name);
-        if let Some(index) = b.define(scale_out.clone(), sexpr, scale.encoding.clone(), Some(sshape))
-        {
-            b.mark_internal(index);
+            continue;
         }
+
+        // The [K|K|V] bands, from the same sibling `gdn_kkv_blocked_shards`
+        // reads them off.
+        let base = &raw.name[..raw.name.len() - "in_proj_qkv.weight".len()];
+        let z_dim = b
+            .find(&format!("{base}in_proj_z.weight"))
+            .and_then(|z| z.shape.first().copied());
+        let conv_dim = raw.shape[0];
+        let Some(v_dim) = z_dim.filter(|&v| v > 0 && conv_dim > v && (conv_dim - v) % 2 == 0)
+        else {
+            return refuse(
+                b,
+                "the [K|K|V] split needs `in_proj_z.weight` to state V, \
+                 and it does not"
+                    .to_string(),
+            );
+        };
+        let k_dim = (conv_dim - v_dim) / 2;
+        let rb = block[0];
+        if k_dim % (rb * tp) != 0 || v_dim % (rb * tp) != 0 {
+            return refuse(
+                b,
+                format!(
+                    "the [K|K|V] bands (K={k_dim}, V={v_dim}) split {tp} \
+                     ways do not fall on {rb}-row scale-block boundaries; \
+                     use a tp_size where {rb}*tp divides both, or a BF16 \
+                     checkpoint"
+                ),
+            );
+        }
+        let (wexpr, wshape) = gdn_kkv_blocked(b, raw, k_dim, v_dim);
+        let s = || Expr::src(&scale.name);
+        let (skey_lo, skey_rows) = b.band(s(), 0, 0, k_dim / rb);
+        let (skey_hi, _) = b.band(s(), 0, k_dim / rb, k_dim / rb);
+        let (svalue, svalue_rows) = b.band(s(), 0, 2 * (k_dim / rb), v_dim / rb);
+        let weight_out = b.output_name(&raw.name);
         b.define(
-            b.output_name(&raw.name),
-            wexpr.scale_per_block(Expr::out(&scale_out)),
-            Encoding::Raw(DType::BF16),
+            weight_out.clone(),
+            wexpr,
+            raw.encoding.clone(),
             Some(wshape),
         );
+        // Public, not internal: the driver reads the factors through the
+        // attachment, and only a finalized tensor has bytes to read.
+        if let Some(index) = b.define(
+            b.output_name(&scale.name),
+            Expr::concat(0, vec![skey_lo, skey_hi, svalue]),
+            scale.encoding.clone(),
+            Some(vec![2 * skey_rows + svalue_rows, scale.shape[1]]),
+        ) {
+            b.set_scales(
+                index,
+                Scales {
+                    of: weight_out,
+                    granularity: QuantGranularity::PerGroup,
+                    group_size: u32::try_from(block[1]).unwrap_or(0),
+                    channel_axis: 0,
+                    form: ScaleForm::F32Factors,
+                },
+            );
+        }
         b.consume(raw.id);
         b.consume(scale.id);
     }
@@ -298,7 +309,7 @@ fn gdn_kkv_blocked_shards(b: &mut Builder<'_>) -> Result<(), Error> {
                 continue;
             }
             // An FP8 `in_proj_qkv` was already banded — with its scales —
-            // by `gdn_fp8_dequant`, and its raw tensor is consumed.
+            // by `gdn_fp8_native_scales`, and its raw tensor is consumed.
             if is_raw(&raw.encoding, DType::F8E4M3) {
                 continue;
             }

--- a/model/tests/family_contracts.rs
+++ b/model/tests/family_contracts.rs
@@ -812,6 +812,148 @@ fn qwen3_5_fp8_gdn_dequantizes_to_expected_bf16() {
     }
 }
 
+/// The GDN fixture with the full-attention layer *also* FP8: every dense
+/// projection ships E4M3 beside a BF16 `weight_scale_inv` in 4x4 blocks,
+/// which is what Qwen3.6-27B-FP8 actually looks like layer for layer.
+fn qwen3_5_fp8_full_checkpoint() -> CheckpointMetadata {
+    let hidden = 8i64;
+    let (k_dim, v_dim) = (8i64, 16i64);
+    let conv_dim = 2 * k_dim + v_dim;
+    let block = 4i64;
+    let fp8 = Encoding::Raw(DType::F8E4M3);
+    let mut ck = Checkpoint::new();
+    ck.push("model.embed_tokens.weight", &[16, hidden], bf16());
+    let la = "model.layers.0.linear_attn.";
+    ck.push(
+        &format!("{la}in_proj_qkv.weight"),
+        &[conv_dim, hidden],
+        fp8.clone(),
+    );
+    ck.push(
+        &format!("{la}in_proj_qkv.weight_scale_inv"),
+        &[conv_dim / block, hidden / block],
+        bf16(),
+    );
+    ck.push(&format!("{la}in_proj_z.weight"), &[v_dim, hidden], fp8.clone());
+    ck.push(
+        &format!("{la}in_proj_z.weight_scale_inv"),
+        &[v_dim / block, hidden / block],
+        bf16(),
+    );
+    ck.push(&format!("{la}in_proj_b.weight"), &[2, hidden], bf16());
+    ck.push(&format!("{la}in_proj_a.weight"), &[2, hidden], bf16());
+    ck.push(&format!("{la}conv1d.weight"), &[conv_dim, 1, 4], bf16());
+    ck.push(&format!("{la}conv1d.bias"), &[conv_dim], bf16());
+    ck.push(&format!("{la}out_proj.weight"), &[hidden, v_dim], fp8.clone());
+    ck.push(
+        &format!("{la}out_proj.weight_scale_inv"),
+        &[hidden / block, v_dim / block],
+        bf16(),
+    );
+    ck.push(&format!("{la}A_log"), &[2], bf16());
+    ck.push(&format!("{la}dt_bias"), &[2], bf16());
+    ck.push(&format!("{la}norm.weight"), &[v_dim], f32enc());
+    // Eight full-attention layers, FP8 with block scales throughout. Eight,
+    // because tp >= 2 runs `coalesce_direct_row_shards`, which rewrites any
+    // 16-or-more equally-shaped row shards into a bank plus views — 8 layers
+    // of q/k/v/o make a 32-member `[8, 8]` bucket, gate/up a 16-member
+    // `[16, 8]` one, and their scale tensors two more — and that rewrite is
+    // where Qwen3.6-27B-FP8 lost 230 of its 263 pairings on the pod.
+    // `down_proj` shards on axis 1, so it stays out of every bucket: both
+    // the rewritten and the untouched paths are asserted below.
+    let (heads, head_dim, inter) = (2i64, 4i64, 16i64);
+    for layer in 1..9 {
+        let p = format!("model.layers.{layer}.");
+        ck.push(&format!("{p}input_layernorm.weight"), &[hidden], bf16());
+        for (leaf, rows, cols) in [
+            ("self_attn.q_proj", heads * head_dim, hidden),
+            ("self_attn.k_proj", heads * head_dim, hidden),
+            ("self_attn.v_proj", heads * head_dim, hidden),
+            ("self_attn.o_proj", hidden, heads * head_dim),
+            ("mlp.gate_proj", inter, hidden),
+            ("mlp.up_proj", inter, hidden),
+            ("mlp.down_proj", hidden, inter),
+        ] {
+            ck.push(&format!("{p}{leaf}.weight"), &[rows, cols], fp8.clone());
+            ck.push(
+                &format!("{p}{leaf}.weight_scale_inv"),
+                &[rows / block, cols / block],
+                bf16(),
+            );
+        }
+        ck.push(&format!("{p}self_attn.q_norm.weight"), &[head_dim], bf16());
+        ck.push(&format!("{p}self_attn.k_norm.weight"), &[head_dim], bf16());
+        ck.push(
+            &format!("{p}post_attention_layernorm.weight"),
+            &[hidden],
+            bf16(),
+        );
+    }
+    ck.push("model.norm.weight", &[hidden], bf16());
+    ck.finish("qwen3_5_fp8_full")
+}
+
+/// Every F8E4M3 tensor the contract publishes reaches `gemm_act_x_w` through
+/// a QuantMeta port, and that port is null unless the plan carries a scale
+/// attachment for it — so each one must be paired, at tp=1 and on both ranks
+/// of tp=2. This is the structural half of the pod failure
+/// `gemm_act_x_w[FP8_E4M3]: quant scale data is null`.
+#[test]
+fn qwen3_5_fp8_quant_weights_carry_scale_attachments() {
+    let mut facts = facts("qwen3_5", 9);
+    facts.head_dim = 4;
+    let checkpoint = qwen3_5_fp8_full_checkpoint();
+    for (tp_rank, tp_size) in [(0, 1), (0, 2), (1, 2)] {
+        let target = target(tp_rank, tp_size);
+        let contract = author(&facts, &checkpoint, &target, &Policy::default())
+            .expect("authoring failed")
+            .expect("no author for qwen3_5");
+        let plan = compile_load_plan(&checkpoint, &contract, target)
+            .expect("compiling failed");
+        // Resolved by name through the plan's own tensor table — the same
+        // arithmetic the driver's `resolve_quant_attachments` runs — because
+        // the row-shard coalesce may rewrite the contract before the plan is
+        // built, and contract indices do not survive that.
+        let name_of: std::collections::HashMap<_, _> = plan
+            .tensors
+            .iter()
+            .map(|decl| (decl.id, decl.name.as_str()))
+            .collect();
+        let mut fp8_weights = 0;
+        for tensor in &contract.tensors {
+            if tensor.encoding != Encoding::Raw(DType::F8E4M3) {
+                continue;
+            }
+            fp8_weights += 1;
+            let attachment = plan
+                .attachments
+                .iter()
+                .find(|attachment| {
+                    name_of.get(&attachment.tensor).copied() == Some(tensor.name.as_str())
+                })
+                .unwrap_or_else(|| {
+                    panic!(
+                        "tp{tp_size} rank {tp_rank}: '{}' is published F8E4M3 \
+                         with no scale attachment — its QuantMeta port binds \
+                         null and the GEMM throws",
+                        tensor.name
+                    )
+                });
+            assert_eq!(
+                name_of.get(&attachment.scale_tensor).copied(),
+                Some(format!("{}_scale_inv", tensor.name).as_str()),
+                "tp{tp_size} rank {tp_rank}: '{}' is paired with the wrong scales",
+                tensor.name
+            );
+        }
+        assert_eq!(
+            fp8_weights, 56,
+            "tp{tp_size} rank {tp_rank}: eight full-attention layers of seven \
+             projections stay FP8 (the GDN ones dequantize to bf16)"
+        );
+    }
+}
+
 /// A tp that splits inside a scale block has no representable scale slice —
 /// K = 8 in 4-row blocks cannot split 4 ways — and must be refused rather
 /// than approximated.

--- a/model/tests/family_contracts.rs
+++ b/model/tests/family_contracts.rs
@@ -26,8 +26,8 @@ use pie_loader::plan::{
     compile as compile_load_plan,
 };
 use pie_loader::types::{
-    BackendKind, CheckpointFormat, DType, Encoding, FileId, QuantGranularity, QuantScheme,
-    RepackLayout, ScaleForm, TensorId, Visibility,
+    BackendKind, CheckpointFormat, DType, Encoding, FileId, QuantGranularity, RepackLayout,
+    ScaleForm, TensorId, Visibility,
 };
 use pie_loader::verify::ContractView;
 
@@ -514,13 +514,13 @@ fn qwen3_5_refuses_fp8_gdn_without_scales() {
             .expect_err(&format!("tp={tp_size}: an unpaired FP8 GDN weight must be refused"));
         let msg = err.to_string();
         assert!(
-            msg.contains("weight_scale_inv") && msg.contains("cannot be dequantized"),
+            msg.contains("weight_scale_inv") && msg.contains("cannot be paired"),
             "tp={tp_size}: unexpected error: {msg}"
         );
     }
 }
 
-// ── qwen3_5: FP8 GDN load-time dequantization ───────────────────────
+// ── qwen3_5: native FP8 GDN — raw weights beside banded block scales ─
 
 /// The E4M3 byte for a small positive value that E4M3 represents exactly.
 fn fp8_e4m3(value: f64) -> u8 {
@@ -626,36 +626,48 @@ fn qwen3_5_fp8_gdn_checkpoint() -> CheckpointMetadata {
     metadata
 }
 
-/// The bf16 bytes the dequant must produce for the local tensor whose
-/// element (r, c) reads global element (rows[r], cols[c]) of a full
-/// `[_, full_cols]` FP8 weight with `[_, full_cols / 4]`-shaped scales.
-fn gdn_expected(rows: &[i64], cols: &[i64], full_cols: i64) -> Vec<u8> {
-    let block = 4i64;
-    let scale_cols = full_cols / block;
-    let mut out = Vec::with_capacity(rows.len() * cols.len() * 2);
+/// The FP8 payload bytes the load must lay down for the local tensor whose
+/// element (r, c) reads global element (rows[r], cols[c]) of the full
+/// `[_, full_cols]` weight — native FP8: the bytes move, nothing decodes.
+fn gdn_fp8_expected(rows: &[i64], cols: &[i64], full_cols: i64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(rows.len() * cols.len());
     for &gr in rows {
         for &gc in cols {
-            let value = gdn_value(usize::try_from(gr * full_cols + gc).unwrap());
-            let scale =
-                gdn_scale(usize::try_from((gr / block) * scale_cols + gc / block).unwrap());
-            out.extend_from_slice(&bf16_bits(value * scale).to_le_bytes());
+            out.push(fp8_e4m3(f64::from(gdn_value(
+                usize::try_from(gr * full_cols + gc).unwrap(),
+            ))));
         }
     }
     out
 }
 
-/// The load plan dequantizes FP8 GDN weights to the mathematically expected
-/// bf16 values — `weight = fp8 * block_scale` — at tp=1 and on both ranks of
-/// tp=2, executed end to end by the host executor over real checkpoint
-/// bytes. The tp=2 ranks also prove the `[K|K|V]` bands and the row/column
-/// shards slice the *scales* consistently with the weights.
+/// The BF16 factor bytes for the local scale tensor, by the same mapping.
+fn gdn_scale_expected(rows: &[i64], cols: &[i64], full_cols: i64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(rows.len() * cols.len() * 2);
+    for &gr in rows {
+        for &gc in cols {
+            let bits = bf16_bits(gdn_scale(usize::try_from(gr * full_cols + gc).unwrap()));
+            out.extend_from_slice(&bits.to_le_bytes());
+        }
+    }
+    out
+}
+
+/// The GDN projections serve natively: the load publishes the E4M3 payload
+/// raw and its `weight_scale_inv` factors beside it, paired through a plan
+/// attachment, at tp=1 and on both ranks of tp=2 — and the host executor
+/// materializes byte-exact `[K|K|V]` bands of the *weight* and of the
+/// *scales*, sliced by the same offsets divided by the row block. That byte
+/// equality is the mathematical content of the tp split: each rank's scale
+/// rows are exactly the blocks its weight rows fall in.
 #[test]
-fn qwen3_5_fp8_gdn_dequantizes_to_expected_bf16() {
+fn qwen3_5_fp8_gdn_ships_raw_with_banded_scales() {
     let mut facts = facts("qwen3_5", 2);
     facts.head_dim = 4;
     let checkpoint = qwen3_5_fp8_gdn_checkpoint();
     let la = "model.layers.0.linear_attn.";
     let all8: Vec<i64> = (0..8).collect();
+    let all2: Vec<i64> = (0..2).collect();
 
     for (tp_rank, tp_size) in [(0, 1), (0, 2), (1, 2)] {
         let target = target(tp_rank, tp_size);
@@ -670,8 +682,8 @@ fn qwen3_5_fp8_gdn_dequantizes_to_expected_bf16() {
                 .unwrap_or_else(|| panic!("{leaf}: no published weight"));
             assert_eq!(
                 entry.encoding,
-                Encoding::Raw(DType::BF16),
-                "{leaf}: the GDN path binds bf16"
+                Encoding::Raw(DType::F8E4M3),
+                "{leaf}: the GDN path serves the shipped FP8, not a dequant"
             );
             let scales = contract
                 .tensors
@@ -680,13 +692,10 @@ fn qwen3_5_fp8_gdn_dequantizes_to_expected_bf16() {
                 .unwrap_or_else(|| panic!("{leaf}: no declared scale factors"));
             assert_eq!(
                 scales.visibility,
-                Visibility::Internal,
-                "{leaf}: factors are load-time only, not a bind name"
+                Visibility::Public,
+                "{leaf}: the driver reads the factors through the attachment, \
+                 so they must be finalized"
             );
-            // At the checkpoint's own dtype: a cast to F32 in the plan hands
-            // the CUDA executor an operand it cannot type — a staged gather
-            // is untyped bytes to it — so the widening belongs to the Scale
-            // kernel, not the contract.
             assert_eq!(
                 scales.encoding,
                 Encoding::Raw(DType::BF16),
@@ -702,26 +711,35 @@ fn qwen3_5_fp8_gdn_dequantizes_to_expected_bf16() {
             let listed: Vec<String> = violations.iter().map(ToString::to_string).collect();
             panic!("tp{tp_size} rank {tp_rank}: {}", listed.join("\n  "));
         }
-        let scaled: Vec<_> = plan
-            .instrs
-            .iter()
-            .filter_map(|instr| match instr {
-                StorageInstr::TileMap {
-                    kind: TileMapKind::Scale,
-                    transform,
-                    ..
-                } => Some(transform),
-                _ => None,
-            })
-            .collect();
-        assert_eq!(
-            scaled.len(),
-            3,
-            "tp{tp_size} rank {tp_rank}: one per-block Scale per FP8 projection"
+        // Native FP8 means nothing dequantizes at load: no Scale tile maps.
+        assert!(
+            !plan.instrs.iter().any(|instr| matches!(
+                instr,
+                StorageInstr::TileMap { kind: TileMapKind::Scale, .. }
+            )),
+            "tp{tp_size} rank {tp_rank}: the load plan should move bytes, not decode them"
         );
-        for transform in scaled {
-            assert_eq!(transform.scale_blocks, vec![4, 4]);
-            assert_eq!(transform.from, Some(QuantScheme::Fp8E4M3));
+        // Each GDN projection is paired, resolved by name through the plan's
+        // tensor table the way the driver's resolve_quant_attachments does.
+        let name_of: std::collections::HashMap<_, _> = plan
+            .tensors
+            .iter()
+            .map(|decl| (decl.id, decl.name.as_str()))
+            .collect();
+        for leaf in ["in_proj_qkv", "in_proj_z", "out_proj"] {
+            let weight = format!("{la}{leaf}.weight");
+            let attachment = plan
+                .attachments
+                .iter()
+                .find(|a| name_of.get(&a.tensor).copied() == Some(weight.as_str()))
+                .unwrap_or_else(|| {
+                    panic!("tp{tp_size} rank {tp_rank}: '{weight}' has no scale attachment")
+                });
+            assert_eq!(
+                name_of.get(&attachment.scale_tensor).copied(),
+                Some(format!("{weight}_scale_inv").as_str()),
+                "tp{tp_size} rank {tp_rank}: '{weight}' paired with the wrong scales"
+            );
         }
         // Every Cast must be one the CUDA engine can actually run: a *dense*
         // file source (its cast path refuses non-compact sources), or an
@@ -775,17 +793,15 @@ fn qwen3_5_fp8_gdn_dequantizes_to_expected_bf16() {
         .expect("host execution failed");
         // This rank's global rows/cols per projection: at tp=2 the qkv rows
         // are the rank's half of each of the [K=8 | K=8 | V=16] bands, z
-        // splits rows, out_proj splits columns.
+        // splits rows, out_proj splits columns — and the scale tensors band
+        // by the same arithmetic divided by the 4-wide block.
         let half = |base: i64, len: i64| -> Vec<i64> {
             let start = base + i64::from(tp_rank) * len / 2;
             (start..start + len / 2).collect()
         };
+        let full = |len: i64| -> Vec<i64> { (0..len).collect() };
         let (qkv_rows, z_rows, out_cols) = if tp_size == 1 {
-            (
-                (0..32).collect::<Vec<i64>>(),
-                (0..16).collect::<Vec<i64>>(),
-                (0..16).collect::<Vec<i64>>(),
-            )
+            (full(32), full(16), full(16))
         } else {
             (
                 [half(0, 8), half(8, 8), half(16, 16)].concat(),
@@ -793,6 +809,31 @@ fn qwen3_5_fp8_gdn_dequantizes_to_expected_bf16() {
                 half(0, 16),
             )
         };
+        let (qkv_srows, z_srows, out_scols) = if tp_size == 1 {
+            (full(8), full(4), full(4))
+        } else {
+            (
+                [half(0, 2), half(2, 2), half(4, 4)].concat(),
+                half(0, 4),
+                half(0, 4),
+            )
+        };
+        for (leaf, srows, scols, scale_cols) in [
+            ("in_proj_qkv", &qkv_srows, &all2, 2),
+            ("in_proj_z", &z_srows, &all2, 2),
+            ("out_proj", &all2, &out_scols, 4),
+        ] {
+            let name = format!("{la}{leaf}.weight_scale_inv");
+            let bytes = storage
+                .tensors
+                .get(&name)
+                .unwrap_or_else(|| panic!("{name}: not materialized"));
+            assert_eq!(
+                bytes,
+                &gdn_scale_expected(srows, scols, scale_cols),
+                "tp{tp_size} rank {tp_rank}: {name} banded wrong"
+            );
+        }
         for (leaf, rows, cols, full_cols) in [
             ("in_proj_qkv", &qkv_rows, &all8, 8),
             ("in_proj_z", &z_rows, &all8, 8),
@@ -805,8 +846,8 @@ fn qwen3_5_fp8_gdn_dequantizes_to_expected_bf16() {
                 .unwrap_or_else(|| panic!("{name}: not materialized"));
             assert_eq!(
                 bytes,
-                &gdn_expected(rows, cols, full_cols),
-                "tp{tp_size} rank {tp_rank}: {name} dequantized wrong"
+                &gdn_fp8_expected(rows, cols, full_cols),
+                "tp{tp_size} rank {tp_rank}: {name} banded wrong"
             );
         }
     }
@@ -947,9 +988,9 @@ fn qwen3_5_fp8_quant_weights_carry_scale_attachments() {
             );
         }
         assert_eq!(
-            fp8_weights, 56,
+            fp8_weights, 59,
             "tp{tp_size} rank {tp_rank}: eight full-attention layers of seven \
-             projections stay FP8 (the GDN ones dequantize to bf16)"
+             projections plus the three GDN projections all serve FP8"
         );
     }
 }

--- a/runtime/engine/src/inferlet/host/forward.rs
+++ b/runtime/engine/src/inferlet/host/forward.rs
@@ -185,6 +185,10 @@ fn poll_channel(
                 return Ok(ChannelPoll::Pending { cell, fires });
             }
             Err(ChannelError::Empty) => {}
+            // A peek surfaces poison without consuming it; fall through to
+            // the real `take` below so the error is delivered exactly once
+            // and the session channel recovers.
+            Err(ChannelError::Poisoned(_)) => {}
             Err(error) => return Ok(ChannelPoll::Ready(Err(error.to_string()))),
         }
     }


### PR DESCRIPTION
Four commits completing the lane fixes started in #531, all GPU-verified on the 2xH100 pod with a content-verified binary (sha 59734974, staticlib rebuilt fresh — see below).

1. Carry scales and visibility through the row-shard coalesce (cherry-pick d5a8cce3): loader-plan-level prerequisite for tp>1 FP8 scale sharding.
2. Serve FP8 Gated DeltaNet natively through quant ports (cherry-pick ed8c637a): the vLLM-parity path; with these two plus #531's factor widening, Qwen3.6-27B-FP8 loads at tp2 and reaches serving with FRESH plan authoring (artifact cache evicted for the test).
3. Poisoned take falls through the settle peek to deliver-and-clear (7930d299): the one-shot poison delivery in #531 was unreachable when fires were pending, because the Take path peeks with read() first.
4. cuda: refresh the elastic budget before rejecting a frame commit (33ef64f9): the real root cause of the 'wedged until restage' failure — the budget is a cached view of free device memory that non-growing frames never refresh, so a transient workspace peak permanently rejected every pad-page-pinned frame while 11+ GB sat free. On a non-Committed commit, recalibrate from cudaMemGetInfo and retry once.

GPU verification: 3 concurrent ~120k-token frames — the over-budget frames fail cleanly with their own error, a concurrent request that previously died of cross-poisoning now completes 200, and all follow-up probes serve 200 with no restage. Build note for reviewers: cargo build does NOT rebuild target/release/libpie_loader_capi.a, which the CUDA driver links for plan authoring — builds from the warm builder image silently shipped a 447135f6-era contract until the build script rebuilt the staticlib explicitly and gated the binary on content markers.