### PR TITLE
runtime: keep a pending fire's KV alive through cancellation

### DIFF
--- a/crates/runtime/src/inferlet/host/forward.rs
+++ b/crates/runtime/src/inferlet/host/forward.rs
@@ -307,6 +307,7 @@ pub(crate) enum ChannelReadMode {
 enum ChannelPoll {
     Ready(Result<Vec<u8>, String>),
     Finalize(crate::pipeline::fire::PendingOp),
+    AwaitCompletion(crate::pipeline::fire::PendingFires),
     Pending {
         cell: Arc<Mutex<ChannelCell>>,
         fires: Option<crate::pipeline::fire::PendingFires>,
@@ -332,16 +333,16 @@ fn poll_channel(
     {
         let ready = cell.lock().unwrap().read();
         match ready {
-            Ok(_) if pop_settled => {
-                if let Some(op) = fires
-                    .as_ref()
-                    .and_then(|fires| fires.lock().unwrap().pop_front())
+            Ok(_) => {
+                if pop_settled && let Some(op) = crate::pipeline::fire::pop_settled(fires.as_ref())
                 {
                     return Ok(ChannelPoll::Finalize(op));
                 }
-            }
-            Ok(_) => {
-                return Ok(ChannelPoll::Pending { cell, fires });
+                // A visible channel may precede fire completion. Wait on that
+                // completion, not the already-ready channel, before taking it.
+                return Ok(ChannelPoll::AwaitCompletion(
+                    fires.expect("the ready take has a pending fire queue"),
+                ));
             }
             Err(ChannelError::Empty) => {}
             Err(error) => return Ok(ChannelPoll::Ready(Err(error.to_string()))),
@@ -380,12 +381,17 @@ async fn materialize_channel(
         let state = match state {
             ChannelPoll::Pending {
                 fires: Some(fires), ..
-            } => {
+            }
+            | ChannelPoll::AwaitCompletion(fires) => {
                 let _finalize_guard = fires.finalize_guard().await;
                 let state = accessor.with(|mut access| {
                     poll_channel(access.get(), &this, mode, true, settle_ready_take)
                 })?;
                 match state {
+                    ChannelPoll::AwaitCompletion(fires) => {
+                        fires.await_front_completion().await;
+                        continue;
+                    }
                     ChannelPoll::Finalize(op) => {
                         let finalized = crate::pipeline::fire::finalize_op_await(op).await?;
                         accessor.with(|mut access| {
@@ -405,6 +411,7 @@ async fn materialize_channel(
                 return Ok(value);
             }
             ChannelPoll::Finalize(_) => unreachable!("finalizer gate required before FIFO pop"),
+            ChannelPoll::AwaitCompletion(_) => unreachable!("completion wait holds finalizer gate"),
             ChannelPoll::Pending { cell, fires, .. } => {
                 settle_ready_take = true;
                 if let Err(error) =
@@ -428,10 +435,15 @@ pub(crate) async fn materialize_channel_blocking(
         let state = match state {
             ChannelPoll::Pending {
                 fires: Some(fires), ..
-            } => {
+            }
+            | ChannelPoll::AwaitCompletion(fires) => {
                 let _finalize_guard = fires.finalize_guard().await;
                 let state = poll_channel(ctx, &this, mode, true, settle_ready_take)?;
                 match state {
+                    ChannelPoll::AwaitCompletion(fires) => {
+                        fires.await_front_completion().await;
+                        continue;
+                    }
                     ChannelPoll::Finalize(op) => {
                         let finalized = crate::pipeline::fire::finalize_op_await(op).await?;
                         crate::pipeline::fire::complete_finalize(ctx, finalized);
@@ -449,6 +461,7 @@ pub(crate) async fn materialize_channel_blocking(
                 return Ok(value);
             }
             ChannelPoll::Finalize(_) => unreachable!("finalizer gate required before FIFO pop"),
+            ChannelPoll::AwaitCompletion(_) => unreachable!("completion wait holds finalizer gate"),
             ChannelPoll::Pending { cell, fires, .. } => {
                 settle_ready_take = true;
                 if let Err(error) =
@@ -2554,6 +2567,102 @@ mod tests {
             port_rows(&[bound("timestep", PortKind::LaneVector, None)]),
             Ok(None)
         );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancelled_ready_take_keeps_pending_kv_for_teardown() -> anyhow::Result<()> {
+        use super::*;
+        use crate::pipeline::fire::lifecycle_tests::{
+            pending_fire_fixture, resolve_test_completion,
+        };
+        use std::future::Future;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        for failed in [false, true] {
+            // The channel is visible before the native completion, which is
+            // the ready-Take path that used to remove an unresolved fire.
+            let mirror = Box::new([7i32, 0]);
+            let words = Box::new([
+                AtomicU64::new(0),
+                AtomicU64::new(1),
+                AtomicU64::new(0),
+                AtomicU64::new(0),
+            ]);
+            let mut cell = ChannelCell::new(vec![1], Dtype::I32, 1);
+            cell.role = Some(HostRole::Reader);
+            cell.attach_reader_mirror(
+                0,
+                mirror.as_ptr() as u64,
+                words.as_ptr() as u64,
+                4,
+                1,
+                0,
+                0,
+                1,
+                2,
+                3,
+            )
+            .map_err(anyhow::Error::msg)?;
+            let cell = Arc::new(Mutex::new(cell));
+            assert_eq!(
+                cell.lock().expect("test channel").read(),
+                Ok(7i32.to_ne_bytes().to_vec())
+            );
+            let (fires, completion, ws, stores, failure) = pending_fire_fixture(vec![cell.clone()]);
+            let mut context = ProcessCtx::new(
+                uuid::Uuid::new_v4(),
+                "test".into(),
+                crate::inferlet::process::OutputMode::Discard,
+                &crate::inferlet::sandbox::InstancePolicy::deny_all(),
+                None,
+            )
+            .await?;
+            context.ctx().table.push(ws)?;
+            let channel = context.ctx().table.push(Channel {
+                cell: cell.clone(),
+                fires: Some(fires.clone()),
+            })?;
+            {
+                let mut take = Box::pin(materialize_channel_blocking(
+                    &mut context,
+                    channel,
+                    ChannelReadMode::Take,
+                ));
+                let mut task = std::task::Context::from_waker(std::task::Waker::noop());
+                assert!(take.as_mut().poll(&mut task).is_pending());
+            }
+            assert_eq!(
+                fires.lock().expect("test FIFO").len(),
+                1,
+                "cancelled ready Take must not remove an unresolved fire"
+            );
+            assert_eq!(
+                words[0].load(Ordering::Acquire),
+                0,
+                "the visible channel must not be consumed before finalization"
+            );
+            *context.ctx().table = wasmtime::component::ResourceTable::new();
+            assert_eq!(stores.kv.lock().available_pages(), 0);
+            resolve_test_completion(&completion, failed);
+            crate::pipeline::fire::finalize_all(&mut context, &fires, true).await?;
+            assert!(fires.lock().expect("test FIFO").is_empty());
+            assert_eq!(
+                stores.kv.lock().available_pages(),
+                1,
+                "the original submitted page must be reclaimed after teardown"
+            );
+            assert_eq!(failure.lock().expect("test failure").is_some(), failed);
+            let value = cell.lock().expect("test channel").read();
+            if failed {
+                assert!(
+                    matches!(value, Err(ChannelError::Poisoned(_))),
+                    "a failed callback must still poison its reader"
+                );
+            } else {
+                assert_eq!(value, Ok(7i32.to_ne_bytes().to_vec()));
+            }
+        }
+        Ok(())
     }
 
     fn binding() -> AttentionBinding {

--- a/crates/runtime/src/pipeline/fire.rs
+++ b/crates/runtime/src/pipeline/fire.rs
@@ -69,6 +69,20 @@ impl PendingFireQueue {
         Arc::clone(&self.finalizer).lock_owned().await
     }
 
+    /// Keep the transaction in the shared FIFO while waiting, so an aborted
+    /// guest leaves teardown its owner. Caller holds the finalizer guard;
+    /// errors are read by finalization too, rather than skipping cleanup.
+    pub(crate) async fn await_front_completion(&self) {
+        let completion = self
+            .lock()
+            .unwrap()
+            .front()
+            .map(PendingOp::completion_signal);
+        if let Some(completion) = completion {
+            completion.await;
+        }
+    }
+
     pub(crate) fn try_finalize_guard(&self) -> Option<tokio::sync::OwnedMutexGuard<()>> {
         Arc::clone(&self.finalizer).try_lock_owned().ok()
     }
@@ -1930,6 +1944,7 @@ pub(crate) async fn finalize_all<C: FireContext>(
 ) -> Anyhow<()> {
     let _finalize_guard = fires.finalize_guard().await;
     loop {
+        fires.await_front_completion().await;
         let op = fires.lock().unwrap().pop_front();
         let Some(op) = op else {
             return Ok(());
@@ -2687,7 +2702,7 @@ fn reclaim_device_geometry_grants<C: FireContext>(ctx: &mut C, fwd_rep: u32, ins
 }
 
 #[cfg(test)]
-mod lifecycle_tests {
+pub(crate) mod lifecycle_tests {
     use super::*;
     use wasmtime::component::ResourceTable;
 
@@ -2704,6 +2719,109 @@ mod lifecycle_tests {
         fn process_id(&self) -> uuid::Uuid {
             self.id
         }
+    }
+
+    pub(crate) fn pending_fire_fixture(
+        cells: BoundCells,
+    ) -> (
+        PendingFires,
+        crate::engine::WorkItemCompletion,
+        KvWorkingSet,
+        crate::store::registry::Stores,
+        PipelineFailure,
+    ) {
+        let model = crate::store::registry::register_model(32, &[1], &[1]);
+        let stores = crate::store::registry::get(model, 0);
+        let (id, txn) = {
+            let mut store = stores.kv.lock();
+            let id = store.create_working_set();
+            store.reserve(id, 1).expect("reserve the test sequence");
+            let mut granted = store
+                .reserve_device_pages(1)
+                .expect("one free physical page");
+            let (_, _, _, txn) = kv::prepare_explicit_reserved(&mut store, id, &[0], &mut granted)
+                .expect("publish a real pending KV transaction");
+            (id, txn)
+        };
+        let ws = KvWorkingSet::new(model, 0, id, 32);
+        let completion = crate::engine::WorkItemCompletion::deferred_with_guard(None);
+        let failure = Arc::new(Mutex::new(None));
+        let fires = Arc::new(PendingFireQueue::new());
+        fires
+            .lock()
+            .expect("test FIFO")
+            .push_back(PendingOp::Fire(PendingFire {
+                completion: completion.clone(),
+                kv: FireKv::Host(Some(txn)),
+                rstxn: RsTxnsGuard::new(model, 0, None),
+                ws_guard: ws.fire_lease().expect("lease the submitted working set"),
+                model,
+                engine: 0,
+                fwd_rep: u32::MAX,
+                instance_id: 0,
+                cells,
+                failure: failure.clone(),
+            }));
+        (fires, completion, ws, stores, failure)
+    }
+
+    pub(crate) fn resolve_test_completion(
+        completion: &crate::engine::WorkItemCompletion,
+        failed: bool,
+    ) {
+        completion.mark_native_retired();
+        if failed {
+            completion.reject("test callback failure");
+        } else {
+            // The completion owns this terminal cell for the entire write.
+            unsafe {
+                (*completion.terminal_cell_ptr())
+                    .publish(crate::engine::completion::TERMINAL_OUTCOME_SUCCESS);
+            }
+            completion
+                .resolve_from_terminal()
+                .expect("publish successful completion");
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn cancelled_full_drain_keeps_pending_kv_for_teardown() -> anyhow::Result<()> {
+        use std::future::Future;
+        for failed in [false, true] {
+            let (fires, completion, ws, stores, failure) = pending_fire_fixture(Vec::new());
+            let mut context = TestContext {
+                id: uuid::Uuid::new_v4(),
+                resources: ResourceTable::new(),
+            };
+            context.resources.push(ws)?;
+            {
+                let mut drain = Box::pin(finalize_all(&mut context, &fires, false));
+                let mut task = std::task::Context::from_waker(std::task::Waker::noop());
+                assert!(drain.as_mut().poll(&mut task).is_pending());
+                // Dropping the real host future models guest-task cancellation.
+            }
+            assert_eq!(
+                fires.lock().expect("test FIFO").len(),
+                1,
+                "cancelled drain must leave its unresolved operation in the FIFO"
+            );
+            context.resources = ResourceTable::new();
+            assert_eq!(
+                stores.kv.lock().available_pages(),
+                0,
+                "resource destruction must not recycle pages before completion"
+            );
+            resolve_test_completion(&completion, failed);
+            finalize_all(&mut context, &fires, true).await?;
+            assert!(fires.lock().expect("test FIFO").is_empty());
+            assert_eq!(
+                stores.kv.lock().available_pages(),
+                1,
+                "teardown must settle the original transaction and release its page"
+            );
+            assert_eq!(failure.lock().expect("test failure").is_some(), failed);
+        }
+        Ok(())
     }
 
     #[tokio::test(flavor = "current_thread")]


### PR DESCRIPTION
Hi, I am an agent helping with @shsym.

Addresses #586.

A pending fire holds a prepared KV reservation until its forward completes. On cancellation the front fire's completion was not awaited, so its KV could be recycled before the in-flight op settled — leaking pages and mishandling teardown.

This pairs `PendingFireQueue::await_front_completion` with the forward ready-channel waits, so a cancelled request keeps the pending KV until its op settles.

Cells: `cancelled_ready_take_keeps_pending_kv_for_teardown` and `cancelled_full_drain_keeps_pending_kv_for_teardown` (both cancellation paths keep the pending KV for teardown).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed channel operations that could consume a ready channel before an earlier pending operation completed.
  - Cancelled channel reads now preserve unresolved operations in the correct order.
  - Improved cleanup so resources remain available until pending operations finish and are fully released during teardown.
  - Preserved failure handling during cancellation and shutdown, preventing unresolved operations from being lost.
  - Added coverage for cancellation, completion, failure handling, ordering, and resource cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->