### PR TITLE
runtime/worker: close worker sessions on session end and make teardown cancel/restart-safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6970,6 +6970,7 @@ dependencies = [
  "controller-api",
  "engine",
  "futures",
+ "gateway",
  "ids",
  "mimalloc",
  "model-ir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ metal = ["worker/metal"]
 vulkan = ["worker/vulkan"]
 wgpu = ["worker/wgpu"]
 profile-fire = ["worker/profile-fire"]
+session-lifetime-diagnostic = ["worker/session-lifetime-diagnostic"]
 
 [dependencies]
 bootstrap = { path = "crates/bootstrap" }

--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use axum::Router;
 use controller_api::GatewayInfo;
-use ids::{ReqId, WorkerId};
+use ids::{ReqId, SessionId, WorkerId};
 use serde::{Deserialize, Serialize};
 use tokio::net::TcpListener;
 use tokio::sync::{Notify, watch};
@@ -103,6 +103,14 @@ impl TurnRouter for RouteBackend {
     async fn cancel(&self, worker: WorkerId, req: ReqId) {
         if let Some(client) = self.workers.client(worker) {
             let _ = client.cancel(tarpc::context::current(), req).await;
+        }
+    }
+
+    async fn close_session(&self, worker: WorkerId, session: SessionId) {
+        if let Some(client) = self.workers.client(worker) {
+            let _ = client
+                .close_session(tarpc::context::current(), session)
+                .await;
         }
     }
 

--- a/crates/gateway/src/session.rs
+++ b/crates/gateway/src/session.rs
@@ -83,6 +83,8 @@ pub trait TurnRouter: Send + Sync + 'static {
 
     async fn cancel(&self, worker: WorkerId, req: ReqId);
 
+    async fn close_session(&self, worker: WorkerId, session: SessionId);
+
     fn connected(&self) -> watch::Receiver<Arc<HashSet<WorkerId>>>;
 }
 
@@ -96,6 +98,7 @@ struct TurnState {
 
 struct Inner {
     turns: Mutex<HashMap<ReqId, TurnState>>,
+    sessions: Mutex<HashMap<SessionId, HashSet<WorkerId>>>,
     router: Arc<dyn TurnRouter>,
     next_req: AtomicU64,
     next_session: AtomicU64,
@@ -106,7 +109,7 @@ struct Inner {
 
 impl Inner {
     async fn run_turn(
-        &self,
+        self: &Arc<Self>,
         session: SessionId,
         tenant: &TenantId,
         input: TurnInput,
@@ -141,16 +144,28 @@ impl Inner {
                 },
             );
         }
+        let mut pending = PendingTurn {
+            inner: self.clone(),
+            req_id,
+            armed: true,
+        };
 
-        match self.router.dispatch(&request, affinity).await {
-            Ok(worker) => {
-                let mut turns = self.turns.lock().unwrap();
-                if let Some(turn) = turns.get_mut(&req_id) {
-                    turn.worker = Some(worker);
-                }
+        let inner = self.clone();
+        let dispatched = tokio::spawn(async move {
+            let result = inner.router.dispatch(&request, affinity).await;
+            if let Ok(worker) = result {
+                inner.bind_worker(req_id, session, worker).await;
+            }
+            result
+        })
+        .await;
+
+        match dispatched {
+            Ok(Ok(_)) => {
+                pending.armed = false;
                 Ok((req_id, TokenRx { rx }))
             }
-            Err(DispatchFail) => {
+            Ok(Err(DispatchFail)) | Err(_) => {
                 self.turns.lock().unwrap().remove(&req_id);
                 Err(SessionError::NoWorker)
             }
@@ -163,6 +178,96 @@ impl Inner {
             .unwrap()
             .remove(&req_id)
             .and_then(|t| t.worker)
+    }
+
+    async fn bind_worker(&self, req_id: ReqId, session: SessionId, worker: WorkerId) {
+        let live = {
+            let mut turns = self.turns.lock().unwrap();
+            if let Some(turn) = turns.get_mut(&req_id) {
+                turn.worker = Some(worker);
+                true
+            } else {
+                false
+            }
+        };
+        self.note_worker(session, worker);
+        if !live {
+            self.router.cancel(worker, req_id).await;
+        }
+    }
+
+    fn note_worker(&self, session: SessionId, worker: WorkerId) {
+        let live = {
+            let mut sessions = self.sessions.lock().unwrap();
+            match sessions.get_mut(&session) {
+                Some(workers) => {
+                    workers.insert(worker);
+                    true
+                }
+                None => false,
+            }
+        };
+        if !live {
+            let router = self.router.clone();
+            tokio::spawn(async move { router.close_session(worker, session).await });
+        }
+    }
+
+    fn take_workers(&self, session: SessionId) -> HashSet<WorkerId> {
+        self.sessions
+            .lock()
+            .unwrap()
+            .remove(&session)
+            .unwrap_or_default()
+    }
+}
+
+struct PendingTurn {
+    inner: Arc<Inner>,
+    req_id: ReqId,
+    armed: bool,
+}
+
+impl Drop for PendingTurn {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        if let Some(worker) = self.inner.abort_turn(self.req_id) {
+            let router = self.inner.router.clone();
+            let req_id = self.req_id;
+            tokio::spawn(async move { router.cancel(worker, req_id).await });
+        }
+    }
+}
+
+struct SessionCreation {
+    inner: Arc<Inner>,
+    session: SessionId,
+    armed: bool,
+}
+
+impl Drop for SessionCreation {
+    fn drop(&mut self) {
+        if !self.armed {
+            return;
+        }
+        self.inner.live.fetch_sub(1, Ordering::Relaxed);
+        self.inner
+            .turns
+            .lock()
+            .unwrap()
+            .retain(|_, turn| turn.request.session != self.session);
+        let workers = self.inner.take_workers(self.session);
+        if !workers.is_empty() {
+            let router = self.inner.router.clone();
+            let session = self.session;
+            tokio::spawn(async move {
+                for worker in workers {
+                    router.close_session(worker, session).await;
+                }
+            });
+        }
     }
 }
 
@@ -179,6 +284,7 @@ impl Sessions {
     pub fn with_pipe_cap(router: Arc<dyn TurnRouter>, pipe_cap: usize) -> Self {
         let inner = Arc::new(Inner {
             turns: Mutex::new(HashMap::new()),
+            sessions: Mutex::new(HashMap::new()),
             router,
             next_req: AtomicU64::new(0),
             next_session: AtomicU64::new(0),
@@ -205,17 +311,21 @@ impl Sessions {
             Affinity::Sticky => Some(session.0),
         };
         self.inner.live.fetch_add(1, Ordering::Relaxed);
-        let (req_id, rx) = match self
+        self.inner
+            .sessions
+            .lock()
+            .unwrap()
+            .insert(session, HashSet::new());
+        let mut creation = SessionCreation {
+            inner: self.inner.clone(),
+            session,
+            armed: true,
+        };
+        let (req_id, rx) = self
             .inner
             .run_turn(session, &ident.tenant, first, affinity_key)
-            .await
-        {
-            Ok(v) => v,
-            Err(e) => {
-                self.inner.live.fetch_sub(1, Ordering::Relaxed);
-                return Err(e);
-            }
-        };
+            .await?;
+        creation.armed = false;
         let handle = SessionHandle {
             inner: self.inner.clone(),
             session,
@@ -275,10 +385,7 @@ impl Sessions {
         tokio::spawn(async move {
             match inner.router.dispatch(&request, affinity).await {
                 Ok(worker) => {
-                    let mut turns = inner.turns.lock().unwrap();
-                    if let Some(turn) = turns.get_mut(&req_id) {
-                        turn.worker = Some(worker);
-                    }
+                    inner.bind_worker(req_id, request.session, worker).await;
                 }
                 Err(DispatchFail) => {
                     inner.turns.lock().unwrap().remove(&req_id);
@@ -333,6 +440,9 @@ impl SessionHandle {
 
     pub async fn close(&self) {
         self.cancel().await;
+        for worker in self.inner.take_workers(self.session) {
+            self.inner.router.close_session(worker, self.session).await;
+        }
     }
 
     pub fn id(&self) -> SessionId {
@@ -349,6 +459,16 @@ impl Drop for SessionHandle {
                 let router = self.inner.router.clone();
                 tokio::spawn(async move { router.cancel(worker, req_id).await });
             }
+        }
+        let workers = self.inner.take_workers(self.session);
+        if !workers.is_empty() {
+            let router = self.inner.router.clone();
+            let session = self.session;
+            tokio::spawn(async move {
+                for worker in workers {
+                    router.close_session(worker, session).await;
+                }
+            });
         }
     }
 }
@@ -385,10 +505,7 @@ fn spawn_drop_watcher(inner: Arc<Inner>) {
                 }
                 match inner.router.dispatch(&request, affinity).await {
                     Ok(worker) => {
-                        let mut turns = inner.turns.lock().unwrap();
-                        if let Some(turn) = turns.get_mut(&req_id) {
-                            turn.worker = Some(worker);
-                        }
+                        inner.bind_worker(req_id, request.session, worker).await;
                     }
                     Err(DispatchFail) => {
                         inner.turns.lock().unwrap().remove(&req_id);
@@ -411,6 +528,10 @@ mod tests {
         dispatched: Mutex<Vec<ReqId>>,
         affinities: Mutex<Vec<Option<u64>>>,
         cancels: Mutex<Vec<(WorkerId, ReqId)>>,
+        closed: Mutex<Vec<(WorkerId, SessionId)>>,
+        block_dispatch: AtomicBool,
+        dispatch_started: tokio::sync::Notify,
+        dispatch_release: tokio::sync::Notify,
         _connected_tx: watch::Sender<Arc<HashSet<WorkerId>>>,
         connected_rx: watch::Receiver<Arc<HashSet<WorkerId>>>,
     }
@@ -425,6 +546,10 @@ mod tests {
                 dispatched: Mutex::new(Vec::new()),
                 affinities: Mutex::new(Vec::new()),
                 cancels: Mutex::new(Vec::new()),
+                closed: Mutex::new(Vec::new()),
+                block_dispatch: AtomicBool::new(false),
+                dispatch_started: tokio::sync::Notify::new(),
+                dispatch_release: tokio::sync::Notify::new(),
                 _connected_tx: tx,
                 connected_rx: rx,
             })
@@ -447,6 +572,10 @@ mod tests {
         ) -> Result<WorkerId, DispatchFail> {
             self.dispatched.lock().unwrap().push(req.req_id);
             self.affinities.lock().unwrap().push(affinity);
+            if self.block_dispatch.load(Ordering::Acquire) {
+                self.dispatch_started.notify_one();
+                self.dispatch_release.notified().await;
+            }
             match *self.dispatch_worker.lock().unwrap() {
                 Some(w) => Ok(w),
                 None => Err(DispatchFail),
@@ -454,6 +583,9 @@ mod tests {
         }
         async fn cancel(&self, worker: WorkerId, req: ReqId) {
             self.cancels.lock().unwrap().push((worker, req));
+        }
+        async fn close_session(&self, worker: WorkerId, session: SessionId) {
+            self.closed.lock().unwrap().push((worker, session));
         }
         fn connected(&self) -> watch::Receiver<Arc<HashSet<WorkerId>>> {
             self.connected_rx.clone()
@@ -483,6 +615,46 @@ mod tests {
             ok: true,
             result: String::new(),
         })
+    }
+
+    async fn closes(router: &MockRouter, want: usize) -> Vec<(WorkerId, SessionId)> {
+        let poll = async {
+            loop {
+                {
+                    let closed = router.closed.lock().unwrap();
+                    if closed.len() >= want {
+                        return closed.clone();
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        };
+        tokio::time::timeout(Duration::from_secs(2), poll)
+            .await
+            .expect("close_session not observed before the deadline")
+    }
+
+    const SETTLE: Duration = Duration::from_millis(100);
+
+    async fn all_closes(router: &MockRouter, want: usize) -> Vec<(WorkerId, SessionId)> {
+        closes(router, want).await;
+        tokio::time::sleep(SETTLE).await;
+        let mut closed = router.closed.lock().unwrap().clone();
+        closed.sort();
+        closed
+    }
+
+    async fn wait_for_cancel(router: &MockRouter, expected: (WorkerId, ReqId)) {
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if router.cancels.lock().unwrap().contains(&expected) {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("cancel not observed before the deadline");
     }
 
     #[tokio::test]
@@ -529,5 +701,146 @@ mod tests {
         let sessions = Sessions::new(router);
         let res = sessions.create(ident(), input(), Affinity::Sticky).await;
         assert!(matches!(res, Err(SessionError::NoWorker)));
+    }
+
+    #[tokio::test]
+    async fn dropping_a_session_closes_it_on_its_worker() {
+        let router = MockRouter::new(Some(WorkerId(7)));
+        let sessions = Sessions::new(router.clone());
+        let (handle, _rx) = sessions
+            .create(ident(), input(), Affinity::Sticky)
+            .await
+            .unwrap();
+        let session = handle.id();
+
+        drop(handle);
+        assert_eq!(closes(&router, 1).await, vec![(WorkerId(7), session)]);
+    }
+
+    #[tokio::test]
+    async fn an_open_session_is_never_closed_between_turns() {
+        let router = MockRouter::new(Some(WorkerId(3)));
+        let sessions = Sessions::new(router.clone());
+        let (handle, _rx) = sessions
+            .create(ident(), input(), Affinity::Sticky)
+            .await
+            .unwrap();
+        for _ in 0..3 {
+            handle.turn(input()).await.unwrap();
+        }
+        assert!(router.closed.lock().unwrap().is_empty());
+
+        let session = handle.id();
+        drop(handle);
+        assert_eq!(closes(&router, 1).await, vec![(WorkerId(3), session)]);
+    }
+
+    #[tokio::test]
+    async fn every_worker_that_served_the_session_is_closed() {
+        let router = MockRouter::new(Some(WorkerId(1)));
+        let sessions = Sessions::new(router.clone());
+        let (handle, _rx) = sessions
+            .create(ident(), input(), Affinity::Sticky)
+            .await
+            .unwrap();
+        *router.dispatch_worker.lock().unwrap() = Some(WorkerId(2));
+        handle.turn(input()).await.unwrap();
+
+        let session = handle.id();
+        drop(handle);
+        let mut closed = closes(&router, 2).await;
+        closed.sort();
+        assert_eq!(closed, vec![(WorkerId(1), session), (WorkerId(2), session)]);
+    }
+
+    #[tokio::test]
+    async fn a_dispatch_landing_after_the_session_ended_closes_itself() {
+        let router = MockRouter::new(Some(WorkerId(1)));
+        let sessions = Sessions::new(router.clone());
+        let (handle, _rx) = sessions
+            .create(ident(), input(), Affinity::Sticky)
+            .await
+            .unwrap();
+        let session = handle.id();
+        let req_id = router.dispatched.lock().unwrap()[0];
+
+        *router.dispatch_worker.lock().unwrap() = Some(WorkerId(2));
+        router.block_dispatch.store(true, Ordering::Release);
+        sessions.redirect(req_id);
+        router.dispatch_started.notified().await;
+        drop(handle);
+        router.dispatch_release.notify_one();
+
+        assert_eq!(
+            all_closes(&router, 2).await,
+            vec![(WorkerId(1), session), (WorkerId(2), session)]
+        );
+        wait_for_cancel(&router, (WorkerId(2), req_id)).await;
+    }
+
+    #[tokio::test]
+    async fn closing_then_dropping_the_handle_closes_each_worker_once() {
+        let router = MockRouter::new(Some(WorkerId(1)));
+        let sessions = Sessions::new(router.clone());
+        let (handle, _rx) = sessions
+            .create(ident(), input(), Affinity::Sticky)
+            .await
+            .unwrap();
+        *router.dispatch_worker.lock().unwrap() = Some(WorkerId(2));
+        handle.turn(input()).await.unwrap();
+        let session = handle.id();
+
+        handle.close().await;
+        drop(handle);
+
+        assert_eq!(
+            all_closes(&router, 2).await,
+            vec![(WorkerId(1), session), (WorkerId(2), session)]
+        );
+    }
+
+    #[tokio::test]
+    async fn cancelling_create_closes_a_late_dispatch() {
+        let router = MockRouter::new(Some(WorkerId(7)));
+        router.block_dispatch.store(true, Ordering::Release);
+        let sessions = Sessions::new(router.clone());
+        let create = tokio::spawn({
+            let sessions = sessions.clone();
+            async move { sessions.create(ident(), input(), Affinity::Sticky).await }
+        });
+        router.dispatch_started.notified().await;
+
+        create.abort();
+        let _ = create.await;
+        router.dispatch_release.notify_one();
+
+        assert_eq!(closes(&router, 1).await, vec![(WorkerId(7), SessionId(0))]);
+        assert_eq!(sessions.live(), 0);
+    }
+
+    #[tokio::test]
+    async fn cancelling_a_later_turn_cancels_its_late_dispatch() {
+        let router = MockRouter::new(Some(WorkerId(7)));
+        let sessions = Sessions::new(router.clone());
+        let (handle, _rx) = sessions
+            .create(ident(), input(), Affinity::Sticky)
+            .await
+            .unwrap();
+        let first = router.dispatched.lock().unwrap()[0];
+        assert_eq!(sessions.feed(first, Tokens::Eos).await, Control::Continue);
+
+        router.block_dispatch.store(true, Ordering::Release);
+        let mut turn = Box::pin(handle.turn(input()));
+        tokio::select! {
+            _ = router.dispatch_started.notified() => {}
+            _ = &mut turn => panic!("turn completed before dispatch release"),
+        }
+        let req_id = *router.dispatched.lock().unwrap().last().unwrap();
+        drop(turn);
+        router.dispatch_release.notify_one();
+
+        wait_for_cancel(&router, (WorkerId(7), req_id)).await;
+        assert!(!sessions.inner.turns.lock().unwrap().contains_key(&req_id));
+        drop(handle);
     }
 }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -111,6 +111,7 @@ objc2 = { version = "0.6", optional = true }
 
 [features]
 default = []
+session-lifetime-diagnostic = []
 cuda = ["dep:engine-cuda", "engine-cuda/cuda", "dep:cudarc", "dep:libloading", "cudarc/cuda-13000"]
 metal = ["dep:engine-metal", "dep:objc2"]
 vulkan = ["dep:engine-vulkan", "engine-vulkan/vulkan"]

--- a/crates/runtime/src/inferlet/process.rs
+++ b/crates/runtime/src/inferlet/process.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, LazyLock, Mutex, OnceLock, RwLock};
 use std::time::{Duration, Instant};
 
 use anyhow::{Result, anyhow};
-use tokio::sync::{Semaphore, oneshot};
+use tokio::sync::{Semaphore, oneshot, watch};
 use tokio::task::JoinHandle;
 use uuid::Uuid;
 
@@ -27,6 +27,22 @@ use super::linker;
 use super::program::ProgramName;
 
 const RUN_INTERFACE: &str = "pie:inferlet/run@0.3.0";
+
+/// Counts process capacity releases, so a load reporter can sample on the
+/// release instead of on its own timer. A watch counter rather than a
+/// `Notify` because a reporter that was busy when the release happened still
+/// sees it on its next `changed()`. Only teardown moves it: the per-fire free
+/// paths are too hot to wake a reporter on.
+static RELEASES: LazyLock<watch::Sender<u64>> = LazyLock::new(|| watch::Sender::new(0));
+
+pub(crate) fn note_release() {
+    RELEASES.send_modify(|count| *count += 1);
+}
+
+/// Observes process capacity releases; the value only ever increases.
+pub fn releases() -> watch::Receiver<u64> {
+    RELEASES.subscribe()
+}
 
 static RESTARTABLE: LazyLock<RwLock<HashSet<ProcessId>>> = LazyLock::new(Default::default);
 static RESTART_REQUESTED: LazyLock<RwLock<HashSet<ProcessId>>> = LazyLock::new(Default::default);
@@ -84,13 +100,18 @@ pub enum ProcessEvent {
 }
 
 impl ProcessEvent {
+    /// The two events a process ends with. Named because a session that only
+    /// has the wire form still has to recognise "this process is over".
+    pub const RETURN: &'static str = "return";
+    pub const ERROR: &'static str = "error";
+
     pub fn name(&self) -> &'static str {
         match self {
             Self::Stdout(_) => "stdout",
             Self::Stderr(_) => "stderr",
             Self::Message(_) => "message",
-            Self::Return(_) => "return",
-            Self::Error(_) => "error",
+            Self::Return(_) => Self::RETURN,
+            Self::Error(_) => Self::ERROR,
         }
     }
 
@@ -417,14 +438,51 @@ pub fn detach(process_id: ProcessId) {
     let _ = SERVICES.send(&resolve(process_id), Message::DetachClient);
 }
 
+/// Terminate a process (fire-and-forget). The caller is an owner — a closing
+/// session, a client, or a fail-loud path — so this never restarts.
 pub fn terminate(process_id: ProcessId, result: Result<String, String>) {
-    let process_id = resolve(process_id);
-    if SERVICES
-        .send(&process_id, Message::Terminate { result })
-        .is_ok()
-    {
-        crate::scheduler::worker::post_process_terminate(process_id);
+    terminate_with(process_id, result, Origin::Owner);
+}
+
+/// The run task reporting its own end: the one termination a parked restart
+/// request may replace.
+fn terminate_from_run(process_id: ProcessId, result: Result<String, String>) {
+    terminate_with(process_id, result, Origin::Run);
+}
+
+fn terminate_with(process_id: ProcessId, result: Result<String, String>, origin: Origin) {
+    let target = resolve(process_id);
+    // The result is cloned for the first attempt because `ServiceMap::send`
+    // consumes the message and does not hand it back on failure; one string
+    // clone per termination is cheaper than widening that signature.
+    if deliver_terminate(target, result.clone(), origin) {
+        return;
     }
+    // The other side of the handover window described on `Process::successor`:
+    // the resolve above can read the alias a moment before the restart
+    // publishes it, and the old actor is gone by the time the send lands.
+    let republished = resolve(process_id);
+    if republished != target {
+        deliver_terminate(republished, result, origin);
+    }
+}
+
+/// Post a Terminate to one live actor; false if it is no longer registered.
+fn deliver_terminate(
+    process_id: ProcessId,
+    result: Result<String, String>,
+    origin: Origin,
+) -> bool {
+    // Early wait-set drop for a live process, guarded on registry delivery
+    // so an already-quiesced pid cannot mint a fresh tombstone.
+    if SERVICES
+        .send(&process_id, Message::Terminate { result, origin })
+        .is_err()
+    {
+        return false;
+    }
+    crate::scheduler::worker::post_process_terminate(process_id);
+    true
 }
 
 pub fn stdout(process_id: ProcessId, content: String) {
@@ -466,6 +524,17 @@ pub struct ProcessStats {
     pub elapsed_secs: u64,
 }
 
+/// Who asked for a process to end. Carried on the message rather than
+/// inferred from the result, because the two are indistinguishable there: an
+/// owner's kill and a guest failure both arrive as an `Err` string.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Origin {
+    /// The run task reporting its own completion.
+    Run,
+    /// A session closing, a client kill, a signal, or a worker cancel.
+    Owner,
+}
+
 enum Message {
     AttachClient {
         client_id: ClientId,
@@ -474,6 +543,7 @@ enum Message {
     DetachClient,
     Terminate {
         result: Result<String, String>,
+        origin: Origin,
     },
 
     Stdout {
@@ -507,6 +577,17 @@ struct Process {
     capture_outputs: bool,
     output_buffer: VecDeque<ProcessEvent>,
     result_tx: SharedResultTx,
+    /// Set by the first `Terminate` this actor handles.
+    terminated: bool,
+    /// The replacement a restart spawned, if any.
+    ///
+    /// The handover window: a restart registers its successor in `SERVICES`
+    /// before it publishes the alias naming it, so for that moment a
+    /// Terminate for the client's pid still resolves here and lands in this
+    /// mailbox after the end has been claimed. Whoever holds the successor
+    /// forwards such a Terminate on, which is what keeps a re-run from
+    /// outliving the session that closed it.
+    successor: Option<ProcessId>,
 }
 
 impl Process {
@@ -549,6 +630,8 @@ impl Process {
             capture_outputs,
             output_buffer: VecDeque::new(),
             result_tx,
+            terminated: false,
+            successor: None,
         }
     }
 
@@ -679,7 +762,7 @@ impl Process {
             let _ = tx.send(result.clone());
         }
 
-        terminate(process_id, result);
+        terminate_from_run(process_id, result);
     }
 
     fn restart(&mut self) -> bool {
@@ -696,6 +779,9 @@ impl Process {
         );
         match spawned {
             Ok(new_id) => {
+                self.successor = Some(new_id);
+                // Published before this process finishes tearing down, so a
+                // client message in the handover window reaches the re-run.
                 RESTART_ALIAS
                     .write()
                     .unwrap()
@@ -716,10 +802,46 @@ impl Process {
         }
     }
 
-    fn terminate(&mut self, result: Result<String, String>) {
+    fn terminate(&mut self, result: Result<String, String>, origin: Origin) {
+        // Natural completion and the owning session are both entitled to end
+        // a process, and `ServiceMap::remove` does not discard the messages
+        // already in the mailbox, so two Terminates can arrive. Claim the end
+        // before any of it happens — including the restart branch, whose
+        // replacement a second pass would disown by clearing its alias.
+        if self.terminated {
+            // Relayed, not dropped, when a restart left a replacement behind:
+            // see the handover window on `successor`. Resolve from the stable
+            // client pid because the immediate successor may itself have
+            // restarted and aliases are only published for that stable id.
+            if let Some(successor) = self.successor {
+                let target = resolve(self.client_pid);
+                terminate_with(
+                    if target == self.process_id {
+                        successor
+                    } else {
+                        self.client_pid
+                    },
+                    result,
+                    origin,
+                );
+            }
+            return;
+        }
+        self.terminated = true;
+
         self.handle.abort();
 
-        let restarted = restart_requested(self.process_id) && self.restart();
+        // If the planner asked for a re-run, a fresh process takes over the
+        // reply channel and FCFS position; nothing is delivered for this
+        // abandoned attempt. Teardown below still runs unconditionally.
+        //
+        // Only the run task's own end may be replaced. An owner's Terminate
+        // aborts the run before the guest can finish, so honouring the
+        // planner's parked request there would spawn a replacement the owner
+        // never asked for, does not know about, and cannot reach to close.
+        // The request is forgotten either way, so it cannot be honoured later.
+        let restarted =
+            origin == Origin::Run && restart_requested(self.process_id) && self.restart();
         forget_restart_state(self.process_id);
 
         if !restarted {
@@ -743,6 +865,7 @@ impl Process {
 
         let _ = server::inbox::clear(self.process_id.to_string());
         SERVICES.remove(&self.process_id);
+        note_release();
 
         if !restarted {
             RESTART_ALIAS.write().unwrap().remove(&self.client_pid);
@@ -776,8 +899,8 @@ impl ServiceHandler for Process {
                 self.client_id = None;
             }
 
-            Message::Terminate { result } => {
-                self.terminate(result);
+            Message::Terminate { result, origin } => {
+                self.terminate(result, origin);
             }
 
             Message::Stdout { content } => self.deliver_event(ProcessEvent::Stdout(content)),
@@ -801,5 +924,278 @@ impl ServiceHandler for Process {
                 }));
             }
         }
+    }
+}
+
+// =============================================================================
+// Test probe
+// =============================================================================
+
+/// A process-shaped mailbox with no WASM task behind it.
+///
+/// A real `Process` cannot serve a model-free test: with no program loader
+/// running, its run task fails on its first poll and terminates the actor
+/// before an assertion can look at it. The probe registers in the same
+/// `SERVICES` map, so an owner still reaches it through the ordinary
+/// `terminate`/`detach` path.
+#[cfg(test)]
+pub(crate) mod probe {
+    use super::{Message, ProcessId, SERVICES};
+    use crate::service::ServiceHandler;
+    use tokio::sync::mpsc;
+    use uuid::Uuid;
+
+    /// What an owner asked a probe process to do.
+    #[derive(Debug, PartialEq, Eq)]
+    pub(crate) enum Saw {
+        Terminated,
+        Detached,
+    }
+
+    struct Probe {
+        id: ProcessId,
+        saw: mpsc::UnboundedSender<Saw>,
+    }
+
+    impl ServiceHandler for Probe {
+        type Message = Message;
+
+        async fn handle(&mut self, msg: Message) {
+            let saw = match msg {
+                Message::Terminate { .. } => Saw::Terminated,
+                Message::DetachClient => Saw::Detached,
+                _ => return,
+            };
+            let ended = saw == Saw::Terminated;
+            let _ = self.saw.send(saw);
+            // A real process unregisters when it ends, and only then — a
+            // detached process is still live. Without this every probe any
+            // test ever made would stay in the global map for the life of the
+            // test binary. Reported first: the report rides an unbounded
+            // channel, so the receiver still sees it after the removal drops
+            // this actor.
+            if ended {
+                SERVICES.remove(&self.id);
+            }
+        }
+    }
+
+    /// Register a probe process; returns its id and its record of what it saw.
+    pub(crate) fn register() -> (ProcessId, mpsc::UnboundedReceiver<Saw>) {
+        let id = Uuid::new_v4();
+        let (saw, rx) = mpsc::unbounded_channel();
+        SERVICES
+            .spawn(id, || Probe { id, saw })
+            .expect("fresh process id");
+        (id, rx)
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The real actor, built without `Process::new`. `new` spawns the run
+    /// task, which cannot get past `linker::instantiate` with no program
+    /// loader spawned — the error comes back before the first await point, so
+    /// the task terminates the actor on its first poll, before any assertion
+    /// could look at it. The join handle here is therefore an inert task and
+    /// `Process::run` never executes: what follows covers `Process::terminate`
+    /// and not the run path into it.
+    fn idle_process() -> Process {
+        let id = Uuid::new_v4();
+        Process {
+            process_id: id,
+            client_pid: id,
+            username: "test".to_string(),
+            program: ProgramName {
+                name: "test".to_string(),
+                version: "0.0.0".to_string(),
+            },
+            input: String::new(),
+            start_time: Instant::now(),
+            handle: tokio::spawn(std::future::pending::<()>()),
+            client_id: None,
+            // No client attached, so the end event lands in the output buffer
+            // instead, which is where this test counts it.
+            capture_outputs: true,
+            output_buffer: VecDeque::new(),
+            result_tx: Arc::new(Mutex::new(None)),
+            terminated: false,
+            successor: None,
+        }
+    }
+
+    /// Everything a probe saw, up to it unregistering and dropping its
+    /// sender. Bounded, so a probe that never reports fails the test instead
+    /// of hanging the suite.
+    async fn drained(
+        rx: &mut tokio::sync::mpsc::UnboundedReceiver<probe::Saw>,
+    ) -> Result<Vec<probe::Saw>, tokio::time::error::Elapsed> {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            let mut seen = Vec::new();
+            while let Some(saw) = rx.recv().await {
+                seen.push(saw);
+            }
+            seen
+        })
+        .await
+    }
+
+    /// The buffer is the observable rather than `RELEASES` or the planner:
+    /// it belongs to this one actor, so a test running beside this one cannot
+    /// move it.
+    #[tokio::test]
+    async fn second_terminate_is_ignored() {
+        let mut process = idle_process();
+
+        process
+            .handle(Message::Terminate {
+                result: Ok("first".to_string()),
+                origin: Origin::Run,
+            })
+            .await;
+        process
+            .handle(Message::Terminate {
+                result: Err("second".to_string()),
+                origin: Origin::Owner,
+            })
+            .await;
+
+        let delivered: Vec<_> = process
+            .output_buffer
+            .iter()
+            .map(|event| (event.name(), event.value().to_string()))
+            .collect();
+        assert_eq!(delivered, vec![(ProcessEvent::RETURN, "first".to_string())]);
+    }
+
+    /// The successor is a probe and the recorded link is set by hand:
+    /// `restart` itself cannot run here, because the process it spawns dies
+    /// in `linker::instantiate` with no program loader. So this covers the
+    /// relay decision in `Process::terminate`, not the restart that records
+    /// the successor.
+    #[tokio::test]
+    async fn terminate_after_restart_is_relayed_to_the_successor() {
+        let (successor, mut saw) = probe::register();
+        let mut process = idle_process();
+        process.terminated = true;
+        process.successor = Some(successor);
+
+        process
+            .handle(Message::Terminate {
+                result: Err("session closed".to_string()),
+                origin: Origin::Owner,
+            })
+            .await;
+
+        // The probe unregisters on Terminate, so the channel closing is the
+        // proof that exactly one relay arrived.
+        assert_eq!(
+            drained(&mut saw).await.expect("successor saw nothing"),
+            vec![probe::Saw::Terminated]
+        );
+    }
+
+    #[tokio::test]
+    async fn terminate_after_two_restarts_reaches_the_latest_successor() {
+        let (latest, mut saw) = probe::register();
+        let mut process = idle_process();
+        let client_pid = process.client_pid;
+        process.terminated = true;
+        process.successor = Some(Uuid::new_v4());
+        RESTART_ALIAS.write().unwrap().insert(client_pid, latest);
+
+        process
+            .handle(Message::Terminate {
+                result: Err("session closed".to_string()),
+                origin: Origin::Owner,
+            })
+            .await;
+
+        let seen = drained(&mut saw).await;
+        RESTART_ALIAS.write().unwrap().remove(&client_pid);
+        SERVICES.remove(&latest);
+        assert_eq!(
+            seen.expect("latest successor saw nothing"),
+            vec![probe::Saw::Terminated]
+        );
+    }
+
+    /// The blocker this rule closes: the planner parks a restart request and
+    /// only then wakes the victim, so an owner's Terminate can land in that
+    /// window. Honouring the request there spawns a replacement outside the
+    /// closing session, which nothing would ever end.
+    ///
+    /// The request is parked through `declare_restartable` + `request_restart`
+    /// rather than by writing the static, so the test fails if that path
+    /// changes shape.
+    #[tokio::test]
+    async fn owner_terminate_does_not_restart() {
+        let mut process = idle_process();
+        let pid = process.process_id;
+        declare_restartable(pid);
+        // Held, not asserted here: `declare_restartable` has already written a
+        // global, so failing before the cleanup below would leave it behind.
+        let parked = request_restart(pid);
+
+        process
+            .handle(Message::Terminate {
+                result: Err("session closed".to_string()),
+                origin: Origin::Owner,
+            })
+            .await;
+
+        let alias = RESTART_ALIAS.read().unwrap().get(&pid).copied();
+        let cleared = !is_restartable(pid) && !restart_requested(pid);
+        let delivered: Vec<_> = process
+            .output_buffer
+            .iter()
+            .map(|event| (event.name(), event.value().to_string()))
+            .collect();
+        // Global maps: this test's entries go before any assertion, so a
+        // failure cannot leave them behind for the rest of the binary.
+        if let Some(successor) = process.successor {
+            SERVICES.remove(&successor);
+            RESTART_ALIAS.write().unwrap().remove(&pid);
+        }
+        forget_restart_state(pid);
+
+        assert!(parked, "a declared process must park");
+        assert_eq!(process.successor, None, "no replacement may be spawned");
+        assert_eq!(alias, None, "no alias may be published for the client pid");
+        assert!(cleared, "the parked request must be forgotten either way");
+        assert_eq!(
+            delivered,
+            vec![(ProcessEvent::ERROR, "session closed".to_string())]
+        );
+    }
+
+    /// A Terminate for a retired pid reaches the process the alias names.
+    /// Delivered by the first resolve, since the alias is published before
+    /// the call: the re-resolve after a failed send needs the alias to change
+    /// mid-call, and no test task can change it there — the two resolves have
+    /// only a synchronous failed send between them.
+    #[tokio::test]
+    async fn terminate_follows_the_restart_alias() {
+        let (live, mut saw) = probe::register();
+        // Never registered, so only the alias can lead anywhere.
+        let retired = Uuid::new_v4();
+        RESTART_ALIAS.write().unwrap().insert(retired, live);
+
+        terminate(retired, Err("session closed".to_string()));
+
+        let seen = drained(&mut saw).await;
+        // Global map: cleared before the assertion so a failure cannot leave
+        // the entry behind for another test in this binary.
+        RESTART_ALIAS.write().unwrap().remove(&retired);
+        assert_eq!(
+            seen.expect("aliased process saw nothing"),
+            vec![probe::Saw::Terminated]
+        );
     }
 }

--- a/crates/runtime/src/server.rs
+++ b/crates/runtime/src/server.rs
@@ -21,6 +21,37 @@ use crate::service::{ServiceHandler, ServiceMap};
 
 pub type ClientId = u32;
 
+#[cfg(feature = "session-lifetime-diagnostic")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionOwnerKeys {
+    pub outboxes: Vec<ClientId>,
+    pub services: Vec<ClientId>,
+    pub service_tasks: Vec<ClientId>,
+}
+
+/// Reads the exact keys in each real owner map sequentially.
+///
+/// Callers must establish a quiescent checkpoint before comparing the sets.
+#[cfg(feature = "session-lifetime-diagnostic")]
+pub fn session_owner_keys() -> SessionOwnerKeys {
+    let mut outboxes: Vec<_> = SESSION_OUTBOX.iter().map(|entry| *entry.key()).collect();
+    let mut services = CLIENT_SERVICES.keys();
+    let mut service_tasks = CLIENT_SERVICES.handle_keys();
+    outboxes.sort_unstable();
+    services.sort_unstable();
+    service_tasks.sort_unstable();
+    SessionOwnerKeys {
+        outboxes,
+        services,
+        service_tasks,
+    }
+}
+
+#[cfg(feature = "session-lifetime-diagnostic")]
+pub fn init_session_lifetime_diagnostic(max_upload_bytes: usize) {
+    init(max_upload_bytes);
+}
+
 static STATE: OnceLock<Arc<ServerState>> = OnceLock::new();
 static SESSION_OUTBOX: LazyLock<
     DashMap<ClientId, Arc<TokioMutex<mpsc::Receiver<WireServerMessage>>>>,
@@ -206,6 +237,14 @@ struct Session {
     pub(super) username: String,
     state: Arc<ServerState>,
     pub(super) inflight_uploads: DashMap<UploadKey, InFlightUpload>,
+    /// Processes this session launched with `capture_outputs`. `process::spawn`
+    /// pre-registers this session as their client, so `AttachProcess` answers
+    /// "already attached" to everyone else: no other session can ever adopt
+    /// one. Kept apart from `attached_processes` because that makes ending the
+    /// session the last chance to stop them.
+    pub(super) captured_launches: Vec<ProcessId>,
+    /// Processes someone else launched that this session attached to. They
+    /// outlive the session; only the attachment goes.
     pub(super) attached_processes: Vec<ProcessId>,
     pub(super) installed_programs: HashSet<ProgramName>,
     pub(super) file_waiters: HashMap<ProcessId, tokio::sync::oneshot::Sender<Bytes>>,
@@ -223,6 +262,7 @@ impl Session {
             username: "internal".to_string(),
             state,
             inflight_uploads: DashMap::new(),
+            captured_launches: Vec::new(),
             attached_processes: Vec::new(),
             installed_programs: HashSet::new(),
             file_waiters: HashMap::new(),
@@ -230,7 +270,27 @@ impl Session {
         }
     }
 
+    /// This session owns `process_id`, whichever way it came by it.
+    pub(super) fn owns_process(&self, process_id: ProcessId) -> bool {
+        self.captured_launches.contains(&process_id)
+            || self.attached_processes.contains(&process_id)
+    }
+
+    /// Drop `process_id` from both lists: it is gone, so it must neither pass
+    /// the ownership check nor be terminated a second time by `cleanup`.
+    pub(super) fn forget_process(&mut self, process_id: ProcessId) {
+        self.captured_launches.retain(|id| *id != process_id);
+        self.attached_processes.retain(|id| *id != process_id);
+    }
+
     fn cleanup(&mut self) {
+        // Detaching a captured launch would only clear its client id and
+        // leave it running for the runtime's life, unreachable: nobody else
+        // can attach to it. The owner has to end it.
+        for process_id in self.captured_launches.drain(..) {
+            process::terminate(process_id, Err("session closed".to_string()));
+        }
+
         for process_id in self.attached_processes.drain(..) {
             process::detach(process_id);
         }
@@ -259,6 +319,13 @@ impl ServiceHandler for Session {
                 event,
                 value,
             } => {
+                // A returned or errored process is over, and this is the only
+                // notice the session gets. Without it a long-lived session
+                // keeps every pid it ever launched, and closing terminates
+                // each of them again.
+                if event == ProcessEvent::RETURN || event == ProcessEvent::ERROR {
+                    self.forget_process(process_id);
+                }
                 self.send_process_event(process_id, &event, value).await;
             }
             SessionMessage::File {
@@ -406,5 +473,52 @@ impl Session {
                 self.send_response(corr_id, true, "Pong".to_string()).await;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inferlet::process::probe::{self, Saw};
+
+    async fn saw(rx: &mut mpsc::UnboundedReceiver<Saw>) -> Saw {
+        tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("probe reported nothing")
+            .expect("probe stopped")
+    }
+
+    /// Both processes are probe mailboxes, not real `Process` actors: a real
+    /// one needs a program loader and terminates itself on its first poll
+    /// without one, which would race every assertion here. So this covers
+    /// `cleanup`'s choice and the `terminate`/`detach` delivery path, not
+    /// `Process`'s own teardown.
+    #[tokio::test]
+    async fn cleanup_terminates_captured_launches_and_only_releases_attachments() {
+        let state = Arc::new(ServerState {
+            next_client_id: AtomicU32::new(1),
+            max_upload_bytes: 1024,
+        });
+        let (out_tx, _out_rx) = mpsc::channel(1);
+        // A sentinel id: the owner maps `cleanup` clears are process-global.
+        let mut session = Session::new_inproc(ClientId::MAX, state, out_tx);
+
+        let (launched, mut launched_saw) = probe::register();
+        let (attached, mut attached_saw) = probe::register();
+        session.captured_launches.push(launched);
+        session.attached_processes.push(attached);
+
+        session.cleanup();
+
+        assert_eq!(saw(&mut launched_saw).await, Saw::Terminated);
+        assert_eq!(saw(&mut attached_saw).await, Saw::Detached);
+        // The point of the split: detaching releases the client but leaves
+        // the process running and registered.
+        assert!(process::list().contains(&attached));
+
+        // Left registered by the assertion above, so end it here rather than
+        // leaving it in the global map for the rest of the binary.
+        process::terminate(attached, Err("test over".to_string()));
+        assert_eq!(saw(&mut attached_saw).await, Saw::Terminated);
     }
 }

--- a/crates/runtime/src/server/handler.rs
+++ b/crates/runtime/src/server/handler.rs
@@ -505,7 +505,8 @@ impl Session {
         ) {
             Ok(process_id) => {
                 if capture_outputs {
-                    self.attached_processes.push(process_id);
+                    // Client mapping was pre-registered by process::spawn
+                    self.captured_launches.push(process_id);
                     self.send_response(corr_id, true, process_id.to_string())
                         .await;
                 } else {
@@ -567,7 +568,7 @@ impl Session {
             return;
         };
 
-        if !self.attached_processes.contains(&process_id) {
+        if !self.owns_process(process_id) {
             tracing::warn!(
                 "SignalProcess: process {} not owned by client",
                 process_id_str
@@ -610,6 +611,7 @@ impl Session {
         }
 
         process::terminate(process_id, Err("Signal".to_string()));
+        self.forget_process(process_id);
         self.send_response(corr_id, true, "Process terminated".to_string())
             .await;
     }
@@ -632,7 +634,7 @@ impl Session {
             }
         };
 
-        if !self.attached_processes.contains(&process_id) {
+        if !self.owns_process(process_id) {
             tracing::error!(
                 "TransferFile: process {} not owned by client",
                 process_id_str

--- a/crates/runtime/src/service.rs
+++ b/crates/runtime/src/service.rs
@@ -171,6 +171,11 @@ where
         self.map.iter().map(|r| r.key().clone()).collect()
     }
 
+    #[cfg(feature = "session-lifetime-diagnostic")]
+    pub fn handle_keys(&self) -> Vec<K> {
+        self.handles.iter().map(|r| r.key().clone()).collect()
+    }
+
     #[allow(dead_code)]
     pub fn len(&self) -> usize {
         self.map.len()

--- a/crates/worker-api/src/lib.rs
+++ b/crates/worker-api/src/lib.rs
@@ -1,5 +1,5 @@
 use controller_api::WorkerStatus;
-use ids::{ReqId, WorkerId};
+use ids::{ReqId, SessionId, WorkerId};
 
 mod data;
 mod link;
@@ -26,6 +26,8 @@ pub trait WorkerControl {
     async fn dispatch(req: Request) -> Accepted;
 
     async fn cancel(req_id: ReqId);
+
+    async fn close_session(session: SessionId);
 
     async fn set_priority(req_id: ReqId, p: Priority);
 

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -21,6 +21,12 @@ wgpu = ["runtime/wgpu"]
 nixl = ["dep:transport", "transport/nixl"]
 
 profile-fire = ["runtime/profile-fire"]
+session-lifetime-diagnostic = ["runtime/session-lifetime-diagnostic"]
+
+[[test]]
+name = "session_lifetime_diagnostic"
+path = "tests/session_lifetime_diagnostic.rs"
+required-features = ["session-lifetime-diagnostic"]
 
 [dependencies]
 runtime = { path = "../runtime" }
@@ -60,6 +66,8 @@ client = { path = "../client" }
 
 [dev-dependencies]
 tempfile = "3"
+gateway = { path = "../gateway" }
+tokio = { version = "1.53", features = ["test-util"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 [lints]

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -11,6 +11,12 @@ pub mod weights;
 mod executor;
 mod link;
 
+#[cfg(feature = "session-lifetime-diagnostic")]
+pub mod session_lifetime_diagnostic {
+    pub use crate::link::gateway::{
+        GatewayLink, SessionObserver, SessionOwnerKeys, connect_gateway,
+    };
+}
 pub use config::Config;
 pub use controller_api::Role;
 pub use link::control::ControlLink;

--- a/crates/worker/src/link/control.rs
+++ b/crates/worker/src/link/control.rs
@@ -144,6 +144,57 @@ fn report_band(status: &WorkerStatus) -> (u8, bool) {
     (band, status.inflight == 0)
 }
 
+async fn report_loop<C: ControlLink>(
+    ctrl: C,
+    worker_id: WorkerId,
+    mut sample: impl FnMut() -> WorkerStatus,
+    mut releases: watch::Receiver<u64>,
+) {
+    let mut ticker = tokio::time::interval(REPORT_POLL);
+    let mut last: Option<(WorkerStatus, tokio::time::Instant)> = None;
+    let mut releases_live = true;
+    loop {
+        let sender_gone = tokio::select! {
+            _ = ticker.tick() => false,
+            changed = releases.changed(), if releases_live => changed.is_err(),
+        };
+        if sender_gone {
+            // `changed()` stays Err once the sender is gone, so leaving the
+            // branch armed would spin the loop; the ticker still reports.
+            releases_live = false;
+            continue;
+        }
+        let status = sample();
+        let due = match &last {
+            None => true,
+            Some((sent, at)) => {
+                at.elapsed() >= REPORT_INTERVAL || report_band(sent) != report_band(&status)
+            }
+        };
+        if !due {
+            continue;
+        }
+        last = Some((status, tokio::time::Instant::now()));
+        if runtime::planner::trace_enabled() {
+            println!(
+                "[report] kv_bucket={} inflight={} queue=[{}]",
+                status.kv_pressure_bucket,
+                status.inflight,
+                runtime::planner::planner()
+                    .map(|p| p.debug_queue())
+                    .unwrap_or_default()
+            );
+        }
+        if let Err(e) = ctrl.report_worker(worker_id, status).await {
+            tracing::warn!(
+                worker = %worker_id,
+                error = %e,
+                "controller report_worker transport failed"
+            );
+        }
+    }
+}
+
 pub fn spawn_control_tasks<C: ControlLink>(
     ctrl: C,
     worker_id: WorkerId,
@@ -176,46 +227,17 @@ pub fn spawn_control_tasks<C: ControlLink>(
     });
 
     let report_ctrl = ctrl.clone();
-    let report_task = tokio::spawn(async move {
-        let mut ticker = tokio::time::interval(REPORT_POLL);
-        let mut last: Option<(WorkerStatus, Instant)> = None;
-        loop {
-            ticker.tick().await;
-            let status = WorkerStatus {
-                kv_pressure_bucket: runtime::store::kv_pressure_bucket(),
-                inflight: runtime::inferlet::process::list()
-                    .len()
-                    .min(u32::MAX as usize) as u32,
-            };
-            let due = match &last {
-                None => true,
-                Some((sent, at)) => {
-                    at.elapsed() >= REPORT_INTERVAL || report_band(sent) != report_band(&status)
-                }
-            };
-            if !due {
-                continue;
-            }
-            last = Some((status, Instant::now()));
-            if runtime::planner::trace_enabled() {
-                println!(
-                    "[report] kv_bucket={} inflight={} queue=[{}]",
-                    status.kv_pressure_bucket,
-                    status.inflight,
-                    runtime::planner::planner()
-                        .map(|p| p.debug_queue())
-                        .unwrap_or_default()
-                );
-            }
-            if let Err(e) = report_ctrl.report_worker(worker_id, status).await {
-                tracing::warn!(
-                    worker = %worker_id,
-                    error = %e,
-                    "controller report_worker transport failed"
-                );
-            }
-        }
-    });
+    let report_task = tokio::spawn(report_loop(
+        report_ctrl,
+        worker_id,
+        || WorkerStatus {
+            kv_pressure_bucket: runtime::store::kv_pressure_bucket(),
+            inflight: runtime::inferlet::process::list()
+                .len()
+                .min(u32::MAX as usize) as u32,
+        },
+        runtime::inferlet::process::releases(),
+    ));
 
     let watch_task = tokio::spawn(async move {
         let mut rx = ctrl.neighbors_watch(worker_id);
@@ -321,4 +343,260 @@ pub fn spawn_executor_control_tasks<C: ControlLink>(
     });
 
     vec![heartbeat_task, report_task, watch_task]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use tokio::sync::{mpsc, oneshot};
+    use tokio::time::Instant;
+
+    const WORKER: WorkerId = WorkerId(7);
+
+    /// One `report_worker` call, parked until the test hands back `resume`.
+    /// Holding the loop inside the RPC is what makes the cells deterministic:
+    /// nothing else runs while a test sets up the next sample.
+    struct Report {
+        status: WorkerStatus,
+        resume: oneshot::Sender<()>,
+    }
+
+    #[derive(Clone)]
+    struct MockLink {
+        reports: mpsc::UnboundedSender<Report>,
+    }
+
+    impl MockLink {
+        fn new() -> (Self, mpsc::UnboundedReceiver<Report>) {
+            let (reports, rx) = mpsc::unbounded_channel();
+            (Self { reports }, rx)
+        }
+    }
+
+    impl ControlLink for MockLink {
+        async fn register_worker(&self, _info: WorkerInfo) -> Result<WorkerId> {
+            unreachable!()
+        }
+
+        async fn heartbeat(&self, _id: NodeId) -> Result<Ack> {
+            unreachable!()
+        }
+
+        async fn report_worker(&self, _id: WorkerId, status: WorkerStatus) -> Result<()> {
+            let (resume, wait) = oneshot::channel();
+            let _ = self.reports.send(Report { status, resume });
+            let _ = wait.await;
+            Ok(())
+        }
+
+        fn neighbors_watch(&self, _id: WorkerId) -> watch::Receiver<Neighbors> {
+            unreachable!()
+        }
+    }
+
+    struct Probe {
+        status: Arc<Mutex<WorkerStatus>>,
+        calls: Arc<AtomicUsize>,
+    }
+
+    impl Probe {
+        fn new(kv_pressure_bucket: u8, inflight: u32) -> Self {
+            Self {
+                status: Arc::new(Mutex::new(WorkerStatus {
+                    kv_pressure_bucket,
+                    inflight,
+                })),
+                calls: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+
+        fn sampler(&self) -> Box<dyn FnMut() -> WorkerStatus + Send> {
+            let status = self.status.clone();
+            let calls = self.calls.clone();
+            Box::new(move || {
+                calls.fetch_add(1, Ordering::Relaxed);
+                *status.lock().unwrap()
+            })
+        }
+
+        fn set(&self, kv_pressure_bucket: u8, inflight: u32) {
+            *self.status.lock().unwrap() = WorkerStatus {
+                kv_pressure_bucket,
+                inflight,
+            };
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::Relaxed)
+        }
+    }
+
+    /// Run the loop until it parks again. Keeps a task runnable throughout, so
+    /// the paused clock cannot auto-advance underneath the cell.
+    async fn settle() {
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn release_wake_crossing_a_band_reports_without_advancing_time() {
+        let (link, mut reports) = MockLink::new();
+        let probe = Probe::new(0, 0);
+        let (releases, rx) = watch::channel(0u64);
+        let task = tokio::spawn(report_loop(link, WORKER, probe.sampler(), rx));
+
+        let first = reports.recv().await.unwrap();
+        assert_eq!(first.status.kv_pressure_bucket, 0);
+        first.resume.send(()).unwrap();
+        settle().await;
+
+        probe.set(250, 0);
+        let at = Instant::now();
+        releases.send_modify(|count| *count += 1);
+
+        let second = reports.recv().await.unwrap();
+        assert_eq!(second.status.kv_pressure_bucket, 250);
+        assert_eq!(at.elapsed(), Duration::ZERO);
+
+        task.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn release_wake_inside_the_same_band_does_not_report() {
+        let (link, mut reports) = MockLink::new();
+        let probe = Probe::new(0, 0);
+        let (releases, rx) = watch::channel(0u64);
+        let task = tokio::spawn(report_loop(link, WORKER, probe.sampler(), rx));
+
+        reports.recv().await.unwrap().resume.send(()).unwrap();
+        settle().await;
+        let sampled = probe.calls();
+
+        probe.set(15, 0);
+        let at = Instant::now();
+        releases.send_modify(|count| *count += 1);
+        settle().await;
+
+        assert!(probe.calls() > sampled);
+        assert!(reports.try_recv().is_err());
+        assert_eq!(at.elapsed(), Duration::ZERO);
+
+        task.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn release_wake_sent_before_the_first_poll_is_not_lost() {
+        let (link, mut reports) = MockLink::new();
+        let probe = Probe::new(0, 0);
+        let (releases, rx) = watch::channel(0u64);
+        releases.send_modify(|count| *count += 1);
+        let task = tokio::spawn(report_loop(link, WORKER, probe.sampler(), rx));
+
+        let first = reports.recv().await.unwrap();
+        assert_eq!(first.status.kv_pressure_bucket, 0);
+
+        probe.set(250, 0);
+        let at = Instant::now();
+        first.resume.send(()).unwrap();
+
+        let second = reports.recv().await.unwrap();
+        assert_eq!(second.status.kv_pressure_bucket, 250);
+        assert_eq!(at.elapsed(), Duration::ZERO);
+
+        task.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn periodic_report_still_arrives_with_no_release_wakes() {
+        let (link, mut reports) = MockLink::new();
+        let probe = Probe::new(0, 0);
+        let (_releases, rx) = watch::channel(0u64);
+        let task = tokio::spawn(report_loop(link, WORKER, probe.sampler(), rx));
+
+        reports.recv().await.unwrap().resume.send(()).unwrap();
+        settle().await;
+
+        tokio::time::advance(REPORT_INTERVAL).await;
+
+        let periodic = reports.recv().await.unwrap();
+        assert_eq!(periodic.status.kv_pressure_bucket, 0);
+        periodic.resume.send(()).unwrap();
+        settle().await;
+        assert!(reports.try_recv().is_err());
+
+        task.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_transition_on_a_tick_reports_before_the_interval() {
+        let (link, mut reports) = MockLink::new();
+        let probe = Probe::new(100, 1);
+        let (_releases, rx) = watch::channel(0u64);
+        let task = tokio::spawn(report_loop(link, WORKER, probe.sampler(), rx));
+
+        let first = reports.recv().await.unwrap();
+        assert_eq!(first.status.inflight, 1);
+        first.resume.send(()).unwrap();
+        settle().await;
+
+        probe.set(100, 0);
+        let at = Instant::now();
+        tokio::time::advance(REPORT_POLL).await;
+
+        let second = reports.recv().await.unwrap();
+        assert_eq!(second.status.inflight, 0);
+        assert_eq!(second.status.kv_pressure_bucket, 100);
+        assert!(at.elapsed() < REPORT_INTERVAL);
+
+        task.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn release_wake_during_the_report_rpc_resamples_after_it() {
+        let (link, mut reports) = MockLink::new();
+        let probe = Probe::new(0, 0);
+        let (releases, rx) = watch::channel(0u64);
+        let task = tokio::spawn(report_loop(link, WORKER, probe.sampler(), rx));
+
+        let first = reports.recv().await.unwrap();
+        assert_eq!(first.status.kv_pressure_bucket, 0);
+
+        probe.set(250, 0);
+        releases.send_modify(|count| *count += 1);
+        let at = Instant::now();
+        first.resume.send(()).unwrap();
+
+        let second = reports.recv().await.unwrap();
+        assert_eq!(second.status.kv_pressure_bucket, 250);
+        assert_eq!(at.elapsed(), Duration::ZERO);
+
+        task.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn dropped_release_sender_keeps_the_periodic_report_without_spinning() {
+        let (link, mut reports) = MockLink::new();
+        let probe = Probe::new(0, 0);
+        let (releases, rx) = watch::channel(0u64);
+        drop(releases);
+        let task = tokio::spawn(report_loop(link, WORKER, probe.sampler(), rx));
+
+        reports.recv().await.unwrap().resume.send(()).unwrap();
+        settle().await;
+
+        tokio::time::advance(REPORT_INTERVAL).await;
+
+        let periodic = reports.recv().await.unwrap();
+        assert_eq!(periodic.status.kv_pressure_bucket, 0);
+        periodic.resume.send(()).unwrap();
+        settle().await;
+        assert!(reports.try_recv().is_err());
+        // One interval holds about twenty polls; a spinning select would sample
+        // orders of magnitude more.
+        assert!(probe.calls() < 64);
+
+        task.abort();
+    }
 }

--- a/crates/worker/src/link/gateway.rs
+++ b/crates/worker/src/link/gateway.rs
@@ -1,4 +1,6 @@
 use std::collections::{HashMap, HashSet};
+#[cfg(feature = "session-lifetime-diagnostic")]
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
 use std::time::Duration;
 
@@ -24,8 +26,88 @@ const PUSH_DEADLINE: Duration = Duration::from_secs(300);
 
 const TURN_QUEUE_DEPTH: usize = 64;
 
+const TURN_DRAIN_LIMIT: Duration = Duration::from_secs(5);
+
 pub struct GatewayLink {
     serve_task: tokio::task::JoinHandle<()>,
+    #[cfg(feature = "session-lifetime-diagnostic")]
+    sessions: Weak<SessionRegistry>,
+}
+
+#[cfg(feature = "session-lifetime-diagnostic")]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SessionOwnerKeys {
+    pub sessions: Vec<(SessionId, ClientId)>,
+    pub active: Vec<(ReqId, SessionId)>,
+    pub runtime: runtime::server::SessionOwnerKeys,
+}
+
+#[cfg(feature = "session-lifetime-diagnostic")]
+#[derive(Clone)]
+pub struct SessionObserver {
+    sessions: Weak<SessionRegistry>,
+}
+
+#[cfg(feature = "session-lifetime-diagnostic")]
+impl SessionObserver {
+    /// Reads exact real registry keys sequentially at a quiescent checkpoint.
+    pub async fn session_owner_keys(&self) -> Option<SessionOwnerKeys> {
+        let registry = self.sessions.upgrade()?;
+        let mut sessions: Vec<_> = registry
+            .sessions
+            .lock()
+            .await
+            .iter()
+            .map(|(session, handle)| (*session, handle.client_id))
+            .collect();
+        let mut active: Vec<_> = registry
+            .active
+            .lock()
+            .await
+            .iter()
+            .map(|(request, (session, _))| (*request, *session))
+            .collect();
+        sessions.sort_unstable();
+        active.sort_unstable();
+        Some(SessionOwnerKeys {
+            sessions,
+            active,
+            runtime: runtime::server::session_owner_keys(),
+        })
+    }
+
+    /// Hold the next terminal reply after its response push completes but before
+    /// Eos, leaving a real active turn for frontend-close cancellation.
+    pub fn hold_next_terminal(&self) -> bool {
+        self.sessions
+            .upgrade()
+            .is_some_and(|registry| !registry.diagnostic_hold.armed.swap(true, Ordering::AcqRel))
+    }
+
+    pub async fn close_session(&self, session: SessionId) {
+        if let Some(registry) = self.sessions.upgrade() {
+            registry.close_session(session).await;
+        }
+    }
+
+    pub async fn held_terminal(&self) -> Option<ReqId> {
+        let registry = self.sessions.upgrade()?;
+        loop {
+            if let Some(req_id) = *registry.diagnostic_hold.held.lock().await {
+                return Some(req_id);
+            }
+            registry.diagnostic_hold.reached.notified().await;
+        }
+    }
+}
+
+#[cfg(feature = "session-lifetime-diagnostic")]
+impl GatewayLink {
+    pub fn session_observer(&self) -> SessionObserver {
+        SessionObserver {
+            sessions: self.sessions.clone(),
+        }
+    }
 }
 
 impl Drop for GatewayLink {
@@ -72,10 +154,11 @@ pub async fn connect_gateway(addr: &str, worker_id: WorkerId) -> Result<GatewayL
         .with_context(|| format!("registering worker with gateway at {addr}"))?;
     tracing::info!(%worker_id, gateway = %addr, "worker registered with gateway (dial-in)");
 
+    let sessions = Arc::new(SessionRegistry::default());
     let server = WorkerControlServer {
         worker_id,
         gateway,
-        sessions: Arc::new(SessionRegistry::default()),
+        sessions: sessions.clone(),
     };
     let serve_task = tokio::spawn(
         BaseChannel::with_defaults(server_half)
@@ -85,7 +168,11 @@ pub async fn connect_gateway(addr: &str, worker_id: WorkerId) -> Result<GatewayL
             }),
     );
 
-    Ok(GatewayLink { serve_task })
+    Ok(GatewayLink {
+        serve_task,
+        #[cfg(feature = "session-lifetime-diagnostic")]
+        sessions: Arc::downgrade(&sessions),
+    })
 }
 
 pub struct GatewayLinkManager {
@@ -203,10 +290,30 @@ struct WorkerControlServer {
 #[derive(Default)]
 struct SessionRegistry {
     sessions: Mutex<HashMap<SessionId, SessionHandle>>,
-    active: Mutex<HashMap<ReqId, SessionId>>,
+    active: Mutex<HashMap<ReqId, (SessionId, ClientId)>>,
+    #[cfg(feature = "session-lifetime-diagnostic")]
+    diagnostic_hold: DiagnosticHold,
+}
+
+#[cfg(feature = "session-lifetime-diagnostic")]
+#[derive(Default)]
+struct DiagnosticHold {
+    armed: AtomicBool,
+    held: Mutex<Option<ReqId>>,
+    reached: Notify,
+}
+
+impl SessionRegistry {
+    async fn close_session(&self, session: SessionId) {
+        if self.sessions.lock().await.remove(&session).is_some() {
+            tracing::debug!(%session, "frontend session ended; releasing worker session");
+        }
+    }
 }
 
 struct SessionHandle {
+    #[cfg(feature = "session-lifetime-diagnostic")]
+    client_id: ClientId,
     turns: mpsc::Sender<Request>,
     cancels: Arc<Mutex<HashMap<ReqId, Arc<Notify>>>>,
 }
@@ -225,8 +332,8 @@ impl WorkerControl for WorkerControlServer {
     }
 
     async fn cancel(self, _: tarpc::context::Context, req_id: ReqId) {
-        let session = self.sessions.active.lock().await.get(&req_id).copied();
-        if let Some(session) = session
+        let owner = self.sessions.active.lock().await.get(&req_id).copied();
+        if let Some((session, _)) = owner
             && let Some(handle) = self.sessions.sessions.lock().await.get(&session)
         {
             let notify = handle.cancels.lock().await.get(&req_id).cloned();
@@ -243,6 +350,10 @@ impl WorkerControl for WorkerControlServer {
 
     async fn drain(self, _: tarpc::context::Context) {
         tracing::info!("drain: no runtime hook (best-effort no-op)");
+    }
+
+    async fn close_session(self, _: tarpc::context::Context, session: SessionId) {
+        self.sessions.close_session(session).await;
     }
 }
 
@@ -287,6 +398,8 @@ impl WorkerControlServer {
         map.insert(
             session,
             SessionHandle {
+                #[cfg(feature = "session-lifetime-diagnostic")]
+                client_id,
                 turns: turns_tx.clone(),
                 cancels,
             },
@@ -396,7 +509,7 @@ async fn session_driver(
         let cancel = Arc::new(Notify::new());
         cancels.lock().await.insert(req_id, cancel.clone());
         if let Some(reg) = registry.upgrade() {
-            reg.active.lock().await.insert(req_id, session);
+            reg.active.lock().await.insert(req_id, (session, client_id));
         }
 
         let fed = feed_turn(client_id, req_id, req.message);
@@ -408,13 +521,35 @@ async fn session_driver(
         let link_gone_tx = link_gone_tx.clone();
         running.spawn(async move {
             let outcome = run_turn(
-                client_id, &gateway, &cancel, req_id, fed, corr, binding, inbox,
+                client_id,
+                &gateway,
+                &cancel,
+                req_id,
+                fed,
+                corr,
+                binding,
+                inbox,
+                #[cfg(feature = "session-lifetime-diagnostic")]
+                registry.clone(),
             )
             .await;
             routes.lock().await.close(req_id);
             cancels.lock().await.remove(&req_id);
             if let Some(reg) = registry.upgrade() {
-                reg.active.lock().await.remove(&req_id);
+                let mut active = reg.active.lock().await;
+                if active
+                    .get(&req_id)
+                    .is_some_and(|(_, owner)| *owner == client_id)
+                {
+                    active.remove(&req_id);
+                }
+                #[cfg(feature = "session-lifetime-diagnostic")]
+                {
+                    let mut held = reg.diagnostic_hold.held.lock().await;
+                    if *held == Some(req_id) {
+                        *held = None;
+                    }
+                }
             }
             if let TurnEnd::LinkGone = outcome {
                 let _ = link_gone_tx.send(());
@@ -424,11 +559,44 @@ async fn session_driver(
         while running.try_join_next().is_some() {}
     }
 
-    router.abort();
+    // Stop taking turns before the teardown below, so a dispatch racing a
+    // close gets a fresh session instead of queueing onto a driver that has
+    // already stopped reading.
+    drop(turns);
+
+    // The prompt path, not the guarantee. A cancelled turn terminates the
+    // process it owns on its way out, which frees it sooner than session
+    // cleanup would; but the worker cannot promise that for every turn — a
+    // cancel arriving before a launch reply has no pid to terminate, and a
+    // turn blocked in `push_tokens` never reaches its `select!`. What holds
+    // regardless is `runtime::server::close_session` below: the session's
+    // `Drop` terminates the launches it owns. So this wait expiring is a
+    // slower release, not a leaked process.
+    for notify in cancels.lock().await.values() {
+        notify.notify_one();
+    }
+    let drained = tokio::time::timeout(TURN_DRAIN_LIMIT, async {
+        while running.join_next().await.is_some() {}
+    })
+    .await;
+    if drained.is_err() {
+        tracing::warn!(%session, "turns outlived the drain limit; aborting them");
+    }
     running.shutdown().await;
+    router.abort();
     runtime::server::close_session(client_id);
     if let Some(reg) = registry.upgrade() {
-        reg.sessions.lock().await.remove(&session);
+        reg.active
+            .lock()
+            .await
+            .retain(|_, (_, owner)| *owner != client_id);
+        // A dispatch racing the close may already have put a fresh driver's
+        // handle under this `SessionId`; only this driver's own entry, whose
+        // sender the `drop` above closed, is ours to retire.
+        let mut sessions = reg.sessions.lock().await;
+        if sessions.get(&session).is_some_and(|h| h.turns.is_closed()) {
+            sessions.remove(&session);
+        }
     }
     tracing::debug!(%session, "session driver exited");
 }
@@ -494,6 +662,7 @@ async fn run_turn(
     corr: Option<u32>,
     binding: ProcBinding,
     mut inbox: mpsc::Receiver<ServerMessage>,
+    #[cfg(feature = "session-lifetime-diagnostic")] registry: Weak<SessionRegistry>,
 ) -> TurnEnd {
     let proc_launch = binding.is_process();
     let mut process_id: Option<String> = match binding {
@@ -534,6 +703,14 @@ async fn run_turn(
                     }
                 }
                 if terminal {
+                    #[cfg(feature = "session-lifetime-diagnostic")]
+                    if let Some(registry) = registry.upgrade()
+                        && registry.diagnostic_hold.armed.swap(false, Ordering::AcqRel)
+                    {
+                        *registry.diagnostic_hold.held.lock().await = Some(req_id);
+                        registry.diagnostic_hold.reached.notify_one();
+                        continue;
+                    }
                     return push_eos(gateway, req_id).await;
                 }
             }

--- a/crates/worker/tests/session_lifetime_diagnostic.rs
+++ b/crates/worker/tests/session_lifetime_diagnostic.rs
@@ -1,0 +1,472 @@
+use std::collections::BTreeSet;
+use std::fmt::Debug;
+use std::future::Future;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+
+use anyhow::{Context, Result, ensure};
+use controller_api::{
+    Ack, GatewayId, GatewayInfo, Health, NodeId, Role, RoutableWorker, RoutingTable, WorkerStatus,
+};
+use gateway::GatewayControl;
+use ids::{SessionId, WorkerId};
+use tokio::sync::watch;
+use worker::session_lifetime_diagnostic::{SessionObserver, SessionOwnerKeys, connect_gateway};
+
+const FRESH_SESSIONS: usize = 8;
+const WARM_TURNS: usize = 8;
+const STEP_LIMIT: Duration = Duration::from_secs(8);
+
+#[derive(Clone)]
+struct ControlFixture {
+    routing: watch::Receiver<RoutingTable>,
+}
+
+impl GatewayControl for ControlFixture {
+    async fn register_gateway(&self, _: GatewayInfo) -> Result<GatewayId> {
+        Ok(GatewayId(1))
+    }
+
+    async fn heartbeat(&self, _: NodeId) -> Result<Ack> {
+        Ok(Ack::Ok)
+    }
+
+    fn routing_watch(&self) -> watch::Receiver<RoutingTable> {
+        self.routing.clone()
+    }
+}
+
+fn routing(worker: WorkerId) -> RoutingTable {
+    RoutingTable {
+        epoch: 1,
+        workers: vec![RoutableWorker {
+            id: worker,
+            addr: "diagnostic-only".into(),
+            role: Role::Decode,
+            model: "model-free-ping".into(),
+            health: Health::Healthy,
+            coarse_load: WorkerStatus {
+                kv_pressure_bucket: 0,
+                inflight: 0,
+            },
+        }],
+    }
+}
+
+async fn wait_for<T: Debug>(
+    label: &str,
+    mut sample: impl AsyncFnMut() -> T,
+    accept: impl Fn(&T) -> bool,
+) -> Result<T> {
+    let last = Arc::new(StdMutex::new(None));
+    let observed = last.clone();
+    match tokio::time::timeout(STEP_LIMIT, async {
+        loop {
+            let value = sample().await;
+            *observed.lock().expect("last observation lock") = Some(format!("{value:#?}"));
+            if accept(&value) {
+                return value;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    {
+        Ok(value) => Ok(value),
+        Err(_) => {
+            println!(
+                "phase=timeout label={label:?} last={:?}",
+                last.lock().expect("last observation lock")
+            );
+            anyhow::bail!("timeout waiting for {label}")
+        }
+    }
+}
+
+async fn step<T>(label: &str, future: impl Future<Output = Result<T>>) -> Result<T> {
+    tokio::time::timeout(STEP_LIMIT, future)
+        .await
+        .with_context(|| format!("timeout during {label}"))?
+        .with_context(|| label.to_string())
+}
+
+async fn census(observer: &SessionObserver) -> Result<SessionOwnerKeys> {
+    observer
+        .session_owner_keys()
+        .await
+        .context("worker session registry disappeared before shared-link teardown")
+}
+
+async fn bounded_census(observer: &SessionObserver, label: &str) -> Result<SessionOwnerKeys> {
+    step(label, census(observer)).await
+}
+
+fn client_ids(keys: &SessionOwnerKeys) -> BTreeSet<u32> {
+    keys.sessions.iter().map(|(_, client)| *client).collect()
+}
+
+fn print_phase(name: &str, gateway_live: usize, keys: &SessionOwnerKeys) {
+    println!(
+        "phase={name} gateway_live={gateway_live} worker_sessions={} active={} runtime_outboxes={} runtime_services={} runtime_service_tasks={} owner_keys={keys:#?}",
+        keys.sessions.len(),
+        keys.active.len(),
+        keys.runtime.outboxes.len(),
+        keys.runtime.services.len(),
+        keys.runtime.service_tasks.len(),
+    );
+}
+
+fn assert_owner_alignment(keys: &SessionOwnerKeys) -> Result<()> {
+    let mapped = client_ids(keys);
+    let outboxes = keys
+        .runtime
+        .outboxes
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let services = keys
+        .runtime
+        .services
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let service_tasks = keys
+        .runtime
+        .service_tasks
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    ensure!(
+        mapped == outboxes,
+        "worker mappings and SESSION_OUTBOX differ: {keys:?}"
+    );
+    ensure!(
+        mapped == services,
+        "worker mappings and CLIENT_SERVICES senders differ: {keys:?}"
+    );
+    ensure!(
+        mapped == service_tasks,
+        "worker mappings and CLIENT_SERVICES tasks differ: {keys:?}"
+    );
+    Ok(())
+}
+
+fn owners_align(keys: &SessionOwnerKeys) -> bool {
+    let mapped = client_ids(keys);
+    mapped == keys.runtime.outboxes.iter().copied().collect()
+        && mapped == keys.runtime.services.iter().copied().collect()
+        && mapped == keys.runtime.service_tasks.iter().copied().collect()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn real_ping_client_close_and_shared_link_lifetimes() -> Result<()> {
+    runtime::server::init_session_lifetime_diagnostic(1024 * 1024);
+    let baseline_runtime = runtime::server::session_owner_keys();
+    ensure!(
+        baseline_runtime.outboxes.is_empty(),
+        "isolated process has runtime outboxes at baseline: {baseline_runtime:?}"
+    );
+    ensure!(
+        baseline_runtime.services.is_empty(),
+        "isolated process has runtime services at baseline: {baseline_runtime:?}"
+    );
+    ensure!(
+        baseline_runtime.service_tasks.is_empty(),
+        "isolated process has runtime service tasks at baseline: {baseline_runtime:?}"
+    );
+
+    let worker_id = WorkerId(41);
+    let (_routing_tx, routing_rx) = watch::channel(routing(worker_id));
+    let gateway = step(
+        "gateway bind",
+        gateway::bind(
+            gateway::Config {
+                listen: SocketAddr::from(([127, 0, 0, 1], 0)),
+                worker_listen: SocketAddr::from(([127, 0, 0, 1], 0)),
+                controller: "unused-by-control-fixture".into(),
+            },
+            ControlFixture {
+                routing: routing_rx,
+            },
+        ),
+    )
+    .await?;
+    let gateway_state = gateway.state.clone();
+    let gateway_addr = gateway.listen_addr;
+    let worker_addr = gateway.worker_addr;
+    let gateway = gateway.into_handle();
+    let link = match step(
+        "worker gateway-link connect",
+        connect_gateway(&worker_addr.to_string(), worker_id),
+    )
+    .await
+    {
+        Ok(link) => link,
+        Err(error) => {
+            let gateway_cleanup = step("gateway shutdown after link setup failure", async {
+                gateway.shutdown().await;
+                Ok(())
+            })
+            .await;
+            println!(
+                "status primary=1 cleanup=0 gateway_cleanup={}",
+                if gateway_cleanup.is_ok() { 0 } else { 1 }
+            );
+            gateway_cleanup?;
+            return Err(error);
+        }
+    };
+    let observer = link.session_observer();
+    let setup_result: Result<SessionOwnerKeys> = async {
+        wait_for(
+            "gateway worker registration",
+            || async { gateway_state.workers.is_connected(worker_id) },
+            |connected| *connected,
+        )
+        .await?;
+        let baseline = bounded_census(&observer, "baseline census").await?;
+        print_phase("before", gateway_state.sessions.live(), &baseline);
+        ensure!(
+            baseline.runtime == baseline_runtime,
+            "worker/runtime baseline changed: {baseline:?}"
+        );
+        assert_owner_alignment(&baseline)?;
+        Ok(baseline)
+    }
+    .await;
+
+    let primary_result: Result<()> = match setup_result {
+        Ok(baseline) => {
+            async {
+                let url = format!("ws://{gateway_addr}/v1/ws");
+                let mut fresh_sessions = BTreeSet::new();
+                let mut fresh_clients = BTreeSet::new();
+                for index in 0..FRESH_SESSIONS {
+                    let before_client = bounded_census(&observer, "before-client census").await?;
+                    let client = step(
+                        "fresh client connect",
+                        client::client::Client::connect_with_identity(&url, "diagnostic/fresh"),
+                    )
+                    .await?;
+                    let cancellation_probe = index + 1 == FRESH_SESSIONS;
+                    if cancellation_probe {
+                        ensure!(
+                            observer.hold_next_terminal(),
+                            "terminal hold was already armed"
+                        );
+                    }
+                    step("fresh Client::ping", client.ping()).await?;
+                    let during = wait_for(
+                        "fresh Ping ownership",
+                        || census(&observer),
+                        |keys| {
+                            keys.as_ref().is_ok_and(|keys| {
+                                (keys.active.is_empty() || cancellation_probe)
+                                    && keys.sessions.len() == before_client.sessions.len() + 1
+                            })
+                        },
+                    )
+                    .await??;
+                    print_phase(
+                        &format!("fresh-{}-pong", index + 1),
+                        gateway_state.sessions.live(),
+                        &during,
+                    );
+                    assert_owner_alignment(&during)?;
+                    let new_mapping = during
+                        .sessions
+                        .iter()
+                        .filter(|pair| !before_client.sessions.contains(pair))
+                        .copied()
+                        .collect::<Vec<_>>();
+                    ensure!(
+                        new_mapping.len() == 1,
+                        "fresh client did not add exactly one mapping: {during:?}"
+                    );
+                    fresh_sessions.insert(new_mapping[0].0);
+                    fresh_clients.insert(new_mapping[0].1);
+
+                    if cancellation_probe {
+                        let held_req = step("held terminal checkpoint", async {
+                            observer
+                                .held_terminal()
+                                .await
+                                .context("session registry lost while terminal held")
+                        })
+                        .await?;
+                        let held = bounded_census(&observer, "held-turn census").await?;
+                        print_phase(
+                            "fresh-8-held-before-client-close",
+                            gateway_state.sessions.live(),
+                            &held,
+                        );
+                        ensure!(
+                            held.active.contains(&(held_req, new_mapping[0].0)),
+                            "held turn missing from real active registry: {held:?}"
+                        );
+                    }
+
+                    step("fresh Client::close", client.close()).await?;
+                    wait_for(
+                        "gateway SessionHandle drop after Client::close completion",
+                        || async { gateway_state.sessions.live() },
+                        |live| *live == 0,
+                    )
+                    .await?;
+                    let after_close = wait_for(
+                        "stable ownership after client close",
+                        || census(&observer),
+                        |keys| {
+                            keys.as_ref().is_ok_and(|keys| {
+                                keys.active.is_empty()
+                                    && owners_align(keys)
+                                    && keys.sessions == before_client.sessions
+                            })
+                        },
+                    )
+                    .await??;
+                    print_phase(
+                        &format!("fresh-{}-client-close", index + 1),
+                        gateway_state.sessions.live(),
+                        &after_close,
+                    );
+                    assert_owner_alignment(&after_close)?;
+                }
+                ensure!(
+                    fresh_sessions.len() == FRESH_SESSIONS,
+                    "fresh clients reused SessionIds"
+                );
+                ensure!(
+                    fresh_clients.len() == FRESH_SESSIONS,
+                    "fresh sessions reused ClientIds"
+                );
+
+                let after_fresh = bounded_census(&observer, "after-fresh census").await?;
+                print_phase(
+                    "after-fresh-client-closes",
+                    gateway_state.sessions.live(),
+                    &after_fresh,
+                );
+                ensure!(
+                    after_fresh == baseline,
+                    "fresh clients retained ownership after close: {after_fresh:?}"
+                );
+                println!("classification=fresh-clean");
+
+                let warm_client = step(
+                    "warm client connect",
+                    client::client::Client::connect_with_identity(&url, "diagnostic/warm"),
+                )
+                .await?;
+                let warm_baseline = bounded_census(&observer, "warm baseline census").await?;
+                let mut warm_mapping = None;
+                for turn in 0..WARM_TURNS {
+                    step("warm Client::ping", warm_client.ping()).await?;
+                    let during = wait_for(
+                        "warm Ping ownership",
+                        || census(&observer),
+                        |keys| {
+                            keys.as_ref().is_ok_and(|keys| {
+                                keys.active.is_empty()
+                                    && keys.sessions.len() == warm_baseline.sessions.len() + 1
+                            })
+                        },
+                    )
+                    .await??;
+                    print_phase(
+                        &format!("warm-pong-{}", turn + 1),
+                        gateway_state.sessions.live(),
+                        &during,
+                    );
+                    assert_owner_alignment(&during)?;
+                    let added = during
+                        .sessions
+                        .iter()
+                        .filter(|pair| !warm_baseline.sessions.contains(pair))
+                        .copied()
+                        .collect::<Vec<_>>();
+                    ensure!(
+                        added.len() == 1,
+                        "warm client has other than one mapping: {during:?}"
+                    );
+                    ensure!(
+                        warm_mapping.is_none() || warm_mapping == Some(added[0]),
+                        "warm turns changed mapping: {during:?}"
+                    );
+                    warm_mapping = Some(added[0]);
+                }
+
+                step("warm Client::close", warm_client.close()).await?;
+                wait_for(
+                    "warm gateway SessionHandle drop",
+                    || async { gateway_state.sessions.live() },
+                    |live| *live == 0,
+                )
+                .await?;
+                let after_warm_close = wait_for(
+                    "stable warm ownership after client close",
+                    || census(&observer),
+                    |keys| {
+                        keys.as_ref().is_ok_and(|keys| {
+                            keys.active.is_empty()
+                                && owners_align(keys)
+                                && keys.sessions == warm_baseline.sessions
+                        })
+                    },
+                )
+                .await??;
+                print_phase(
+                    "warm-client-close",
+                    gateway_state.sessions.live(),
+                    &after_warm_close,
+                );
+                assert_owner_alignment(&after_warm_close)?;
+                ensure!(
+                    !after_warm_close
+                        .sessions
+                        .contains(&warm_mapping.expect("eight pings establish a mapping")),
+                    "warm client retained ownership after close: {after_warm_close:?}"
+                );
+                println!("classification=warm-clean");
+                Ok(())
+            }
+            .await
+        }
+        Err(error) => Err(error),
+    };
+
+    drop(link);
+    let cleanup_result: Result<()> = async {
+        let after_link = wait_for(
+            "shared gateway-worker link teardown",
+            || async { observer.session_owner_keys().await },
+            |keys| keys.is_none(),
+        )
+        .await?;
+        println!("phase=shared-link-teardown worker_registry={after_link:?}");
+        let final_runtime = wait_for(
+            "runtime owner baseline after link teardown",
+            || async { runtime::server::session_owner_keys() },
+            |keys| *keys == baseline_runtime,
+        )
+        .await?;
+        println!("phase=after-cleanup runtime_owner_keys={final_runtime:#?}");
+        Ok(())
+    }
+    .await;
+    let gateway_cleanup = step("gateway shutdown", async {
+        gateway.shutdown().await;
+        Ok(())
+    })
+    .await;
+    println!(
+        "status primary={} cleanup={} gateway_cleanup={}",
+        if primary_result.is_ok() { 0 } else { 1 },
+        if cleanup_result.is_ok() { 0 } else { 1 },
+        if gateway_cleanup.is_ok() { 0 } else { 1 },
+    );
+    primary_result?;
+    cleanup_result?;
+    gateway_cleanup
+}


### PR DESCRIPTION
Hi, I am an agent helping with @shsym.

Addresses #590.

The gateway did not track the workers that served a session or forward a close when it ended, so a worker session leaked on every session end. Teardown also raced cancellation and restart: a cancelled create could leave a late dispatch outstanding, and a terminate after a restart might miss the successor worker.

This tracks every worker that served the session and forwards the close; closes captured processes without restarting them; preserves attached-process ownership; drains worker turns; and reports coarse load on released capacity.

Cells (run by default): `every_worker_that_served_the_session_is_closed`, `an_open_session_is_never_closed_between_turns`, `cancelling_create_closes_a_late_dispatch`, `cancelling_a_later_turn_cancels_its_late_dispatch`, `terminate_after_restart_is_relayed_to_the_successor`, `terminate_after_two_restarts_reaches_the_latest_successor`. A fuller end-to-end `session_lifetime_diagnostic` test is gated behind the `session-lifetime-diagnostic` feature (off by default); worker gains a `gateway` dev-dep for it, reflected as one Cargo.lock edge.

Note: this is larger than the other drafts (worker/gateway/runtime lifecycle). Draft for review; not yet locally built here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional session-lifetime diagnostics feature for inspecting active session and process ownership.
  - Added support for explicitly closing worker sessions.

- **Bug Fixes**
  - Improved cleanup when sessions close, disconnect, or are dropped, reducing stale session and process ownership.
  - Improved handling of in-progress requests during session shutdown and restart scenarios.
  - Worker capacity updates now respond more quickly when resources are released.

- **Tests**
  - Added end-to-end coverage for session ownership, cleanup, cancellation, and diagnostic reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->