### PR TITLE
runtime: refuse an over-length working set before it is pumped

### DIFF
--- a/crates/runtime/src/inferlet/host/kv_working_set.rs
+++ b/crates/runtime/src/inferlet/host/kv_working_set.rs
@@ -63,6 +63,14 @@ impl pie::inferlet::working_set::HostKvWorkingSet for ProcessCtx {
         crate::inferlet::process::gate::residency_gate(self).await?;
         let ws = self.ctx().table.get(&this)?.clone();
         let stores = store_registry::get(ws.model, ws.engine);
+        if let Some(refusal) = past_the_seat(
+            ws.page_len().unwrap_or(0),
+            u64::from(pages),
+            stores.context_pages,
+            stores.kv_page_size,
+        ) {
+            return Ok(Err(refusal));
+        }
         let range = store_registry::with_kv_lock(&stores.kv, "host-working-set", |kv| {
             kv.reserve(ws.id, pages as u64)
         });
@@ -257,4 +265,25 @@ impl pie::inferlet::working_set::HostKvWorkingSet for ProcessCtx {
         ws.release();
         Ok(())
     }
+}
+
+/// A claim that would take the working set past what the engine seats in one
+/// sequence is refused here, before any pages are pumped: a fire refused later
+/// at submit has already fouled the pipeline.
+fn past_the_seat(have: u64, asked: u64, seat_pages: u64, page_size: u32) -> Option<String> {
+    if seat_pages == 0 {
+        return None;
+    }
+    let want = have.saturating_add(asked);
+    if want <= seat_pages {
+        return None;
+    }
+    let tokens = |pages: u64| pages.saturating_mul(u64::from(page_size));
+    Some(format!(
+        "this working set would hold {want} pages ({} tokens) and this engine seats \
+         {seat_pages} pages ({} tokens) in one sequence; raise `[engine] max_model_len` \
+         or send fewer tokens",
+        tokens(want),
+        tokens(seat_pages),
+    ))
 }

--- a/crates/runtime/src/inferlet/host/kv_working_set.rs
+++ b/crates/runtime/src/inferlet/host/kv_working_set.rs
@@ -287,3 +287,35 @@ fn past_the_seat(have: u64, asked: u64, seat_pages: u64, page_size: u32) -> Opti
         tokens(seat_pages),
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::past_the_seat;
+
+    /// The seat is a ceiling on the whole working set, not on one claim: a
+    /// drain's later chunk asks for little and still crosses.
+    #[test]
+    fn a_small_claim_on_a_full_working_set_is_refused() {
+        let refusal = past_the_seat(511, 2, 512, 32).expect("511 + 2 is past a 512-page seat");
+        assert!(refusal.contains("513 pages (16416 tokens)"), "{refusal}");
+        assert!(refusal.contains("512 pages (16384 tokens)"), "{refusal}");
+    }
+
+    /// The incident's request: 32,700 tokens against a 16,384-token seat,
+    /// refused on its first claim rather than at a later chunk.
+    #[test]
+    fn the_first_claim_of_an_unservable_request_is_refused() {
+        assert!(past_the_seat(0, 1022, 512, 32).is_some());
+    }
+
+    #[test]
+    fn a_claim_that_exactly_fills_the_seat_is_served() {
+        assert_eq!(past_the_seat(500, 12, 512, 32), None);
+    }
+
+    /// A seat of zero is an engine that declared no ceiling: nothing to exceed.
+    #[test]
+    fn no_declared_seat_refuses_nothing() {
+        assert_eq!(past_the_seat(1_000_000, 1_000_000, 0, 32), None);
+    }
+}


### PR DESCRIPTION
Hi, I am an agent helping with @shsym.

Addresses #582.

`HostKvWorkingSet::reserve` claimed KV pages with no size check, so a working set longer than the engine seats in one sequence was refused only at submit — after its pages were pumped, fouling the pipeline instead of answering the guest.

This adds a `past_the_seat` check before `kv.reserve`: if the working set's total pages would pass the engine's `context_pages` seat, it returns a clean `Err` naming the limit and how to raise it (`[engine] max_model_len`). A seat of zero — no declared ceiling — is unaffected.