### PR TITLE
Name the vLLM RoPE-table knobs as the debug toggles they are

### DIFF
--- a/driver/cuda/src/kernels/rope.cu
+++ b/driver/cuda/src/kernels/rope.cu
@@ -841,7 +841,7 @@ __global__ void rope_partial_vllm_table_bf16_kernel(
 //
 // CAPACITY. Indexed by absolute position, so the table must span the context.
 // Default 262144 positions (33.5 MB at rotary_dim=64), overridable with
-// PIE_ROPE_VLLM_TABLE_MAX_POS. Beyond it the kernel degrades to device trig --
+// PIE_DEBUG_ROPE_VLLM_TABLE_MAX_POS. Beyond it the kernel degrades to device trig --
 // i.e. to the 4-in-1.9M behaviour above -- and bumps `oob` so that degradation
 // cannot be silent. The right fix is to size this from
 // `cfg.max_position_embeddings`, which is in scope at all eight call sites;
@@ -925,7 +925,7 @@ std::uint16_t bf16_rne_bits(float f) {
 // PIE_CUDA_RUNTIME_IMAGE=nvidia/cuda:12.9.1-cudnn-runtime-ubuntu22.04, so the
 // decoder runs on Ubuntu 22.04.
 //
-// `PIE_ROPE_VLLM_TABLE_TRIG=libm` selects the `cosf`/`sinf` build, so the
+// `PIE_DEBUG_ROPE_VLLM_TABLE_TRIG=libm` selects the `cosf`/`sinf` build, so the
 // comparison stays reproducible and the choice revisitable rather than
 // entombed. Do not chase the remaining 19: the reference's exact bits require
 // vendoring closed-source, x86-only oneMKL into a CUDA driver's host-side table
@@ -935,7 +935,7 @@ enum class TableTrig { Libm, Exact };
 
 TableTrig vllm_table_trig() {
     static const TableTrig mode = [] {
-        const char* v = std::getenv("PIE_ROPE_VLLM_TABLE_TRIG");
+        const char* v = std::getenv("PIE_DEBUG_ROPE_VLLM_TABLE_TRIG");
         if (v != nullptr && std::strcmp(v, "libm") == 0) return TableTrig::Libm;
         return TableTrig::Exact;
     }();
@@ -944,7 +944,7 @@ TableTrig vllm_table_trig() {
 
 int vllm_table_capacity() {
     static const int cap = [] {
-        if (const char* v = std::getenv("PIE_ROPE_VLLM_TABLE_MAX_POS")) {
+        if (const char* v = std::getenv("PIE_DEBUG_ROPE_VLLM_TABLE_MAX_POS")) {
             const int n = std::atoi(v);
             if (n > 0) return n;
         }
@@ -1052,7 +1052,7 @@ const VllmCosSinTable* vllm_table_for(float theta, int rotary_dim) {
 // the default flips.
 bool rope_vllm_table_enabled() {
     static const bool enabled = [] {
-        const char* v = std::getenv("PIE_ROPE_VLLM_TABLE");
+        const char* v = std::getenv("PIE_DEBUG_ROPE_VLLM_TABLE");
         return v != nullptr && v[0] != '\0' && v[0] != '0';
     }();
     return enabled;

--- a/driver/cuda/src/kernels/rope.hpp
+++ b/driver/cuda/src/kernels/rope.hpp
@@ -198,7 +198,7 @@ void launch_rope_partial_bf16_position_delta(
 // and casts q/k down to match, so a Pie that computed accurate fp32 trig on the
 // fly would be MORE accurate than the reference and still mismatch it.
 //
-// Reached in production only via `PIE_ROPE_VLLM_TABLE=1`, which redirects both
+// Reached in production only via `PIE_DEBUG_ROPE_VLLM_TABLE=1`, which redirects both
 // `launch_rope_partial_bf16` and `..._position_delta`. Exposed directly so a
 // test can drive both pipelines in one process without touching the
 // environment. Default OFF: this moves every partial-rotary model, Gemma-4
@@ -216,7 +216,7 @@ void launch_rope_partial_vllm_table_bf16(
 
 // Blocks that ran past the end of the host-built table and fell back to device
 // trig, which is NOT bit-parity with the reference. Non-zero means the table is
-// too small for the context in use -- raise PIE_ROPE_VLLM_TABLE_MAX_POS. This
+// too small for the context in use -- raise PIE_DEBUG_ROPE_VLLM_TABLE_MAX_POS. This
 // synchronises; call it from tests and diagnostics, not from a hot path.
 unsigned int rope_vllm_table_oob_blocks(float theta, int rotary_dim);
 
@@ -225,7 +225,7 @@ int rope_vllm_table_capacity_for(float theta, int rotary_dim);
 
 // Which host trig built the table: "exact" (correctly rounded; the default,
 // and deterministic across C libraries) or "libm" (`cosf`/`sinf`, selected by
-// PIE_ROPE_VLLM_TABLE_TRIG=libm, which correlates slightly better with the
+// PIE_DEBUG_ROPE_VLLM_TABLE_TRIG=libm, which correlates slightly better with the
 // reference's MKL but is a property of the build host). This changes the
 // table's bits, so a parity result is uninterpretable without it.
 const char* rope_vllm_table_trig_name();

--- a/driver/cuda/src/kernels/rope_device.cuh
+++ b/driver/cuda/src/kernels/rope_device.cuh
@@ -63,7 +63,7 @@ __device__ __forceinline__ void rope_cos_sin(
     __sincosf(ang, &sin_v, &cos_v);
 }
 
-// ── vLLM cos/sin-table primitives (opt-in, PIE_ROPE_VLLM_TABLE=1) ──────────
+// ── vLLM cos/sin-table primitives (opt-in, PIE_DEBUG_ROPE_VLLM_TABLE=1) ──────────
 //
 // vLLM never evaluates trig on a GPU. `RotaryEmbedding.__init__` builds
 // `cos_sin_cache` once on the host in fp32 -- inv_freq from a weak-scalar

--- a/driver/cuda/tests/gen_rope_vllm_golden.py
+++ b/driver/cuda/tests/gen_rope_vllm_golden.py
@@ -55,7 +55,7 @@ one. Measured against the real MKL reference, it does not:
 
 The driver therefore DEFAULTS to the correctly rounded build, which is both the
 closer of the two and deterministic across C libraries;
-PIE_ROPE_VLLM_TABLE_TRIG=libm selects the other.
+PIE_DEBUG_ROPE_VLLM_TABLE_TRIG=libm selects the other.
 
 A claim that cosf/sinf scores 0 mismatches in the campaign window and 1 overall
 is NOT true and should not be re-derived. It came from misreading an artifact

--- a/driver/cuda/tests/rope_partial_parity.cu
+++ b/driver/cuda/tests/rope_partial_parity.cu
@@ -8,7 +8,7 @@
 //     question is "does it rotate the right dims by the right angle" and the
 //     historical bugs were whole-number-sized.
 //
-//   * `launch_rope_partial_vllm_table_bf16` (PIE_ROPE_VLLM_TABLE=1) -- BITS:
+//   * `launch_rope_partial_vllm_table_bf16` (PIE_DEBUG_ROPE_VLLM_TABLE=1) -- BITS:
 //     does it reproduce vLLM's `cos_sin_cache` exactly. Checked against that
 //     table itself, with NO tolerance and NO transcendental evaluated here.
 //


### PR DESCRIPTION
Renames PIE_ROPE_VLLM_TABLE, PIE_ROPE_VLLM_TABLE_TRIG, and PIE_ROPE_VLLM_TABLE_MAX_POS to carry a PIE_DEBUG_ prefix. The knobs are a parity-debugging A/B instrument, not a serving feature, and their names should say so wherever they are set. Pure rename: eleven occurrences across five files, no behavior change, default remains off.