### PR TITLE
docs(checkpoint): drop dead golden_plans command, fix goldens count

### DIFF
--- a/crates/checkpoint/README.md
+++ b/crates/checkpoint/README.md
@@ -43,7 +43,6 @@ executor. See `src/executor/arena.rs`.
 cargo test -p checkpoint                    # the whole compiler, no GPU needed
 cargo clippy -p checkpoint --all-targets
 cargo fmt -p checkpoint --check
-UPDATE_GOLDEN=1 cargo test -p checkpoint --test golden_plans
 ```
 
 No GPU, in any configuration. A `cuda` feature stood here, gating a
@@ -100,7 +99,7 @@ deliberately not a second compiler; the two share no code, which is what makes
 disagreement mean something.
 
 `pie model import` runs it on every plan it compiles, before a byte is read.
-The golden-plan tests run it too, over all sixteen goldens, so a golden cannot
+The golden-plan tests run it too, over all fifteen goldens, so a golden cannot
 be regenerated from a broken compiler.
 
 `dump::describe` is the one-line boot-log summary and `dump::plan_stats_json`


### PR DESCRIPTION
## What
Removed a dead `UPDATE_GOLDEN=1 cargo test -p checkpoint --test golden_plans` command from crates/checkpoint/README.md (no such test target or env var exists in the crate/repo) and corrected the golden-plan test count from sixteen to fifteen, matching the actual number of files in tests/golden/*.json.

## Why
A small, objectively-verifiable improvement (docs) found during a
daily open-source maintenance pass (2026-09-12).

## How verified
Grepped the whole repo for `golden_plans` and `UPDATE_GOLDEN` — only the README referenced them, confirming the command is dead code in docs. Counted tests/golden/*.json (excluding the contracts/ subfolder) and got exactly 15 files, not 16.
Automated gates: 3 changed lines across 1 files (within limits); cargo check: not needed.

---
Prepared with Claude Code assistance and reviewed by Aarush's
automation gates (diff-size, file-scope, deletion, and build checks)
before opening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated checkpoint documentation to reflect the current set of golden-plan tests.
  - Removed the documented command for regenerating golden plans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->