### PR TITLE
docs(server): remove dead rpc_loop.rs file reference

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -43,5 +43,4 @@ server/src/config.rs            user-facing TOML schema
 server/src/serve.rs             engine startup/shutdown
 server/src/embedded_driver.rs   embedded driver startup
 server/src/subprocess_driver.rs Python driver supervision
-server/src/rpc_loop.rs          embedded-driver RPC loop
 ```


### PR DESCRIPTION
## What
Removed a reference to server/src/rpc_loop.rs in server/README.md's Files table — the file doesn't exist anywhere in the repo (RPC dispatch actually lives in serve.rs, already listed).

## Why
A small, objectively-verifiable improvement (broken-link) found during a
daily open-source maintenance pass (2026-08-25).

## How verified
Ran find/grep across the repo for rpc_loop and rpc references; confirmed no such file exists and grep -n rpc in serve.rs shows the RPC wiring is there instead.
Automated gates: 1 changed lines across 1 files (within limits); cargo check: not needed.

---
Prepared with Claude Code assistance and reviewed by Aarush's
automation gates (diff-size, file-scope, deletion, and build checks)
before opening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `pie-server` documentation file listing to remove an outdated source file reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->